### PR TITLE
fix: Improve logging and error handling

### DIFF
--- a/cmd/urunc/create.go
+++ b/cmd/urunc/create.go
@@ -68,8 +68,7 @@ var createCommand = cli.Command{
 		},
 	},
 	Action: func(context *cli.Context) error {
-		// FIXME: Remove or change level of log
-		logrus.WithField("args", os.Args).Info("urunc INVOKED")
+		logrus.WithField("command", "CREATE").WithField("args", os.Args).Debug("urunc INVOKED")
 		if err := checkArgs(context, 1, exactArgs); err != nil {
 			return err
 		}

--- a/cmd/urunc/create.go
+++ b/cmd/urunc/create.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/creack/pty"
 	"github.com/nubificus/urunc/pkg/unikontainers"
-	"github.com/opencontainers/runc/libcontainer/logs"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 	"golang.org/x/sys/unix"
@@ -161,7 +160,7 @@ func createUnikontainer(context *cli.Context) (err error) {
 	reexecCommand := createReexecCmd(initSockChild, logPipeChild)
 
 	// Create a go func to handle logs from nsenter
-	logsDone := logs.ForwardLogs(logPipeParent)
+	logsDone := ForwardLogs(logPipeParent)
 
 	// Start reexec process
 	metrics.Capture(containerID, "TS03")

--- a/cmd/urunc/delete.go
+++ b/cmd/urunc/delete.go
@@ -44,7 +44,7 @@ status of "ubuntu01" as "stopped" the following will delete resources held for
 	Action: func(context *cli.Context) error {
 		runtime.GOMAXPROCS(1)
 		runtime.LockOSThread()
-		logrus.WithField("args", os.Args).Info("urunc INVOKED")
+		logrus.WithField("command", "DELETE").WithField("args", os.Args).Debug("urunc INVOKED")
 		if err := checkArgs(context, 1, exactArgs); err != nil {
 			return err
 		}

--- a/cmd/urunc/kill.go
+++ b/cmd/urunc/kill.go
@@ -44,8 +44,7 @@ signal to the init process of the "ubuntu01" container:
 	Action: func(context *cli.Context) error {
 		runtime.GOMAXPROCS(1)
 		runtime.LockOSThread()
-		// FIXME: Remove or change level of log
-		logrus.WithField("args", os.Args).Info("urunc INVOKED")
+		logrus.WithField("command", "KILL").WithField("args", os.Args).Debug("urunc INVOKED")
 		if err := checkArgs(context, 1, minArgs); err != nil {
 			return err
 		}

--- a/cmd/urunc/log_forward.go
+++ b/cmd/urunc/log_forward.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2023-2025, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"io"
+	"maps"
+	"regexp"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+var msgRegex = regexp.MustCompile(`^([\w\-]+\[\d+\]): (.+)$`)
+
+type StructuredJSONFormatter struct{}
+
+func (f *StructuredJSONFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+	data := make(logrus.Fields, len(entry.Data)+4)
+	maps.Copy(data, entry.Data)
+
+	data["time"] = entry.Time.Format(time.RFC3339)
+	data["level"] = entry.Level.String()
+
+	if matches := msgRegex.FindStringSubmatch(entry.Message); len(matches) == 3 {
+		data["subsystem"] = matches[1]
+		data["msg"] = matches[2]
+	} else {
+		data["msg"] = entry.Message
+	}
+
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	encoder.SetEscapeHTML(false)
+
+	err := encoder.Encode(data)
+	return buf.Bytes(), err
+}
+
+// ForwardLogs reads logs from the provided logPipe and forwards them to the standard logger.
+// It returns a channel that will receive an error if reading from the logPipe fails.
+//
+// Modified version of runc's ForwardLogs:
+// https://github.com/opencontainers/runc/blob/b55b308143715914bd3569727237bb0b0ddb62bd/libcontainer/logs/logs.go#11
+func ForwardLogs(logPipe io.ReadCloser) chan error {
+	done := make(chan error, 1)
+	s := bufio.NewScanner(logPipe)
+
+	logger := logrus.StandardLogger()
+
+	if logger.ReportCaller {
+		// Need a copy of the standard logger, but with ReportCaller
+		// turned off, as the logs are merely forwarded and their
+		// true source is not this file/line/function.
+		logNoCaller := *logrus.StandardLogger()
+		logNoCaller.ReportCaller = false
+		logger = &logNoCaller
+	}
+	switch logger.Formatter.(type) {
+	case *logrus.JSONFormatter:
+		logger.SetFormatter(&StructuredJSONFormatter{})
+	default:
+		logger.SetFormatter(&logrus.TextFormatter{
+			DisableColors: true,
+			ForceQuote:    true,
+		})
+	}
+
+	go func() {
+		for s.Scan() {
+			processEntry(s.Bytes(), logger)
+		}
+		if err := logPipe.Close(); err != nil {
+			logrus.Errorf("error closing log source: %v", err)
+		}
+		// The only error we want to return is when reading from
+		// logPipe has failed.
+		done <- s.Err()
+		close(done)
+	}()
+
+	return done
+}
+
+// processEntry processes a log entry, decoding it from JSON and logging it using the provided logger.
+// It expects the log entry to be in a specific JSON format
+// with "level" and "msg" fields. If the entry cannot be decoded, it logs an error.
+//
+// Modified version of runc's processEntry:
+// https://github.com/opencontainers/runc/blob/b55b308143715914bd3569727237bb0b0ddb62bd/libcontainer/logs/logs.go#41
+func processEntry(text []byte, logger *logrus.Logger) {
+	if len(text) == 0 {
+		return
+	}
+
+	var jl struct {
+		Level logrus.Level `json:"level"`
+		Msg   string       `json:"msg"`
+	}
+	if err := json.Unmarshal(text, &jl); err != nil {
+		logrus.Errorf("failed to decode %q to json: %v", text, err)
+		return
+	}
+	logger.Log(jl.Level, jl.Msg)
+}

--- a/cmd/urunc/main.go
+++ b/cmd/urunc/main.go
@@ -96,6 +96,10 @@ func main() {
 			Value: "auto",
 			Usage: "ignore cgroup permission errors ('true', 'false', or 'auto')",
 		},
+		cli.BoolFlag{
+			Name:  "syslog",
+			Usage: "send log messages to syslog",
+		},
 	}
 	app.Commands = []cli.Command{
 		createCommand,
@@ -186,11 +190,14 @@ func configLogrus(context *cli.Context) error {
 	default:
 		return errors.New("invalid log-format: " + f)
 	}
-	hook, err := lSyslog.NewSyslogHook("", "", syslog.LOG_DEBUG, "")
-	if err != nil {
-		log.Fatal(err)
+
+	if context.GlobalBool("syslog") {
+		hook, err := lSyslog.NewSyslogHook("", "", syslog.LOG_DEBUG, "")
+		if err != nil {
+			log.Fatal(err)
+		}
+		logrus.AddHook(hook)
 	}
-	logrus.AddHook(hook)
 
 	if file := context.GlobalString("log"); file != "" {
 		f, err := os.OpenFile(file, os.O_CREATE|os.O_WRONLY|os.O_APPEND|os.O_SYNC, 0o644)

--- a/cmd/urunc/run.go
+++ b/cmd/urunc/run.go
@@ -60,9 +60,7 @@ var runCommand = cli.Command{
 		},
 	},
 	Action: func(context *cli.Context) error {
-		// FIXME: Remove or change level of log
-		logrus.WithField("args", os.Args).Info("urunc INVOKED")
-
+		logrus.WithField("command", "RUN").WithField("args", os.Args).Debug("urunc INVOKED")
 		if err := checkArgs(context, 1, exactArgs); err != nil {
 			return err
 		}

--- a/cmd/urunc/start.go
+++ b/cmd/urunc/start.go
@@ -31,8 +31,7 @@ are starting. The name you provide for the container instance must be unique on
 your host.`,
 	Description: `The start command executes the user defined process in a created container.`,
 	Action: func(context *cli.Context) error {
-		// FIXME: Remove or change level of log
-		logrus.WithField("args", os.Args).Info("urunc INVOKED")
+		logrus.WithField("command", "START").WithField("args", os.Args).Debug("urunc INVOKED")
 		if err := checkArgs(context, 1, exactArgs); err != nil {
 			return err
 		}

--- a/cmd/urunc/utils.go
+++ b/cmd/urunc/utils.go
@@ -34,7 +34,7 @@ const (
 	maxArgs          // Checks for a maximum number of arguments.
 )
 
-var ErrEmptyContainerID = errors.New("Container ID can not be empty")
+var ErrEmptyContainerID = errors.New("container ID can not be empty")
 
 // checkArgs checks the number of arguments provided in the command-line context
 // against the expected number, based on the specified checkType.
@@ -127,6 +127,5 @@ func fatalWithCode(err error, ret int) {
 	if !logrusToStderr() {
 		fmt.Fprintln(os.Stderr, err)
 	}
-
 	os.Exit(ret)
 }

--- a/docs/developer-guide/development.md
+++ b/docs/developer-guide/development.md
@@ -1,5 +1,9 @@
+---
 title: Setup a Dev environment
-------
+description: "Dev environment setup guide"
+---
+
+## Prerequisites
 
 Most of the steps are covered in the [installation](../../installation) document.
 Please refer to it for:
@@ -10,11 +14,13 @@ Please refer to it for:
 - installing `nerdctl` and the `CNI` plugins
 - installing the relevant hypervisors
 
+## crictl installation
+
 In addition to the above, we strongly suggest to install
 [crictl](https://github.com/kubernetes-sigs/cri-tools/tree/master) which `urunc`
 uses for its end-to-end tests. The following commands will install `crictl`
 
-```bash
+```console
 $ VERSION="v1.30.0" # check latest version in /releases page
 $ wget https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-$VERSION-linux-amd64.tar.gz
 $ sudo tar zxvf crictl-$VERSION-linux-amd64.tar.gz -C /usr/local/bin
@@ -23,7 +29,7 @@ $ rm -f crictl-$VERSION-linux-amd64.tar.gz
 
 Since default endpoints for `crictl` are now deprecated, we need to set them up:
 
-```
+```console
 $ sudo tee -a /etc/crictl.yaml > /dev/null <<'EOT'
 runtime-endpoint: unix:///run/containerd/containerd.sock
 image-endpoint: unix:///run/containerd/containerd.sock
@@ -31,9 +37,11 @@ timeout: 20
 EOT
 ```
 
+## urunc installation
+
 The next step is to clone and build `urunc`:
 
-```bash
+```console
 $ git clone https://github.com/nubificus/urunc.git
 $ cd urunc
 $ make && sudo make install
@@ -49,3 +57,19 @@ by running the:
 > Note: When running `make` commands for `urunc` that will use go (i.e. build,
 > unitest, e2etest) you might need to specify the path to the go binary
 with `sudo GO=$(which go) make`.
+
+## Debugging
+
+To enable debugging logs, we need to pass the `--debug` flag when calling `urunc`. Also, to facilitate easier
+debugging, the `--syslog` flag can be set to ensure that all logs are propagated to the syslog.
+
+An easy way to achieve this is to create a Bash wrapper for `urunc`:
+
+```console
+$ sudo mv /usr/local/bin/urunc /usr/local/bin/urunc.default
+$ sudo tee /usr/local/bin/urunc > /dev/null <<'EOT'
+#!/usr/bin/env bash
+exec /usr/local/bin/urunc.default --debug --syslog "$@"
+EOT
+$ sudo chmod +x /usr/local/bin/urunc
+```

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -220,7 +220,7 @@ func networkSetup(tapName string, ipAddress string, redirectLink netlink.Link, a
 	err := ensureEth0Exists()
 	// if eth0 does not exist in the namespace, the unikernel was spawned using ctr, so we skip the network setup
 	if err != nil {
-		netlog.Info("eth0 interface not found, assuming unikernel was spawned using ctr")
+		netlog.Warn("eth0 interface not found, assuming unikernel was spawned using ctr")
 		return nil, nil
 	}
 	newTapDevice, err := createTapDevice(tapName, redirectLink.Attrs().MTU, uid, gid)
@@ -262,7 +262,7 @@ func networkSetup(tapName string, ipAddress string, redirectLink netlink.Link, a
 }
 
 func Cleanup(tapDevice string) error {
-	netlog.Info("net cleanup called")
+	netlog.Debug("net cleanup called")
 	ifaces, err := net.Interfaces()
 	if err != nil {
 		return err

--- a/pkg/network/network_static.go
+++ b/pkg/network/network_static.go
@@ -52,7 +52,7 @@ func setNATRule(iface string, sourceIP string) error {
 	if err != nil {
 		return fmt.Errorf("failed to enable IP forwarding: %w", err)
 	}
-	netlog.Debugf("Enabled IP forwarding")
+	netlog.Debug("Enabled IP forwarding")
 
 	args = append(args, path)
 	args = append(args, "-t")
@@ -84,7 +84,7 @@ func setNATRule(iface string, sourceIP string) error {
 		}
 	}
 
-	netlog.Infof("Applied iptables rule for NAT")
+	netlog.Debug("Applied iptables rule for NAT")
 
 	return nil
 }

--- a/pkg/unikontainers/hypervisors/firecracker.go
+++ b/pkg/unikontainers/hypervisors/firecracker.go
@@ -160,10 +160,10 @@ func (fc *Firecracker) Execve(args ExecArgs, _ unikernels.Unikernel) error {
 	if err := os.WriteFile(JSONConfigFile, FCConfigJSON, 0o644); err != nil { //nolint: gosec
 		return fmt.Errorf("failed to save Firecracker json config: %w", err)
 	}
-	vmmLog.WithField("Json=", string(FCConfigJSON)).Info("Firecracker json config")
+	vmmLog.WithField("Json", string(FCConfigJSON)).Debug("Firecracker json config")
 
 	exArgs := strings.Split(cmdString, " ")
-	vmmLog.WithField("Firecracker command", exArgs).Info("Ready to execve Firecracker")
+	vmmLog.WithField("Firecracker command", exArgs).Debug("Ready to execve Firecracker")
 
 	return syscall.Exec(fc.Path(), exArgs, args.Environment) //nolint: gosec
 }

--- a/pkg/unikontainers/hypervisors/hvt.go
+++ b/pkg/unikontainers/hypervisors/hvt.go
@@ -112,8 +112,8 @@ func applySeccompFilter() error {
 		return err
 	}
 
-	vmmLog.Info("Loaded seccomp filters")
-	vmmLog.Debug("Whitelisted system calls ", syscalls)
+	vmmLog.Debug("Loaded seccomp filters")
+	vmmLog.WithField("allowed syscalls", syscalls).Debug("Whitelisted system calls")
 
 	return nil
 }
@@ -157,6 +157,6 @@ func (h *HVT) Execve(args ExecArgs, ukernel unikernels.Unikernel) error {
 			return err
 		}
 	}
-	vmmLog.WithField("hvt command", cmdString).Error("Ready to execve hvt")
+	vmmLog.WithField("hvt command", cmdString).Debug("Ready to execve hvt")
 	return syscall.Exec(h.binaryPath, cmdArgs, args.Environment) //nolint: gosec
 }

--- a/pkg/unikontainers/hypervisors/qemu.go
+++ b/pkg/unikontainers/hypervisors/qemu.go
@@ -105,6 +105,6 @@ func (q *Qemu) Execve(args ExecArgs, ukernel unikernels.Unikernel) error {
 	cmdString += ukernel.MonitorCli(qemuString)
 	exArgs := strings.Split(cmdString, " ")
 	exArgs = append(exArgs, "-append", args.Command)
-	vmmLog.WithField("qemu command", exArgs).Info("Ready to execve qemu")
+	vmmLog.WithField("qemu command", exArgs).Debug("Ready to execve qemu")
 	return syscall.Exec(q.Path(), exArgs, args.Environment) //nolint: gosec
 }

--- a/pkg/unikontainers/hypervisors/spt.go
+++ b/pkg/unikontainers/hypervisors/spt.go
@@ -65,6 +65,6 @@ func (s *SPT) Execve(args ExecArgs, ukernel unikernels.Unikernel) error {
 	cmdString = appendNonEmpty(cmdString, " ", ukernel.MonitorCli(sptString))
 	cmdString += " " + args.UnikernelPath + " " + args.Command
 	cmdArgs := strings.Split(cmdString, " ")
-	vmmLog.WithField("spt command", cmdString).Error("Ready to execve spt")
+	vmmLog.WithField("spt command", cmdString).Debug("Ready to execve spt")
 	return syscall.Exec(s.binaryPath, cmdArgs, args.Environment) //nolint: gosec
 }

--- a/pkg/unikontainers/ipc.go
+++ b/pkg/unikontainers/ipc.go
@@ -65,7 +65,7 @@ func SockAddrExists(sockAddr string) bool {
 	if errors.Is(err, fs.ErrNotExist) {
 		return false
 	}
-	Log.WithError(err).Errorf("Failed to get file info for %s", sockAddr)
+	uniklog.WithError(err).Errorf("Failed to get file info for %s", sockAddr)
 	return false
 }
 

--- a/pkg/unikontainers/storage.go
+++ b/pkg/unikontainers/storage.go
@@ -65,7 +65,7 @@ func getBlockDevice(path string) (RootFs, error) {
 		fields = strings.Fields(parts[1])
 		result.FsType = fields[0]
 		result.Device = fields[1]
-		Log.WithFields(logrus.Fields{
+		uniklog.WithFields(logrus.Fields{
 			"mountpoint": result.Path,
 			"device":     result.Device,
 			"fstype":     result.FsType,
@@ -95,7 +95,7 @@ func extractFilesFromBlock(unikernel string, uruncJSON string, initrd string, ro
 	if err != nil {
 		err1 := os.RemoveAll(tmpDir)
 		if err1 != nil {
-			Log.Errorf("Could not remove directory %s", tmpDir)
+			uniklog.Errorf("Could not remove directory %s", tmpDir)
 		}
 		return "", err
 	}
@@ -108,7 +108,7 @@ func extractFilesFromBlock(unikernel string, uruncJSON string, initrd string, ro
 		if err != nil {
 			err1 := os.RemoveAll(tmpDir)
 			if err1 != nil {
-				Log.Errorf("Could not remove directory %s", tmpDir)
+				uniklog.Errorf("Could not remove directory %s", tmpDir)
 			}
 			return "", err
 		}
@@ -119,7 +119,7 @@ func extractFilesFromBlock(unikernel string, uruncJSON string, initrd string, ro
 	if err != nil {
 		err1 := os.RemoveAll(tmpDir)
 		if err1 != nil {
-			Log.Errorf("Could not remove directory %s", tmpDir)
+			uniklog.Errorf("Could not remove directory %s", tmpDir)
 		}
 		return "", err
 	}

--- a/pkg/unikontainers/storage.go
+++ b/pkg/unikontainers/storage.go
@@ -26,7 +26,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var ErrMountpoint = errors.New("No FS is mounted in this mountpoint")
+var ErrMountpoint = errors.New("no FS is mounted in this mountpoint")
 
 // RootFs contains information regarding a mount
 type RootFs struct {
@@ -53,7 +53,7 @@ func getBlockDevice(path string) (RootFs, error) {
 		line := scanner.Text()
 		parts := strings.Split(line, " - ")
 		if len(parts) != 2 {
-			return result, fmt.Errorf("Invalid mountinfo line in /proc/self/mountinfo")
+			return result, fmt.Errorf("invalid mountinfo line in /proc/self/mountinfo")
 		}
 
 		fields := strings.Fields(parts[0])

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -43,8 +43,8 @@ import (
 
 var Log = logrus.WithField("subsystem", "unikontainers")
 
-var ErrQueueProxy = errors.New("This a queue proxy container")
-var ErrNotUnikernel = errors.New("This is not a unikernel container")
+var ErrQueueProxy = errors.New("this a queue proxy container")
+var ErrNotUnikernel = errors.New("this is not a unikernel container")
 
 // Unikontainer holds the data necessary to create, manage and delete unikernel containers
 type Unikontainer struct {
@@ -518,11 +518,11 @@ func (u Unikontainer) joinSandboxNetNs() error {
 	}).Info("Joining network namespace")
 	fd, err := unix.Open(netNsPath, unix.O_RDONLY|unix.O_CLOEXEC, 0)
 	if err != nil {
-		return fmt.Errorf("Error opening namespace path: %w", err)
+		return fmt.Errorf("error opening namespace path: %w", err)
 	}
 	err = unix.Setns(int(fd), unix.CLONE_NEWNET)
 	if err != nil {
-		return fmt.Errorf("Error joining namespace: %w", err)
+		return fmt.Errorf("error joining namespace: %w", err)
 	}
 	Log.Info("Joined network namespace")
 	return nil


### PR DESCRIPTION
This pull request introduces a set of improvements aimed at enhancing logging clarity, consistency, and debugging capabilities:

- **Fix escaped `nsenter` logs**  
  Replaces escaped characters in `nsenter` logs with properly formatted output via a custom formatter for improved readability.

- **Refactor sequential hook execution in unikontainers**  
  Refactors hook execution to better handle errors, use `sync.WaitGroup` more cleanly, and allow detailed logging per hook.

- **Correct logging levels**  
  Ensures consistent use of severity levels in log messages for clearer diagnostics.

- **Add optional syslog support**  
  Introduces a new `--syslog` CLI flag that enables logging to syslog alongside other destinations for centralized logging and monitoring.

- **Uncapitalize error messages**  
  Updates error messages to conform to Go’s [`ST1005`](https://staticcheck.dev/docs/checks#ST1005) style guideline by removing capitalization from the beginning of error strings.
