### PR TITLE
specific tag for deploy container image as per branch

### DIFF
--- a/.github/contributors.yaml
+++ b/.github/contributors.yaml
@@ -74,3 +74,7 @@ users:
   0xull:
     name: Ikeh Akinyemi
     email: mrikehchukwuka@gmail.com
+  prashantpandeygit:
+    name: Prashant Pandey
+    email: prashantpandey.acad@gmail.com
+

--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -211,6 +211,13 @@ jobs:
           VAR=`docker manifest push ${{ env.REGISTRY }}/${{ github.repository }}/urunc-deploy:${{ env.TAG }} | tail -1`
           echo "manifest_sha=$VAR" >> "$GITHUB_OUTPUT"
 
+          # Also tag with commit hash on main branch
+          if [[ "${{ github.ref }}" == "refs/heads/main" && "${{ inputs.version-tag }}" != "true" ]]; then
+            docker buildx imagetools create -t ${{ env.REGISTRY }}/${{ github.repository }}/urunc-deploy:${{ env.SHA_SHORT }} \
+              ${{ env.REGISTRY }}/${{ github.repository }}/urunc-deploy:${{ env.TAG }}
+          fi
+
+
       - name: Install cosign
         uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # main
 

--- a/docs/tutorials/How-to-urunc-on-k8s.md
+++ b/docs/tutorials/How-to-urunc-on-k8s.md
@@ -97,6 +97,7 @@ kubectl get pods
 and artifacts required to run `urunc`, as well as reference DaemonSets, which can
 be utilized to install `urunc` runtime on a running Kubernetes cluster.
 
+
 ### urunc-deploy in k3s
 
 To install in a k3s cluster, first we need to create the RBAC:
@@ -105,10 +106,21 @@ To install in a k3s cluster, first we need to create the RBAC:
 kubectl apply -f https://raw.githubusercontent.com/urunc-dev/urunc/main/deployment/urunc-deploy/urunc-rbac/urunc-rbac.yaml
 ```
 
-Then, we create the `urunc-deploy` Daemonset, followed by the k3s customization:
+Then, we create the `urunc-deploy` Daemonset, followed by the k3s customization.
+
+The below command will install the latest version from the main branch. If you want to deploy a specific version, follow the instructions below this command.
 
 ```bash
 kubectl apply -k https://github.com/urunc-dev/urunc//deployment/urunc-deploy/urunc-deploy/overlays/k3s?ref=main
+```
+
+If you want to deploy a specific version (e.g., `abc1234`), download the required files locally, set the version, update the image tag using `sed` and apply:
+
+```bash
+VERSION=abc1234
+git clone https://github.com/urunc-dev/urunc.git && cd urunc
+sed -i "s|ghcr.io/urunc-dev/urunc/urunc-deploy:latest|ghcr.io/urunc-dev/urunc/urunc-deploy:${VERSION}|" deployment/urunc-deploy/urunc-deploy/base/urunc-deploy.yaml
+kubectl apply -k deployment/urunc-deploy/urunc-deploy/overlays/k3s
 ```
 
 Finally, we need to create the appropriate k8s runtime class:


### PR DESCRIPTION
Fixes #283 

Enabled branch specific container image tags for `urunc-deploy`, removed the hardcoded latest tag, with this it is easy to deploy and test with versions.

## Changes

added `images` field so that override can be done on the tag,
script to get tag from the git state. (also, the tag remains `:latest` as default, making backward compatible)


## Tests

getting the tag:

<img width="520" height="64" alt="image" src="https://github.com/user-attachments/assets/cee9e792-bb1a-472c-b1a4-95b3cbcf579f" />

kustomize build on `urunc-deploy` (same for cleanup):

<img width="869" height="72" alt="image" src="https://github.com/user-attachments/assets/8305a102-d260-4f67-b7b6-afdb2b966e10" />

set the tag:

<img width="566" height="148" alt="image" src="https://github.com/user-attachments/assets/28ef4e3b-13bd-44a7-843e-870c9c1362a4" />

verifying through build:
<img width="893" height="86" alt="image" src="https://github.com/user-attachments/assets/8418afd0-b9ff-4181-aba6-a5adb52763be" />



