### PR TITLE
ci: Add arm64 tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,6 @@ jobs:
       ref: ${{ inputs.ref }}
     secrets: inherit
 
-  #FIXME: run for arm64
   vm_test:
     if: ${{ inputs.skip-build != 'yes' }}
     needs: [build,unit_test]
@@ -62,6 +61,7 @@ jobs:
     uses: ./.github/workflows/vm_test.yml
     with:
       ref: ${{ inputs.ref }}
+      runner-archs: '["amd64", "arm64"]'
       runc_version: '1.3.0'
       containerd_version: '2.1.3'
       cni_version: '1.7.1'

--- a/.github/workflows/ci_on_push.yml
+++ b/.github/workflows/ci_on_push.yml
@@ -3,7 +3,7 @@ name: urunc CI
 on:
   pull_request:
     branches: ["main"]
-    types: [open,synchronize,reopened,labeled]
+    types: [opened,synchronize,reopened,labeled]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/vm_test.yml
+++ b/.github/workflows/vm_test.yml
@@ -44,17 +44,22 @@ on:
 jobs:
   prepare:
     name: VM test
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        arch: ["${{ fromJSON(inputs.runner-archs) }}"]
+        arch: ${{ fromJSON(inputs.runner-archs) }}
         test: ["test_ctr","test_nerdctl","test_crictl","test_docker"]
-      fail-fast: false
+        include:
+          - arch: amd64
+            runner: ubuntu-22.04
+          - arch: arm64
+            runner: ubuntu-22.04-arm
+         
     steps:
     - uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
-    - uses: actions/setup-go@v4
+    - uses: actions/setup-go@v5
       with:
         go-version: '1.24.1'
         cache: false
@@ -126,7 +131,6 @@ jobs:
         EOT
         sudo systemctl restart containerd
 
-
     - name: Install CNI plugins
       run: |
         wget -q https://github.com/containernetworking/plugins/releases/download/v${{ inputs.cni_version }}/cni-plugins-linux-$(dpkg --print-architecture)-v${{ inputs.cni_version }}.tgz
@@ -142,9 +146,9 @@ jobs:
 
     - name: Install crictl
       run: |
-        wget https://github.com/kubernetes-sigs/cri-tools/releases/download/${{ inputs.crictl_version }}/crictl-${{ inputs.crictl_version }}-linux-amd64.tar.gz
-        sudo tar zxvf crictl-${{ inputs.crictl_version }}-linux-amd64.tar.gz -C /usr/local/bin
-        rm -f crictl-${{ inputs.crictl_version }}-linux-amd64.tar.gz
+        wget https://github.com/kubernetes-sigs/cri-tools/releases/download/${{ inputs.crictl_version }}/crictl-${{ inputs.crictl_version }}-linux-${{matrix.arch}}.tar.gz
+        sudo tar zxvf crictl-${{ inputs.crictl_version }}-linux-${{matrix.arch}}.tar.gz -C /usr/local/bin
+        rm -f crictl-${{ inputs.crictl_version }}-linux-${{matrix.arch}}.tar.gz
         sudo tee -a /etc/crictl.yaml > /dev/null <<'EOT'
         runtime-endpoint: unix:///run/containerd/containerd.sock
         image-endpoint: unix:///run/containerd/containerd.sock
@@ -189,8 +193,9 @@ jobs:
         sudo mv urunc_static_${{ matrix.arch }} /usr/local/bin/urunc
         sudo mv containerd-shim-urunc-v2_static_${{ matrix.arch }} /usr/local/bin/containerd-shim-urunc-v2
         urunc --version
-
+  
     - name: Add runner user to KVM group
+      if: ${{ matrix.arch == 'amd64' }}
       id: kvm-setup
       run: |
         echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
@@ -198,9 +203,17 @@ jobs:
         sudo udevadm trigger --name-match=kvm
         sudo usermod -a -G kvm $USER
 
-
     - name: Run ${{ matrix.test }}
       id: test
       if: ${{ !cancelled() }}
       run: |
-        sudo make ${{ matrix.test }}
+        # Set up Go environment properly
+        export GOROOT=$(go env GOROOT)
+        export PATH="$GOROOT/bin:$PATH"
+        go version
+        go env GOROOT
+        if [ "${{ matrix.arch }}" = "arm64" ]; then
+          sudo -E env "PATH=$PATH" "GOROOT=$GOROOT" make ${{ matrix.test }}_Spt
+        else
+          sudo -E env "PATH=$PATH" "GOROOT=$GOROOT" make ${{ matrix.test }}
+        fi


### PR DESCRIPTION
Add end to end tests for arm64 architecture.
Currently, only solo5-spt tests are supported for arm64 runners.