### PR TITLE
test(hypervisors): add unit tests for HVT

### DIFF
--- a/pkg/unikontainers/hypervisors/hvt_test.go
+++ b/pkg/unikontainers/hypervisors/hvt_test.go
@@ -22,39 +22,25 @@ import (
 	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
 )
 
+type mockUnikernel struct {
+	netCli   string
+	blockCli []types.MonitorBlockArgs
+	monCli   types.MonitorCliArgs
+}
+
+func (m *mockUnikernel) Init(_ types.UnikernelParams) error        { return nil }
+func (m *mockUnikernel) CommandString() (string, error)            { return "", nil }
+func (m *mockUnikernel) SupportsBlock() bool                       { return false }
+func (m *mockUnikernel) SupportsFS(_ string) bool                  { return false }
+func (m *mockUnikernel) MonitorNetCli(_, _ string) string          { return m.netCli }
+func (m *mockUnikernel) MonitorBlockCli() []types.MonitorBlockArgs { return m.blockCli }
+func (m *mockUnikernel) MonitorCli() types.MonitorCliArgs          { return m.monCli }
+
 func newTestHVT() *HVT {
 	return &HVT{
 		binary:     HvtBinary,
 		binaryPath: "/usr/bin/solo5-hvt",
 	}
-}
-
-func TestHVTUsesKVM(t *testing.T) {
-	t.Parallel()
-	assert.True(t, newTestHVT().UsesKVM())
-}
-
-func TestHVTSupportsSharedfs(t *testing.T) {
-	t.Parallel()
-	h := newTestHVT()
-	assert.False(t, h.SupportsSharedfs("virtio"))
-	assert.False(t, h.SupportsSharedfs("9p"))
-	assert.False(t, h.SupportsSharedfs(""))
-}
-
-func TestHVTPath(t *testing.T) {
-	t.Parallel()
-	assert.Equal(t, "/usr/bin/solo5-hvt", newTestHVT().Path())
-}
-
-func TestHVTOkBinaryNotFound(t *testing.T) {
-	t.Parallel()
-	assert.ErrorIs(t, newTestHVT().Ok(), ErrVMMNotInstalled)
-}
-
-func TestHVTPreExecNoSeccomp(t *testing.T) {
-	t.Parallel()
-	assert.NoError(t, newTestHVT().PreExec(types.ExecArgs{Seccomp: false}))
 }
 
 func TestHVTBuildExecCmd(t *testing.T) {
@@ -67,14 +53,6 @@ func TestHVTBuildExecCmd(t *testing.T) {
 		wantContain []string
 		wantAbsent  []string
 	}{
-		{
-			name: "binary path is first element",
-			args: types.ExecArgs{
-				UnikernelPath: "/unikernel.bin",
-			},
-			unikernel:   &mockUnikernel{},
-			wantContain: []string{"/usr/bin/solo5-hvt"},
-		},
 		{
 			name: "default memory when MemSizeB is zero",
 			args: types.ExecArgs{
@@ -134,15 +112,6 @@ func TestHVTBuildExecCmd(t *testing.T) {
 			},
 			wantContain: []string{"--dumpcore"},
 		},
-		{
-			name: "unikernel path and command are last",
-			args: types.ExecArgs{
-				UnikernelPath: "/unikernel.bin",
-				Command:       "console=ttyS0",
-			},
-			unikernel:   &mockUnikernel{},
-			wantContain: []string{"/unikernel.bin", "console=ttyS0"},
-		},
 	}
 
 	for _, tc := range tests {
@@ -162,4 +131,17 @@ func TestHVTBuildExecCmd(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHVTBuildExecCmdOrdering(t *testing.T) {
+	t.Parallel()
+	h := newTestHVT()
+	got, err := h.BuildExecCmd(types.ExecArgs{
+		UnikernelPath: "/unikernel.bin",
+		Command:       "console=ttyS0",
+	}, &mockUnikernel{})
+	assert.NoError(t, err)
+	assert.Equal(t, "/usr/bin/solo5-hvt", got[0])
+	assert.Equal(t, "/unikernel.bin", got[len(got)-2])
+	assert.Equal(t, "console=ttyS0", got[len(got)-1])
 }

--- a/pkg/unikontainers/hypervisors/hvt_test.go
+++ b/pkg/unikontainers/hypervisors/hvt_test.go
@@ -1,0 +1,165 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hypervisors
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
+)
+
+func newTestHVT() *HVT {
+	return &HVT{
+		binary:     HvtBinary,
+		binaryPath: "/usr/bin/solo5-hvt",
+	}
+}
+
+func TestHVTUsesKVM(t *testing.T) {
+	t.Parallel()
+	assert.True(t, newTestHVT().UsesKVM())
+}
+
+func TestHVTSupportsSharedfs(t *testing.T) {
+	t.Parallel()
+	h := newTestHVT()
+	assert.False(t, h.SupportsSharedfs("virtio"))
+	assert.False(t, h.SupportsSharedfs("9p"))
+	assert.False(t, h.SupportsSharedfs(""))
+}
+
+func TestHVTPath(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "/usr/bin/solo5-hvt", newTestHVT().Path())
+}
+
+func TestHVTOkBinaryNotFound(t *testing.T) {
+	t.Parallel()
+	assert.ErrorIs(t, newTestHVT().Ok(), ErrVMMNotInstalled)
+}
+
+func TestHVTPreExecNoSeccomp(t *testing.T) {
+	t.Parallel()
+	assert.NoError(t, newTestHVT().PreExec(types.ExecArgs{Seccomp: false}))
+}
+
+func TestHVTBuildExecCmd(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		args        types.ExecArgs
+		unikernel   *mockUnikernel
+		wantContain []string
+		wantAbsent  []string
+	}{
+		{
+			name: "binary path is first element",
+			args: types.ExecArgs{
+				UnikernelPath: "/unikernel.bin",
+			},
+			unikernel:   &mockUnikernel{},
+			wantContain: []string{"/usr/bin/solo5-hvt"},
+		},
+		{
+			name: "default memory when MemSizeB is zero",
+			args: types.ExecArgs{
+				UnikernelPath: "/unikernel.bin",
+			},
+			unikernel:   &mockUnikernel{},
+			wantContain: []string{"--mem=256"},
+		},
+		{
+			name: "memory set from MemSizeB",
+			args: types.ExecArgs{
+				UnikernelPath: "/unikernel.bin",
+				MemSizeB:      512 * 1000 * 1000,
+			},
+			unikernel:   &mockUnikernel{},
+			wantContain: []string{"--mem=512"},
+		},
+		{
+			name: "net cli from unikernel when TapDev set",
+			args: types.ExecArgs{
+				UnikernelPath: "/unikernel.bin",
+				Net: types.NetDevParams{
+					TapDev: "tap0",
+					MAC:    "aa:bb:cc:dd:ee:ff",
+				},
+			},
+			unikernel:   &mockUnikernel{netCli: "--net:service0=tap0"},
+			wantContain: []string{"--net:service0=tap0"},
+		},
+		{
+			name: "no net args when TapDev is empty",
+			args: types.ExecArgs{
+				UnikernelPath: "/unikernel.bin",
+			},
+			unikernel:  &mockUnikernel{},
+			wantAbsent: []string{"--net"},
+		},
+		{
+			name: "block device appended",
+			args: types.ExecArgs{
+				UnikernelPath: "/unikernel.bin",
+			},
+			unikernel: &mockUnikernel{
+				blockCli: []types.MonitorBlockArgs{
+					{ID: "storage0", Path: "/dev/vda"},
+				},
+			},
+			wantContain: []string{"--block:storage0=/dev/vda"},
+		},
+		{
+			name: "extra args from MonitorCli appended",
+			args: types.ExecArgs{
+				UnikernelPath: "/unikernel.bin",
+			},
+			unikernel: &mockUnikernel{
+				monCli: types.MonitorCliArgs{OtherArgs: "--dumpcore"},
+			},
+			wantContain: []string{"--dumpcore"},
+		},
+		{
+			name: "unikernel path and command are last",
+			args: types.ExecArgs{
+				UnikernelPath: "/unikernel.bin",
+				Command:       "console=ttyS0",
+			},
+			unikernel:   &mockUnikernel{},
+			wantContain: []string{"/unikernel.bin", "console=ttyS0"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			h := newTestHVT()
+			got, err := h.BuildExecCmd(tc.args, tc.unikernel)
+			assert.NoError(t, err)
+			assert.Equal(t, "/usr/bin/solo5-hvt", got[0])
+
+			joined := strings.Join(got, " ")
+			for _, want := range tc.wantContain {
+				assert.Contains(t, joined, want)
+			}
+			for _, absent := range tc.wantAbsent {
+				assert.NotContains(t, joined, absent)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Adds unit tests for the HVT VMM backend, covering BuildExecCmd and the interface methods (UsesKVM, SupportsSharedfs, Path, Ok, PreExec). Tests verify memory configuration, networking, block devices, extra monitor args and the binary not found error case.

### Related issues

- Part of #96

### How was this tested?

Ran unit tests locally:
```
go test ./pkg/unikontainers/hypervisors/ -v -run "TestHVT"
```
All 13 test cases passed. Full package tests also pass:
```
go test ./pkg/... ./internal/...
```
Linter passes locally (make lint, 0 issues).

### LLM usage

Claude Sonnet 4.6 was used to assist with writing the tests. All code was reviewed and tested locally before submission.

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
