### PR TITLE
fix(ci): Use our fork for building solo5

### DIFF
--- a/.github/workflows/vm_test.yml
+++ b/.github/workflows/vm_test.yml
@@ -165,7 +165,8 @@ jobs:
 
     - name: Install solo5
       run: |
-        git clone -b ${{ inputs.solo5_version }} https://github.com/Solo5/solo5.git
+        ## TODO: Revert when PR gets merged or Solo5 fixes aarch64 building
+        git clone -b fix_hvt_build_aarch64 https://github.com/nubificus/solo5.git
         cd solo5
         ./configure.sh && make -j$(nproc)
         sudo cp tenders/hvt/solo5-hvt /usr/local/bin


### PR DESCRIPTION
In newer versions of gcc in aarch64 Solo5 fails to build successfully. A small patch is required and we have submitted a PR. However, until the issue gets resolved, use our fork with the patch included.

This is submitted as separate PR in order to revert it easily when the issue gets resolved.