### PR TITLE
feat(hypervisors): add Cloud Hypervisor VMM support

### DIFF
--- a/pkg/unikontainers/hypervisors/cloud_hypervisor.go
+++ b/pkg/unikontainers/hypervisors/cloud_hypervisor.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2023-2025, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hypervisors
+
+import (
+	"fmt"
+	"path/filepath"
+	"syscall"
+
+	"github.com/urunc-dev/urunc/pkg/unikontainers/unikernels"
+)
+
+const (
+	CloudHypervisorVmm    VmmType = "cloud-hypervisor"
+	CloudHypervisorBinary string  = "cloud-hypervisor"
+)
+
+type CloudHypervisor struct {
+	binaryPath string
+	binary     string
+}
+
+func (ch *CloudHypervisor) Stop(_ string) error {
+	return nil
+}
+
+func (ch *CloudHypervisor) Ok() error {
+	return nil
+}
+
+func (ch *CloudHypervisor) UsesKVM() bool {
+	return true
+}
+
+func (ch *CloudHypervisor) SupportsSharedfs() bool {
+	return true
+}
+
+func (ch *CloudHypervisor) Path() string {
+	return ch.binaryPath
+}
+
+func (ch *CloudHypervisor) Execve(args ExecArgs, unikernel unikernels.Unikernel) error {
+	apiSocketPath := filepath.Join("/temp", args.Container+"-ch.sock")
+	cmd := []string{
+		ch.Path(),
+		"--api-socket",
+		apiSocketPath,
+	}
+
+	cmd = append(cmd, "--cpus", "boot=1")
+
+	// Add memory
+	mem := DefaultMemory
+	if args.MemSizeB != 0 {
+		mem = bytesToMiB(args.MemSizeB)
+		if mem == 0 {
+			mem = DefaultMemory
+		}
+	}
+	memStr := fmt.Sprintf("size=%dM", mem)
+	cmd = append(cmd, "--memory", memStr)
+
+	cmd = append(cmd, "--kernel", args.UnikernelPath)
+
+	cmd = append(cmd, "--cmdline", args.Command)
+
+	if args.TapDevice != "" {
+		netStr := fmt.Sprintf("tap=%s", args.TapDevice)
+		if args.GuestMAC != "" {
+			netStr += fmt.Sprintf(",mac=%s", args.GuestMAC)
+		}
+		cmd = append(cmd, "--net", netStr)
+	}
+
+	if args.BlockDevice != "" {
+		cmd = append(cmd, "--disk", fmt.Sprintf("path=%s", args.BlockDevice))
+	}
+
+	vmmLog.WithField("Cloud-hypervisor command", cmd).Debug("Ready to execve Cloud-hypervisor")
+	return syscall.Exec(ch.Path(), cmd, args.Environment) //nolint: gosec
+
+}

--- a/pkg/unikontainers/hypervisors/vmm.go
+++ b/pkg/unikontainers/hypervisors/vmm.go
@@ -87,6 +87,16 @@ func NewVMM(vmmType VmmType) (vmm VMM, err error) {
 			return nil, ErrVMMNotInstalled
 		}
 		return &Firecracker{binary: FirecrackerBinary, binaryPath: vmmPath}, nil
+	case CloudHypervisorVmm:
+		chPath, err := exec.LookPath(CloudHypervisorBinary)
+		if err != nil {
+			return nil, fmt.Errorf("failed to find cloud-hypervisor binary: %w", err)
+		}
+		vmm = &CloudHypervisor{
+			binaryPath: chPath,
+			binary:     CloudHypervisorBinary,
+		}
+		return vmm, nil
 	case HedgeVmm:
 		hedge := Hedge{}
 		err := hedge.Ok()
@@ -94,6 +104,7 @@ func NewVMM(vmmType VmmType) (vmm VMM, err error) {
 			return nil, ErrVMMNotInstalled
 		}
 		return &hedge, nil
+
 	default:
 		return nil, fmt.Errorf("vmm \"%s\" is not supported", vmmType)
 	}


### PR DESCRIPTION
This commit introduces support for the Cloud Hypervisor VMM, expanding the range of lightweight, cloud-native hypervisors that urunc can utilize for running unikernels.

Cloud Hypervisor is a modern VMM from the rust-vmm project, similar in scope to Firecracker. This implementation follows the established pattern for adding new VMMs to urunc:
- A new `CloudHypervisor` struct implements the `VMM` interface.
- Unlike Firecracker, which is configured via a JSON file, this implementation constructs the necessary command-line arguments to launch the `cloud-hypervisor` binary.
- The new VMM is registered in the central factory in `hypervisor.go`, making it available to the runtime.