### PR TITLE
docs: fix nginx deployment example in k8s tutorial

### DIFF
--- a/docs/tutorials/How-to-urunc-on-k8s.md
+++ b/docs/tutorials/How-to-urunc-on-k8s.md
@@ -62,8 +62,6 @@ spec:
       - image: harbor.nbfc.io/nubificus/urunc/nginx-firecracker-unikraft-initrd:latest
         imagePullPolicy: Always
         name: nginx-urunc
-        command: ["sleep"]
-        args: ["infinity"]
         ports:
         - containerPort: 80
           protocol: TCP


### PR DESCRIPTION
## Summary

This PR fixes the nginx deployment example in the Kubernetes tutorial that was causing deployment failures.

## Problem

The current nginx deployment example in `docs/tutorials/How-to-urunc-on-k8s.md` includes:

```yaml
command: ["sleep"]
args: ["infinity"]
```

This causes the following error when deployed:
```
nginx: invalid option: "sleep"
```

## Solution

Removed the problematic `command` and `args` specifications from the nginx-urunc deployment example. The nginx unikernel should run its default nginx process without custom command overrides.

## Testing

- ✅ Verified the deployment YAML syntax is correct
- ✅ Confirmed the nginx unikernel image works properly without command overrides
- ✅ Checked that the fix resolves the reported error in issue #237

Fixes #237

🤖 Generated with [Claude Code](https://claude.ai/code)