### PR TITLE
Copy the files defined in the mount list of the container inside the block rootfs of the VM

### DIFF
--- a/.github/linters/urunc-dict.txt
+++ b/.github/linters/urunc-dict.txt
@@ -342,3 +342,4 @@ yourdockerhubid
 zerolog
 overlayfs
 macaddr
+copyMountfiles

--- a/pkg/unikontainers/rootfs.go
+++ b/pkg/unikontainers/rootfs.go
@@ -20,6 +20,7 @@
 package unikontainers
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -28,6 +29,8 @@ import (
 
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
+
+var ErrCopyDir = errors.New("can not copy a directory")
 
 type mountFlagStruct struct {
 	clear bool
@@ -350,7 +353,6 @@ func fileFromHost(monRootfs string, hostPath string, target string, mFlags int, 
 	dstPath := filepath.Join(monRootfs, target)
 
 	if (mode & unix.S_IFMT) != unix.S_IFDIR {
-		uniklog.Debugf("%s is a file", hostPath)
 		dstDir := filepath.Dir(dstPath)
 		if withCopy {
 			err = copyFile(hostPath, dstPath)
@@ -364,6 +366,9 @@ func fileFromHost(monRootfs string, hostPath string, target string, mFlags int, 
 			}
 		}
 	} else {
+		if withCopy {
+			return ErrCopyDir
+		}
 		err = bindMountFile(hostPath, dstPath, "", 0, mFlags, true)
 		if err != nil {
 			return fmt.Errorf("failed to bind mount file %s: %w", hostPath, err)

--- a/pkg/unikontainers/rootfs.go
+++ b/pkg/unikontainers/rootfs.go
@@ -350,9 +350,10 @@ func fileFromHost(monRootfs string, hostPath string, target string, mFlags int, 
 	dstPath := filepath.Join(monRootfs, target)
 
 	if (mode & unix.S_IFMT) != unix.S_IFDIR {
+		uniklog.Debugf("%s is a file", hostPath)
 		dstDir := filepath.Dir(dstPath)
 		if withCopy {
-			err = copyFile(hostPath, dstDir)
+			err = copyFile(hostPath, dstPath)
 			if err != nil {
 				return fmt.Errorf("failed to copy file %s: %w", hostPath, err)
 			}

--- a/pkg/unikontainers/storage.go
+++ b/pkg/unikontainers/storage.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/moby/sys/mount"
+	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 )
 
@@ -127,6 +128,20 @@ func prepareDMAsBlock(rootfsPath string, newRootfsPath string, unikernel string,
 	err = mount.Unmount(rootfsPath)
 	if err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func copyMountfiles(targetPath string, mounts []specs.Mount) error {
+	for _, m := range mounts {
+		if m.Type != "bind" {
+			continue
+		}
+		err := fileFromHost(targetPath, m.Source, m.Destination, 0, true)
+		if (err != nil) && !errors.Is(err, ErrCopyDir) {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -331,6 +331,10 @@ func (u *Unikontainer) Exec() error {
 				return err
 			}
 			if unikernel.SupportsFS(rootFsDevice.FsType) {
+				err = copyMountfiles(rootFsDevice.Path, u.Spec.Mounts)
+				if err != nil {
+					return err
+				}
 				err = prepareDMAsBlock(rootFsDevice.Path, monRootfs, unikernelPath, uruncJSONFilename, initrdPath)
 				if err != nil {
 					return err

--- a/pkg/unikontainers/utils.go
+++ b/pkg/unikontainers/utils.go
@@ -63,35 +63,39 @@ func getInitPid(filePath string) (float64, error) {
 
 // copy sourceFile to targetDir
 // creates targetDir and all necessary parent directories
-func copyFile(sourceFile string, targetDir string) error {
+func copyFile(sourceFile string, targetPath string) error {
+	targetDir := filepath.Dir(targetPath)
 	source, err := os.Open(sourceFile)
 	if err != nil {
 		return err
 	}
 	defer source.Close()
+
 	err = os.MkdirAll(targetDir, 0755)
 	if err != nil {
 		return err
 	}
 
-	_, filename := filepath.Split(sourceFile)
-	targetPath := filepath.Join(targetDir, filename)
 	target, err := os.Create(targetPath)
 	if err != nil {
 		return err
 	}
 	defer target.Close()
+
 	_, err = io.Copy(target, source)
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
 // move sourceFile to targetDir
 // creates targetDir and all necessary parent directories
 func moveFile(sourceFile string, targetDir string) error {
-	err := copyFile(sourceFile, targetDir)
+	_, filename := filepath.Split(sourceFile)
+	targetPath := filepath.Join(targetDir, filename)
+	err := copyFile(sourceFile, targetPath)
 	if err != nil {
 		return err
 	}

--- a/pkg/unikontainers/utils_test.go
+++ b/pkg/unikontainers/utils_test.go
@@ -136,14 +136,15 @@ func TestCopyFile(t *testing.T) {
 
 		// Create a temporary target directory
 		targetDir := t.TempDir()
+		_, filename := filepath.Split(srcFile.Name())
+		copiedFilePath := filepath.Join(targetDir, filename)
+
 
 		// Call the function
-		err = copyFile(srcFile.Name(), targetDir)
+		err = copyFile(srcFile.Name(), copiedFilePath)
 		assert.NoError(t, err, "Expected no error in copying file")
 
 		// Verify the file was copied
-		_, filename := filepath.Split(srcFile.Name())
-		copiedFilePath := filepath.Join(targetDir, filename)
 		copiedContent, err := os.ReadFile(copiedFilePath)
 		assert.NoError(t, err, "Expected no error in reading copied file")
 		assert.Equal(t, content, string(copiedContent), "Expected copied content to match original")
@@ -202,7 +203,7 @@ func TestCopyFile(t *testing.T) {
 		targetFile.Close()
 
 		// Call the function
-		err = copyFile(srcFile.Name(), targetDir)
+		err = copyFile(srcFile.Name(), targetFilePath)
 		assert.Error(t, err, "Expected an error for read-only target file")
 	})
 }


### PR DESCRIPTION
Since we are not able to handle the mount list when we have a block-based rootfs for the guest, at least copy all the files from the mount list of the container inside the rootfs of the guest. This is not very nice, yet it is the only possible way to pass some files defined in the mount list of the container inside the VM.

Furthermore, change copyFIle and make it more generic to allow defining the full path of the new file and not just its directory.