### PR TITLE
chore: Replacce references of old repository in code and docs

### DIFF
--- a/cmd/urunc/create.go
+++ b/cmd/urunc/create.go
@@ -26,9 +26,9 @@ import (
 	"strconv"
 
 	"github.com/creack/pty"
-	"github.com/nubificus/urunc/pkg/unikontainers"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
+	"github.com/urunc-dev/urunc/pkg/unikontainers"
 	"golang.org/x/sys/unix"
 )
 

--- a/cmd/urunc/main.go
+++ b/cmd/urunc/main.go
@@ -25,10 +25,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/nubificus/urunc/internal/constants"
-	m "github.com/nubificus/urunc/internal/metrics"
 	"github.com/sirupsen/logrus"
 	lSyslog "github.com/sirupsen/logrus/hooks/syslog"
+	"github.com/urunc-dev/urunc/internal/constants"
+	m "github.com/urunc-dev/urunc/internal/metrics"
 
 	_ "github.com/opencontainers/runc/libcontainer/nsenter"
 	"github.com/urfave/cli"

--- a/cmd/urunc/utils.go
+++ b/cmd/urunc/utils.go
@@ -21,9 +21,9 @@ import (
 	"os/exec"
 	"syscall"
 
-	"github.com/nubificus/urunc/pkg/unikontainers"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
+	"github.com/urunc-dev/urunc/pkg/unikontainers"
 	"golang.org/x/sys/unix"
 )
 

--- a/docs/tutorials/How-to-urunc-on-k8s.md
+++ b/docs/tutorials/How-to-urunc-on-k8s.md
@@ -107,34 +107,34 @@ be utilized to install `urunc` runtime  on a running Kubernetes cluster.
 To install in a k3s cluster, first we need to create the RBAC:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/nubificus/urunc/main/deployment/urunc-deploy/urunc-rbac/urunc-rbac.yaml
+kubectl apply -f https://raw.githubusercontent.com/urunc-dev/urunc/main/deployment/urunc-deploy/urunc-rbac/urunc-rbac.yaml
 ```
 
 Then, we create the `urunc-deploy` Daemonset, followed by the k3s customization:
 
 ```bash
-kubectl apply -k https://github.com/nubificus/urunc//deployment/urunc-deploy/urunc-deploy/overlays/k3s?ref=main
+kubectl apply -k https://github.com/urunc-dev/urunc//deployment/urunc-deploy/urunc-deploy/overlays/k3s?ref=main
 ```
 
 Finally, we need to create the appropriate k8s runtime class:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/nubificus/urunc/refs/heads/main/deployment/urunc-deploy/runtimeclasses/runtimeclass.yaml
+kubectl apply -f https://raw.githubusercontent.com/urunc-dev/urunc/refs/heads/main/deployment/urunc-deploy/runtimeclasses/runtimeclass.yaml
 ```
 
 To uninstall:
 
 ```bash
-kubectl delete -k https://github.com/nubificus/urunc//deployment/urunc-deploy/urunc-deploy/overlays/k3s?ref=main
-kubectl apply -k https://github.com/nubificus/urunc//deployment/urunc-deploy/urunc-cleanup/overlays/k3s?ref=main
+kubectl delete -k https://github.com/urunc-dev/urunc//deployment/urunc-deploy/urunc-deploy/overlays/k3s?ref=main
+kubectl apply -k https://github.com/urunc-dev/urunc//deployment/urunc-deploy/urunc-cleanup/overlays/k3s?ref=main
 ```
 
 After the cleanup is completed and the `urunc-deploy` Pod is terminated:
 
 ```bash
-kubectl delete -k https://github.com/nubificus/urunc//deployment/urunc-deploy/urunc-cleanup/overlays/k3s?ref=main
-kubectl delete -f https://raw.githubusercontent.com/nubificus/urunc/refs/heads/main/deployment/urunc-deploy/runtimeclasses/runtimeclass.yaml
-kubectl delete -f https://raw.githubusercontent.com/nubificus/urunc/main/deployment/urunc-deploy/urunc-rbac/urunc-rbac.yaml
+kubectl delete -k https://github.com/urunc-dev/urunc//deployment/urunc-deploy/urunc-cleanup/overlays/k3s?ref=main
+kubectl delete -f https://raw.githubusercontent.com/urunc-dev/urunc/refs/heads/main/deployment/urunc-deploy/runtimeclasses/runtimeclass.yaml
+kubectl delete -f https://raw.githubusercontent.com/urunc-dev/urunc/main/deployment/urunc-deploy/urunc-rbac/urunc-rbac.yaml
 ```
 
 ### urunc-deploy in k8s with containerd
@@ -142,34 +142,34 @@ kubectl delete -f https://raw.githubusercontent.com/nubificus/urunc/main/deploym
 To install in a k8s cluster, first we need to create the RBAC:
 
 ```bash
-kubectl delete -f https://raw.githubusercontent.com/nubificus/urunc/main/deployment/urunc-deploy/urunc-rbac/urunc-rbac.yaml
+kubectl delete -f https://raw.githubusercontent.com/urunc-dev/urunc/main/deployment/urunc-deploy/urunc-rbac/urunc-rbac.yaml
 ```
 
 Then, we create the `urunc-deploy` Daemonset:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/nubificus/urunc/main/deployment/urunc-deploy/urunc-deploy/base/urunc-deploy.yaml
+kubectl apply -f https://raw.githubusercontent.com/urunc-dev/urunc/main/deployment/urunc-deploy/urunc-deploy/base/urunc-deploy.yaml
 ```
 
 Finally, we need to create the appropriate k8s runtime class:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/nubificus/urunc/refs/heads/main/deployment/urunc-deploy/runtimeclasses/runtimeclass.yaml
+kubectl apply -f https://raw.githubusercontent.com/urunc-dev/urunc/refs/heads/main/deployment/urunc-deploy/runtimeclasses/runtimeclass.yaml
 ```
 
 To uninstall:
 
 ```bash
-kubectl delete -f https://raw.githubusercontent.com/nubificus/urunc/main/deployment/urunc-deploy/urunc-deploy/base/urunc-deploy.yaml
-kubectl apply -f https://raw.githubusercontent.com/nubificus/urunc/main/deployment/urunc-deploy/urunc-cleanup/base/urunc-cleanup.yaml
+kubectl delete -f https://raw.githubusercontent.com/urunc-dev/urunc/main/deployment/urunc-deploy/urunc-deploy/base/urunc-deploy.yaml
+kubectl apply -f https://raw.githubusercontent.com/urunc-dev/urunc/main/deployment/urunc-deploy/urunc-cleanup/base/urunc-cleanup.yaml
 ```
 
 After the cleanup is completed:
 
 ```bash
-kubectl delete -f https://raw.githubusercontent.com/nubificus/urunc/main/deployment/urunc-deploy/urunc-cleanup/base/urunc-cleanup.yaml
-kubectl delete -f https://raw.githubusercontent.com/nubificus/urunc/refs/heads/main/deployment/urunc-deploy/runtimeclasses/runtimeclass.yaml
-kubectl delete -f https://raw.githubusercontent.com/nubificus/urunc/main/deployment/urunc-deploy/urunc-rbac/urunc-rbac.yaml
+kubectl delete -f https://raw.githubusercontent.com/urunc-dev/urunc/main/deployment/urunc-deploy/urunc-cleanup/base/urunc-cleanup.yaml
+kubectl delete -f https://raw.githubusercontent.com/urunc-dev/urunc/refs/heads/main/deployment/urunc-deploy/runtimeclasses/runtimeclass.yaml
+kubectl delete -f https://raw.githubusercontent.com/urunc-dev/urunc/main/deployment/urunc-deploy/urunc-rbac/urunc-rbac.yaml
 ```
 
 Now, we can create new `urunc` deployments using the [instruction provided in manual installation](#create-a-test-deployment).

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/nubificus/urunc
+module github.com/urunc-dev/urunc
 
 go 1.23.0
 
@@ -13,6 +13,7 @@ require (
 	github.com/jackpal/gateway v1.0.16
 	github.com/moby/sys/mount v0.3.4
 	github.com/nubificus/hedge_cli v0.0.3
+	github.com/nubificus/urunc v0.6.0
 	github.com/opencontainers/runc v1.2.6
 	github.com/opencontainers/runtime-spec v1.2.1
 	github.com/prometheus-community/pro-bing v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -143,6 +143,8 @@ github.com/mrunalp/fileutils v0.5.1 h1:F+S7ZlNKnrwHfSwdlgNSkKo67ReVf8o9fel6C3dkm
 github.com/mrunalp/fileutils v0.5.1/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=
 github.com/nubificus/hedge_cli v0.0.3 h1:psu0tXb9XbzREp1S6AW4VJytbgdKP7tZ+HOXcz4W8Xk=
 github.com/nubificus/hedge_cli v0.0.3/go.mod h1:YtvRtb7bUPF+Jd+np3gFoGs12Z+BZ2LWDnhsDvuh6ZA=
+github.com/nubificus/urunc v0.6.0 h1:mCou1AJHzOHDHgNm3U+L9R+1GJ8cEeGNC4RxMR/9shs=
+github.com/nubificus/urunc v0.6.0/go.mod h1:f+B/TBjxnbhEt0YGjCen0R6P6NMrIwJ4r0yHCT8+3pk=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	DefaultInterface = "eth0" // FIXME: Discover the veth endpoint name instead of using default "eth0". See: https://github.com/nubificus/urunc/issues/14
+	DefaultInterface = "eth0" // FIXME: Discover the veth endpoint name instead of using default "eth0". See: https://github.com/urunc-dev/urunc/issues/14
 	DefaultTap       = "tapX_urunc"
 )
 

--- a/pkg/network/network_dynamic.go
+++ b/pkg/network/network_dynamic.go
@@ -19,7 +19,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/nubificus/urunc/internal/constants"
+	"github.com/urunc-dev/urunc/internal/constants"
 	"github.com/vishvananda/netlink"
 )
 
@@ -34,7 +34,7 @@ type DynamicNetwork struct {
 //
 // FIXME: CUrrently only one tap device per netns can provide functional networking. We need to find a proper way to handle networking
 // for multiple unikernels in the same pod/network namespace.
-// See: https://github.com/nubificus/urunc/issues/13
+// See: https://github.com/urunc-dev/urunc/issues/13
 func (n DynamicNetwork) NetworkSetup(uid uint32, gid uint32) (*UnikernelNetworkInfo, error) {
 	tapIndex, err := getTapIndex()
 	if err != nil {

--- a/pkg/network/network_static.go
+++ b/pkg/network/network_static.go
@@ -21,7 +21,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/nubificus/urunc/internal/constants"
+	"github.com/urunc-dev/urunc/internal/constants"
 	"github.com/vishvananda/netlink"
 )
 

--- a/pkg/unikontainers/config.go
+++ b/pkg/unikontainers/config.go
@@ -63,7 +63,7 @@ type UnikernelConfig struct {
 // GetUnikernelConfig tries to get the Unikernel config from the bundle annotations.
 // If that fails, it gets the Unikernel config from the urunc.json file inside the rootfs.
 // FIXME: custom annotations are unreachable, we need to investigate why to skip adding the urunc.json file
-// For more details, see: https://github.com/nubificus/urunc/issues/12
+// For more details, see: https://github.com/urunc-dev/urunc/issues/12
 func GetUnikernelConfig(bundleDir string, spec *specs.Spec) (*UnikernelConfig, error) {
 	conf, err := getConfigFromSpec(spec)
 	if err == nil {

--- a/pkg/unikontainers/hypervisors/firecracker.go
+++ b/pkg/unikontainers/hypervisors/firecracker.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/nubificus/urunc/pkg/unikontainers/unikernels"
+	"github.com/urunc-dev/urunc/pkg/unikontainers/unikernels"
 )
 
 const (

--- a/pkg/unikontainers/hypervisors/hedge.go
+++ b/pkg/unikontainers/hypervisors/hedge.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	hedge "github.com/nubificus/hedge_cli/hedge_api"
-	"github.com/nubificus/urunc/pkg/unikontainers/unikernels"
+	"github.com/urunc-dev/urunc/pkg/unikontainers/unikernels"
 )
 
 const (

--- a/pkg/unikontainers/hypervisors/hvt.go
+++ b/pkg/unikontainers/hypervisors/hvt.go
@@ -20,7 +20,7 @@ import (
 	"syscall"
 
 	seccomp "github.com/elastic/go-seccomp-bpf"
-	"github.com/nubificus/urunc/pkg/unikontainers/unikernels"
+	"github.com/urunc-dev/urunc/pkg/unikontainers/unikernels"
 )
 
 const (

--- a/pkg/unikontainers/hypervisors/qemu.go
+++ b/pkg/unikontainers/hypervisors/qemu.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/nubificus/urunc/pkg/unikontainers/unikernels"
+	"github.com/urunc-dev/urunc/pkg/unikontainers/unikernels"
 )
 
 const (

--- a/pkg/unikontainers/hypervisors/spt.go
+++ b/pkg/unikontainers/hypervisors/spt.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/nubificus/urunc/pkg/unikontainers/unikernels"
+	"github.com/urunc-dev/urunc/pkg/unikontainers/unikernels"
 )
 
 const (

--- a/pkg/unikontainers/hypervisors/vmm.go
+++ b/pkg/unikontainers/hypervisors/vmm.go
@@ -19,8 +19,8 @@ import (
 	"fmt"
 	"os/exec"
 
-	"github.com/nubificus/urunc/pkg/unikontainers/unikernels"
 	"github.com/sirupsen/logrus"
+	"github.com/urunc-dev/urunc/pkg/unikontainers/unikernels"
 )
 
 const DefaultMemory uint64 = 256 // The default memory for every hypervisor: 256 MB

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -29,16 +29,16 @@ import (
 	"sync"
 	"syscall"
 
-	"github.com/nubificus/urunc/pkg/network"
-	"github.com/nubificus/urunc/pkg/unikontainers/hypervisors"
-	"github.com/nubificus/urunc/pkg/unikontainers/unikernels"
+	"github.com/urunc-dev/urunc/pkg/network"
+	"github.com/urunc-dev/urunc/pkg/unikontainers/hypervisors"
+	"github.com/urunc-dev/urunc/pkg/unikontainers/unikernels"
 	"github.com/vishvananda/netlink/nl"
 	"golang.org/x/sys/unix"
 
-	"github.com/nubificus/urunc/internal/constants"
-	m "github.com/nubificus/urunc/internal/metrics"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
+	"github.com/urunc-dev/urunc/internal/constants"
+	m "github.com/urunc-dev/urunc/internal/metrics"
 )
 
 const (

--- a/pkg/unikontainers/utils.go
+++ b/pkg/unikontainers/utils.go
@@ -24,8 +24,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/nubificus/urunc/internal/constants"
 	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/urunc-dev/urunc/internal/constants"
 )
 
 const (

--- a/tests/benchmarks/benchmark_test.go
+++ b/tests/benchmarks/benchmark_test.go
@@ -18,8 +18,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/nubificus/urunc/internal/constants"
-	m "github.com/nubificus/urunc/internal/metrics"
+	"github.com/urunc-dev/urunc/internal/constants"
+	m "github.com/urunc-dev/urunc/internal/metrics"
 )
 
 func BenchmarkZerologWriter(b *testing.B) {


### PR DESCRIPTION
Replace the references to the previous repository of urunc (github.com/nubificus/urunc) with the new and correct url github.com/urunc-dev/urunc.

This change might be necessary to trigger the replacement of the old repository with the new one in pkg.go.dev too.