### PR TITLE
test: add unit tests for resolveAgainstBase

### DIFF
--- a/pkg/unikontainers/resolve_test.go
+++ b/pkg/unikontainers/resolve_test.go
@@ -1,0 +1,27 @@
+package unikontainers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveAgainstBase(t *testing.T) {
+	t.Run("absolute path is returned as is", func(t *testing.T) {
+		result, err := resolveAgainstBase("/some/base", "/absolute/path")
+		assert.NoError(t, err)
+		assert.Equal(t, "/absolute/path", result)
+	})
+
+	t.Run("relative path is joined with absolute base", func(t *testing.T) {
+		result, err := resolveAgainstBase("/home/shreya", "documents/file.txt")
+		assert.NoError(t, err)
+		assert.Equal(t, "/home/shreya/documents/file.txt", result)
+	})
+
+	t.Run("relative path with relative base", func(t *testing.T) {
+		result, err := resolveAgainstBase("mybase", "myfile.txt")
+		assert.NoError(t, err)
+		assert.Contains(t, result, "mybase/myfile.txt")
+	})
+}


### PR DESCRIPTION
## Description
Adds unit tests for the `resolveAgainstBase` function in `pkg/unikontainers/utils.go`.
This function had no test coverage. The tests cover:
- absolute path returned unchanged
- relative path joined with absolute base
- relative path joined with relative base

### Related issues
- Fixes #96

### How was this tested?
Ran the unit tests locally using:
`go test ./pkg/unikontainers/... -v -run TestResolveAgainstBase`
All 3 test cases passed.

### LLM usage
Claude Sonnet 4.6 was used to assist in understanding the codebase and test structure.
All generated code was reviewed and understood before submission.

### Checklist
- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).