### PR TITLE
Add support for the creation and change to a new rootfs for monitor execution

### DIFF
--- a/deployment/urunc-deploy/scripts/install.sh
+++ b/deployment/urunc-deploy/scripts/install.sh
@@ -58,15 +58,9 @@ function install_artifacts() {
             if which "qemu-system-$(uname -m)" >/dev/null 2>&1; then
                 echo "QEMU is already installed."
             else
-                install_artifact /urunc-artifacts/hypervisors/qemu-system-$(uname -m) /host/usr/local/bin/qemu-urunc
-                qemu_wrapper="/host/usr/local/bin/qemu-system-$(uname -m)"
-                cat <<EOF > $qemu_wrapper
-#!/bin/bash
-exec qemu-urunc -L /usr/local/share/qemu "\$@"
-EOF
-                chmod +x $qemu_wrapper
-                mkdir -p /host/usr/local/share/qemu/
-                cp -r /urunc-artifacts/opt/kata/share/kata-qemu/qemu /host/usr/local/share
+                install_artifact /urunc-artifacts/hypervisors/qemu-system-$(uname -m) /host/usr/local/bin/qemu-$(uname -m)
+                mkdir -p /host/usr/share/qemu/
+                cp -r /urunc-artifacts/opt/kata/share/kata-qemu/qemu /host/usr/share
             fi
             ;;
         firecracker)

--- a/docs/tutorials/How-to-urunc-on-k8s.md
+++ b/docs/tutorials/How-to-urunc-on-k8s.md
@@ -195,8 +195,8 @@ During installation, the following steps take place:
     * Labels the Node with label `urunc.io/urunc-runtime=true`.
 - Finally, `urunc` is added as a runtime class in k8s.
 
-> Note: `urunc-deploy` will install a static version of QEMU along with the QEMU BIOS files, if QEMU is not installed in PATH. The QEMU BIOS files are placed
-under the `/usr/local/share` directory. If the host system already had installed the BIOS files in this directory, they might get overwritten.
+> Note: `urunc-deploy` will install a static version of QEMU along with the QEMU BIOS files. The QEMU BIOS files are placed
+under the `/usr/share` directory. If the host system already had installed QEMU, then QEMU binary and the BIOS files in `/usr/share`, will get overwritten.
 
 During cleanup, these changes are reverted:
 

--- a/docs/tutorials/Non-root-monitor-execution.md
+++ b/docs/tutorials/Non-root-monitor-execution.md
@@ -1,42 +1,8 @@
 # Non-root execution of monitor
 
 To enhance security, `urunc` supports running the monitor process (VMM or
-seccomp monitor) as a non-root user. In this tutorial, we will walk through the
-necessary steps to set up the environment and successfully execute the monitor
-as a non-root user.
-
-## Requirements
-
-The vast majority of supported monitors use KVM and therefore require access to
-`/dev/kvm`. This includes monitors like
-[Solo5-hvt](https://github.com/Solo5/solo5), [Qemu](https://www.qemu.org), and
-[Firecracker](https://github.com/firecracker-microvm/firecracker). In contrast,
-[Solo5-spt](https://github.com/Solo5/solo5) does not require access to
-`/dev/kvm`. As such, when spawning the monitor process, we must ensure that it
-has the necessary permissions to access `/dev/kvm`.
-
-Usually `/dev/kvm` has the following filesystem permissions:
-
-```
-$ ls -l /dev/kvm
-crw-rw---- 1 root kvm 10, 232 Apr  3 08:10 /dev/kvm
-```
-
-In case the above permissions are different in your system, we strongly
-recommend to perform the following steps:
-
-```
-$ sudo groupadd kvm -r
-$ sudo chown root:kvm /dev/kvm
-$ sudo chmod 660 /dev/kvm
-```
-
-An important information we need to obtain is the group ID of `kvm` group:
-
-```
-$ getent group kvm
-kvm:x:108:ubuntu
-```
+seccomp monitor) as a non-root user. This can be as simple as setting the
+respective uid/gid for the execution of the container.
 
 ## Running the monitor as non-root user
 
@@ -44,9 +10,7 @@ By default `urunc` will execute the monitor setting up the `uid`, `gid` and
 `additionalGids` from the [container's OCI
 configuration](https://github.com/opencontainers/runtime-spec/blob/main/config.md#posix-platform-user).
 As a result, we simply need to instruct `urunc` to run a container as the desired
-user. However, since most monitors require access to `/dev/kvm`, we must ensure
-that the container is a member of the `kvm` group to grant the necessary
-permissions.
+user.
 
 ### Docker and Nerdctl
 
@@ -56,19 +20,7 @@ container with the `--user <uid>:<gid>` option and the additional groups using
 monitor with `urunc` as `nobody`, we use the following command:
 
 ```
-$ sudo nerdctl run  --user 65534:65534 --group-add 108 --runtime "io.containerd.urunc.v2" --rm -it harbor.nbfc.io/nubificus/urunc/nginx-firecracker-unikraft-initrd:latest
-```
-
-Pay attention to the `--group-add 108` option which instructs `urunc` to add
-the group with id `108` as an additional group for the container. The
-`108` id is the group id of `kvm` that we found previously.
-
-On the other hand, if we are using a monitor that does not require access to
-`/dev/kvm`, such as [Solo5-spt](https://github.com/Solo5/solo5), then we can
-omit the `--group-add` command.  As a result, the command will transform to:
-
-```
-$ sudo nerdctl run  --user 65534:65534 --runtime "io.containerd.urunc.v2" --rm -it harbor.nbfc.io/nubificus/urunc/net-spt-mirage:latest
+$ sudo nerdctl run  --user 65534:65534 --runtime "io.containerd.urunc.v2" --rm -it harbor.nbfc.io/nubificus/urunc/nginx-firecracker-unikraft-initrd:latest
 ```
 
 > Note The commands are the same for docker.
@@ -84,30 +36,9 @@ the `securityContext` field of the deployment yaml:
 securityContext:
   runAsUser: 65534
   runAsGroup: 65534
-  supplementalGroups: [108]
+  supplementalGroups: [1000]
 ```
-
-As previously mentioned, if we want to run a monitor that requires access to
-`/dev/kvm`, we need to add the `kvm`'s groupid in the `supplementalGroups`.
-Otherwise, we do not have to specify any supplementary group.
 
 For more information regarding the Security Context of a Pod / Container take a
 look at [Kubernetes's
 documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
-
-
-## Caveats
-
-For monitors that require access to `/dev/kvm`, we need to ensure that the
-container (and, by extension, the monitor) is a member of the `kvm` group. This
-is unavoidable. Additionally, it is essential that the `kvm`
-group has the same ID across all nodes to make sure that all containers,
-regardless of the node, can access `/dev/kvm`.
-
-Another caveat of this setup is access to the device mapper snapshot. In some
-cases, `urunc` uses the device mapper snapshot as a block device for the
-unikernel. However, the snapshot is typically created by root and belongs to the
-`disk` group. As a result, to use this feature of `urunc`, we will also need
-to add the container to the `disk` group, similar to how we handle the `kvm`
-group. Fortunately, there are options we can explore to address this issue, and
-we are actively working towards a solution.

--- a/pkg/unikontainers/hypervisors/firecracker.go
+++ b/pkg/unikontainers/hypervisors/firecracker.go
@@ -76,6 +76,11 @@ func (fc *Firecracker) Stop(_ string) error {
 func (fc *Firecracker) Ok() error {
 	return nil
 }
+
+func (fc *Firecracker) UsesKVM() bool {
+	return true
+}
+
 func (fc *Firecracker) Path() string {
 	return fc.binaryPath
 }

--- a/pkg/unikontainers/hypervisors/firecracker.go
+++ b/pkg/unikontainers/hypervisors/firecracker.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"syscall"
@@ -93,7 +94,7 @@ func (fc *Firecracker) Execve(args ExecArgs, _ unikernels.Unikernel) error {
 	// functions in the unikernel interface do not integrate well with FC's
 	// json configuration.
 	cmdString := fc.Path() + " --no-api --config-file "
-	JSONConfigFile := FCJsonFilename
+	JSONConfigFile := filepath.Join("/tmp/", FCJsonFilename)
 	cmdString += JSONConfigFile
 	if !args.Seccomp {
 		cmdString += " --no-seccomp"

--- a/pkg/unikontainers/hypervisors/hedge.go
+++ b/pkg/unikontainers/hypervisors/hedge.go
@@ -37,6 +37,10 @@ func (h *Hedge) Stop(_ string) error {
 	return fmt.Errorf("hedge not implemented yet")
 }
 
+func (h *Hedge) UsesKVM() bool {
+	return true
+}
+
 func (h *Hedge) Path() string {
 	return ""
 }

--- a/pkg/unikontainers/hypervisors/hvt.go
+++ b/pkg/unikontainers/hypervisors/hvt.go
@@ -124,6 +124,11 @@ func (h *HVT) Stop(_ string) error {
 	return nil
 }
 
+// UsesKVM returns a bool value depending on if the monitor uses KVM
+func (h *HVT) UsesKVM() bool {
+	return true
+}
+
 // Path returns the path to the hvt binary.
 func (h *HVT) Path() string {
 	return h.binaryPath

--- a/pkg/unikontainers/hypervisors/qemu.go
+++ b/pkg/unikontainers/hypervisors/qemu.go
@@ -53,6 +53,7 @@ func (q *Qemu) Execve(args ExecArgs, ukernel unikernels.Unikernel) error {
 	qemuString := string(QemuVmm)
 	qemuMem := bytesToStringMB(args.MemSizeB)
 	cmdString := q.binaryPath + " -m " + qemuMem + "M"
+	cmdString += " -L /usr/share/qemu"   // Set the path for qemu bios/data
 	cmdString += " -cpu host"            // Choose CPU
 	cmdString += " -enable-kvm"          // Enable KVM to use CPU virt extensions
 	cmdString += " -nographic -vga none" // Disable graphic output

--- a/pkg/unikontainers/hypervisors/qemu.go
+++ b/pkg/unikontainers/hypervisors/qemu.go
@@ -39,6 +39,12 @@ func (q *Qemu) Stop(_ string) error {
 func (q *Qemu) Ok() error {
 	return nil
 }
+
+// UsesKVM returns a bool value depending on if the monitor uses KVM
+func (q *Qemu) UsesKVM() bool {
+	return true
+}
+
 func (q *Qemu) Path() string {
 	return q.binaryPath
 }

--- a/pkg/unikontainers/hypervisors/spt.go
+++ b/pkg/unikontainers/hypervisors/spt.go
@@ -38,6 +38,11 @@ func (s *SPT) Stop(_ string) error {
 	return nil
 }
 
+// UsesKVM returns a bool value depending on if the monitor uses KVM
+func (s *SPT) UsesKVM() bool {
+	return false
+}
+
 // Path returns the path to the spt binary.
 func (s *SPT) Path() string {
 	return s.binaryPath

--- a/pkg/unikontainers/hypervisors/vmm.go
+++ b/pkg/unikontainers/hypervisors/vmm.go
@@ -50,6 +50,7 @@ type VMM interface {
 	Execve(args ExecArgs, ukernel unikernels.Unikernel) error
 	Stop(t string) error
 	Path() string
+	UsesKVM() bool
 	Ok() error
 }
 


### PR DESCRIPTION
Add support to create a new rootfs which we will use to execute the monitor process. The new rootfs is based on the unikernel's container rootfs and we append all the necessary files and devices for the monitor execution. In particular, we perform the necessary steps to prepare the container's rootfs to become the new rootfs and append the below files and devs:
- The monitor binary
- `/dev/urandom`
- `/dev/null`
- `/dev/net/tun`: If the container has network
- `/dev/kvm`: If the monitor requires access to KVM.
- The snapshotter device if devmapper is used

In addition, since qemu is usually dynamically linked, we also need to append the shared objects from the libraries that it requires. This is not nice, but enough as a first step for a clean rootfs and helps us for a smoother transition to statically linked binaries.

It is important to note that the permissions of the devices are changed to rw for others to enable the easier non-root execution of the monitor process.  This does not affect safety, since we have a single process running inside the "container" and it already requires access to such devices.