### PR TITLE
ci: Cleanup & refactor CI to account for external PRs

### DIFF
--- a/.github/linters/licenserc.yml
+++ b/.github/linters/licenserc.yml
@@ -41,6 +41,7 @@ header:
     - 'docs/overrides/**'
     - 'docs/assets/stylesheets/**'
     - 'docs/assets/images/**'
+    - 'docs/assets/javascripts/**'
     - 'docs/hooks/**'
     - 'pkg/unikontainers/ipc_message.go'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,10 @@ name: Build
 on:
   workflow_call:
     inputs:
+      ref:
+        required: true
+        type: string
+        default: ''
       runner:
         type: string
         default: '["base", "dind", "2204"]'
@@ -43,13 +47,15 @@ jobs:
       run: |
         go version
 
-    - name: Find SHA
+    - name: Set ref and repo from PR or dispatch
+      id: set-ref
       run: |
-        if [[ "${{github.event.pull_request.head.sha}}" != "" ]]
-        then
-          echo "ARTIFACT_SHA=$(echo ${{github.event.pull_request.head.ref}})" >> $GITHUB_ENV
+        if [[ "${{ github.event_name }}" == "pull_request" || "${{ github.event_name }}" == "pull_request_target" ]]; then
+          echo "ref=${{ github.event.pull_request.head.ref }}" >> "$GITHUB_OUTPUT"
+          echo "repo=${{ github.event.pull_request.head.repo.full_name }}" >> "$GITHUB_OUTPUT"
         else
-          echo "ARTIFACT_SHA=$(echo ${GITHUB_REF##*/})" >> $GITHUB_ENV
+          echo "ref=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          echo "repo=${{ github.repository }}" >> "$GITHUB_OUTPUT"
         fi
 
     - name: Build urunc binaries
@@ -65,7 +71,7 @@ jobs:
         access-key: ${{ secrets.AWS_ACCESS_KEY }}
         secret-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         local-path: dist/urunc_static_arm64
-        remote-path: nbfc-assets/github/urunc/dist/${{ env.ARTIFACT_SHA }}/${{ matrix.archconfig }}/
+        remote-path: nbfc-assets/github/urunc/dist/${{ steps.set-ref.outputs.ref }}/${{ matrix.archconfig }}/
         policy: 1
 
     - name: Upload urunc_amd64 to S3
@@ -76,7 +82,7 @@ jobs:
         access-key: ${{ secrets.AWS_ACCESS_KEY }}
         secret-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         local-path: dist/urunc_static_amd64
-        remote-path: nbfc-assets/github/urunc/dist/${{ env.ARTIFACT_SHA }}/${{ matrix.archconfig }}/
+        remote-path: nbfc-assets/github/urunc/dist/${{ steps.set-ref.outputs.ref }}/${{ matrix.archconfig }}/
         policy: 1
 
     - name: Upload containerd-shim-urunc-v2_arm64 to S3
@@ -87,7 +93,7 @@ jobs:
         access-key: ${{ secrets.AWS_ACCESS_KEY }}
         secret-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         local-path: dist/containerd-shim-urunc-v2_static_arm64
-        remote-path: nbfc-assets/github/urunc/dist/${{ env.ARTIFACT_SHA }}/${{ matrix.archconfig }}/
+        remote-path: nbfc-assets/github/urunc/dist/${{ steps.set-ref.outputs.ref }}/${{ matrix.archconfig }}/
         policy: 1
 
     - name: Upload containerd-shim-urunc-v2_amd64 to S3
@@ -98,5 +104,5 @@ jobs:
         access-key: ${{ secrets.AWS_ACCESS_KEY }}
         secret-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         local-path: dist/containerd-shim-urunc-v2_static_amd64
-        remote-path: nbfc-assets/github/urunc/dist/${{ env.ARTIFACT_SHA }}/${{ matrix.archconfig }}/
+        remote-path: nbfc-assets/github/urunc/dist/${{ steps.set-ref.outputs.ref }}/${{ matrix.archconfig }}/
         policy: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,57 +1,66 @@
-name: CI
-
+name: urunc CI
 on:
-  pull_request_target:
-    branches: ["main"]
-    types: [synchronize, labeled, unlabeled]
-  workflow_dispatch:
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+      skip-build:
+        required: false
+        type: string
+        default: "no"
+      skip-lint:
+        required: false
+        type: string
+        default: "no"
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+permissions:
+  contents: read
+  pull-requests: read
+  packages: write
+  id-token: write
+  attestations: write
 
 jobs:
   validate-files-and-commits:
+    if: ${{ inputs.skip-lint != 'yes' }}
     name: Lint Files & commits 
-    if: | 
-      contains(github.event.pull_request.labels.*.name, 'ok-to-test') &&
-      !contains(github.event.pull_request.labels.*.name, 'skip-lint')
     uses: ./.github/workflows/validate-files-and-commits.yml
+    with:
+      ref: ${{ inputs.ref }}
     secrets: inherit
 
   lint:
     name: Lint code
-    if: | 
-      contains(github.event.pull_request.labels.*.name, 'ok-to-test') &&
-      !contains(github.event.pull_request.labels.*.name, 'skip-lint')
+    if: ${{ inputs.skip-lint != 'yes' }}
     uses: ./.github/workflows/lint.yml
+    with:
+      ref: ${{ inputs.ref }}
     secrets: inherit
 
   build:
-    #needs: [validate-files-and-commits, lint]
+    if: ${{ inputs.skip-build != 'yes' }}
     name: Build
-    if: | 
-      contains(github.event.pull_request.labels.*.name, 'ok-to-test') &&
-      !contains(github.event.pull_request.labels.*.name, 'skip-build')
     uses: ./.github/workflows/build.yml
+    with:
+      ref: ${{ inputs.ref }}
     secrets: inherit
 
   unit_test:
-    #needs: [validate-files-and-commits, lint]
+    if: ${{ inputs.skip-build != 'yes' }}
     name: Unit tests
-    if: | 
-      contains(github.event.pull_request.labels.*.name, 'ok-to-test') &&
-      !contains(github.event.pull_request.labels.*.name, 'skip-build')
     uses: ./.github/workflows/unit_test.yml
+    with:
+      ref: ${{ inputs.ref }}
     secrets: inherit
 
   #FIXME: run for arm64
   vm_test:
+    if: ${{ inputs.skip-build != 'yes' }}
     needs: [build,unit_test]
     name: E2E test
-    if: | 
-      contains(github.event.pull_request.labels.*.name, 'ok-to-test') &&
-      !contains(github.event.pull_request.labels.*.name, 'skip-build')
     uses: ./.github/workflows/vm_test.yml
+    with:
+      ref: ${{ inputs.ref }}
     secrets: inherit
 

--- a/.github/workflows/ci_devel.yml
+++ b/.github/workflows/ci_devel.yml
@@ -1,0 +1,32 @@
+name: urunc CI (manually triggered)
+on:
+  workflow_dispatch:
+    inputs:
+      skip_build:
+        description: 'Skip the build job?'
+        required: false
+        default: "no"
+        type: string
+      skip_lint:
+        description: 'Skip the lint job?'
+        required: false
+        default: "no"
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  ci-on-push:
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+      pull-requests: read
+    uses: ./.github/workflows/ci.yml
+    with:
+      ref: ${{ github.sha }}
+      skip-build: ${{ inputs.skip_build }}
+      skip-lint: ${{ inputs.skip_lint }}
+    secrets: inherit

--- a/.github/workflows/ci_on_push.yml
+++ b/.github/workflows/ci_on_push.yml
@@ -1,0 +1,63 @@
+name: urunc CI
+
+on:
+  pull_request_target:
+    branches: ["main"]
+    types: [synchronize, labeled, unlabeled]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-labels:
+    runs-on: ubuntu-latest
+    outputs:
+      skip_build: ${{ steps.set-vars.outputs.skip_build }}
+      skip_lint:  ${{ steps.set-vars.outputs.skip_lint }}
+    steps:
+      - name: Fetch PR Labels
+        id: get-labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const labels = await github.rest.issues.listLabelsOnIssue({
+              ...context.repo,
+              issue_number: prNumber
+            });
+            const names = labels.data.map(l => l.name);
+            core.setOutput("labels", names.join(','));
+
+      - name: Set skip flags
+        id: set-vars
+        run: |
+          LABELS="${{ steps.get-labels.outputs.labels }}"
+          echo "Labels: $LABELS"
+
+          if [[ "$LABELS" == *"skip-build"* ]]; then
+            echo "skip_build=yes" >> $GITHUB_OUTPUT
+          else
+            echo "skip_build=no" >> $GITHUB_OUTPUT
+          fi
+
+          if [[ "$LABELS" == *"skip-lint"* ]]; then
+            echo "skip_lint=yes" >> $GITHUB_OUTPUT
+          else
+            echo "skip_lint=no" >> $GITHUB_OUTPUT
+          fi
+
+  ci-on-push:
+    needs: [check-labels]
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+      pull-requests: read
+    uses: ./.github/workflows/ci.yml
+    with:
+      ref: ${{ github.sha }}
+      skip-build: ${{ needs.check-labels.outputs.skip_build }}
+      skip-lint: ${{ needs.check-labels.outputs.skip_lint }}
+    secrets: inherit

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,10 @@ name: Code linting
 on:
   workflow_call:
     inputs:
+      ref:
+        required: true
+        type: string
+        default: ''
       runner:
         type: string
         default: '["base", "dind", "2204"]'

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -3,12 +3,16 @@ name: Run unit tests
 on:
   workflow_call:
     inputs:
+      ref:
+        type: string
+        default: ''
+        required: true
       runner:
         type: string
         default: '["base", "dind", "2204"]'
       runner-archs:
         type: string
-        default: '["amd64"]'
+        default: '["amd64", "arm64"]'
       runner-arch-map:
         type: string
         default: '[{"amd64":"x86_64", "arm64":"aarch64", "arm":"armv7l"}]'
@@ -18,7 +22,6 @@ on:
 
 permissions:
   contents: read
-  # allow read access to pull request. Use with `only-new-issues` option.
   pull-requests: read
 
 jobs:
@@ -30,7 +33,7 @@ jobs:
         archconfig: ["${{ fromJSON(inputs.runner-archs) }}"]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Run unikontainers pkg unit tests

--- a/.github/workflows/validate-files-and-commits.yml
+++ b/.github/workflows/validate-files-and-commits.yml
@@ -3,12 +3,10 @@ name: Validate Files and Commit Messages
 on:
   workflow_call:
     inputs:
-      actions-repo:
+      ref:
+        required: true
         type: string
-        default: 'nubificus/vaccel'
-      actions-rev:
-        type: string
-        default: 'main'
+        default: ''
       runner:
         type: string
         default: '["base", "dind", "2204"]'
@@ -31,20 +29,8 @@ jobs:
         arch: ["${{ fromJSON(inputs.runner-archs) }}"]
       fail-fast: false
     steps:
-      - name: Checkout .github directory
+      - name: Checkout Code
         uses: actions/checkout@v4
-        with:
-          sparse-checkout: .github
-          repository: ${{ inputs.actions-repo }}
-          ref: ${{ inputs.actions-rev }}
-
-      - name: Initialize workspace
-        uses: ./.github/actions/initialize-workspace
-        with:
-          submodules: 'false'
-          remote-actions-repo: ${{ inputs.actions-repo }}
-          token: ${{ secrets.GIT_CLONE_PAT || github.token }}
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Run commitlint
         uses: wagoid/commitlint-github-action@v6
@@ -59,20 +45,8 @@ jobs:
         arch: ["${{ fromJSON(inputs.runner-archs) }}"]
       fail-fast: false
     steps:
-      - name: Checkout .github directory
+      - name: Checkout Code
         uses: actions/checkout@v4
-        with:
-          sparse-checkout: .github
-          repository: ${{ inputs.actions-repo }}
-          ref: ${{ inputs.actions-rev }}
-
-      - name: Initialize workspace
-        uses: ./.github/actions/initialize-workspace
-        with:
-          submodules: 'false'
-          remote-actions-repo: ${{ inputs.actions-repo }}
-          token: ${{ secrets.GIT_CLONE_PAT || github.token }}
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Spell check
         uses: crate-ci/typos@master
@@ -87,20 +61,8 @@ jobs:
         arch: ["${{ fromJSON(inputs.runner-archs) }}"]
       fail-fast: false
     steps:
-      - name: Checkout .github directory
+      - name: Checkout Code
         uses: actions/checkout@v4
-        with:
-          sparse-checkout: .github
-          repository: ${{ inputs.actions-repo }}
-          ref: ${{ inputs.actions-rev }}
-
-      - name: Initialize workspace
-        uses: ./.github/actions/initialize-workspace
-        with:
-          submodules: 'false'
-          remote-actions-repo: ${{ inputs.actions-repo }}
-          token: ${{ secrets.GIT_CLONE_PAT || github.token }}
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Fix paths
         run: |

--- a/.github/workflows/vm_test.yml
+++ b/.github/workflows/vm_test.yml
@@ -2,6 +2,9 @@ name: custom VM spawner
 on:
   workflow_call:
     inputs:
+      ref:
+        type: string
+        default: ''
       runner:
         type: string
         default: '["base", "dind", "2204"]'
@@ -52,10 +55,23 @@ jobs:
         length: 2
         style: 'lowerCase'
 
+    - name: Set ref and repo from PR or dispatch
+      id: set-ref
+      run: |
+        if [[ "${{ github.event_name }}" == "pull_request" || "${{ github.event_name }}" == "pull_request_target" ]]; then
+          echo "ref=${{ github.event.pull_request.head.ref }}" >> "$GITHUB_OUTPUT"
+          echo "repo=${{ github.event.pull_request.head.repo.full_name }}" >> "$GITHUB_OUTPUT"
+          echo "vmnamestr=pr${{ github.event.pull_request.number }}" >> "$GITHUB_ENV"
+        else
+          echo "ref=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          echo "repo=${{ github.repository }}" >> "$GITHUB_OUTPUT"
+          echo "vmnamestr=manual" >> "$GITHUB_ENV"
+        fi
+
     - name: Set VM name
       id: set-vm-name
       run: |
-        echo "VM_NAME=${{ github.event.repository.name }}-pr${{ github.event.pull_request.number }}-${{ steps.generate-names.outputs.name }}" >> $GITHUB_ENV
+        echo "VM_NAME=${{ github.event.repository.name }}-${{ env.vmnamestr }}-${{ steps.generate-names.outputs.name }}" >> $GITHUB_ENV
 
     - name: Launch VM
       id: launch-vm
@@ -80,14 +96,14 @@ jobs:
         export VM_NAME="${{ env.INCUS_CLUSTER }}:${{ env.VM_NAME }}"
         export INCUS_RUN="incus exec $VM_NAME --project ${{ env.INCUS_PROJECT }} -- sh -c "
         $INCUS_RUN "rm -f /usr/local/bin/urunc"
-        $INCUS_RUN "wget https://s3.nbfc.io/nbfc-assets/github/urunc/dist/${{ github.event.pull_request.head.ref }}/amd64/containerd-shim-urunc-v2_static_amd64"
-        $INCUS_RUN "wget https://s3.nbfc.io/nbfc-assets/github/urunc/dist/${{ github.event.pull_request.head.ref }}/amd64/urunc_static_amd64"
+        $INCUS_RUN "wget https://s3.nbfc.io/nbfc-assets/github/urunc/dist/${{ steps.set-ref.outputs.ref }}/amd64/containerd-shim-urunc-v2_static_amd64"
+        $INCUS_RUN "wget https://s3.nbfc.io/nbfc-assets/github/urunc/dist/${{ steps.set-ref.outputs.ref }}/amd64/urunc_static_amd64"
         $INCUS_RUN "chmod +x urunc_static_amd64"
         $INCUS_RUN "chmod +x containerd-shim-urunc-v2_static_amd64"
         $INCUS_RUN "mv urunc_static_amd64 /usr/local/bin/urunc"
         $INCUS_RUN "mv containerd-shim-urunc-v2_static_amd64 /usr/local/bin/containerd-shim-urunc-v2"
         $INCUS_RUN "urunc --version"
-        $INCUS_RUN "git clone https://github.com/${{ github.event.pull_request.head.repo.full_name }} -b ${{ github.event.pull_request.head.ref }} /root/develop/urunc"
+        $INCUS_RUN "git clone https://github.com/${{ steps.set-ref.outputs.repo }} -b ${{ steps.set-ref.outputs.ref }} /root/develop/urunc"
 
 
     - name: Run ctr tests


### PR DESCRIPTION
To be able to properly test both external (forked) and local branch-based PRs, we need to hack our way through Github Actions.

The issue is that since we moved to `pull_request_target` trigger (because we need secrets to upload binaries and trigger VM test jobs), the context of the github action that gets triggered is `main`. As a result, we need to explicitly check out the PRs' code to test it. This is fine with the actual (go) code, however, with the CI code this is different. There is no way we can test a change in a workflow using this method. 

To overcome this we follow the kata-containers approach, adding a manual trigger (`.github/workflows/ci_devel.yml`) that allows us to choose the branch (and thus the context) that the action will run. This adds the limitation that any change to the CI code (workflows in `.github/workflows/**`) should be "migrated" to a local branch in order to be tested.

So, in summary: 
- for `urunc` code changes (go, scripts etc.), the way we test is the same as before: a potential contributor posts a PR, the tests run against their code and after the review process, given a successful CI run, and approval by a Maintainer, we can merge 
- for CI-related changes (`.github/workflows` dir), the way to test a new workflow is to go to Actions -> urunc CI (manually triggered) and choose the local branch where the code is pushed. For external (forked) PRs it is the responsibility of a Maintainer to push the code to a local branch, run the test manually and link the successful run to the PR, so that we can merge
