### PR TITLE
Add WSL2 setup tutorial [Docs]

### DIFF
--- a/docs/tutorials/Running-urunc-on-wsl2.md
+++ b/docs/tutorials/Running-urunc-on-wsl2.md
@@ -1,0 +1,94 @@
+# Running `urunc` on WSL2
+
+In this tutorial, we describe how to set up and run `urunc` on
+**Windows Subsystem for Linux 2 (WSL2)**.
+
+## Prerequisites
+
+Before proceeding, make sure you have a working WSL2 instance with
+Ubuntu installed. You can follow the official
+[Microsoft WSL documentation](https://learn.microsoft.com/en-us/windows/wsl/install)
+to set this up.
+
+### Verify KVM support
+
+Some of `urunc` supported monitors require KVM for
+hardware-accelerated virtualization. On WSL2, KVM is available only if
+nested virtualization is enabled on your Windows host.
+
+Verify that `/dev/kvm` exists:
+```bash
+ls -la /dev/kvm
+```
+
+If the device is missing, enable nested virtualization by creating or
+editing the `.wslconfig` file at `%USERPROFILE%\.wslconfig` on your
+Windows host:
+```ini
+[wsl2]
+nestedVirtualization=true
+```
+
+Then restart WSL from PowerShell:
+```powershell
+wsl --shutdown
+```
+
+After restarting, verify KVM is available:
+```bash
+lsmod | grep kvm
+```
+
+You should see `kvm_intel` or `kvm_amd` in the output.
+
+## Install `urunc`
+
+Follow the standard [installation guide](../installation.md) to build
+and install `urunc` and the containerd shim.
+
+## Snapshotter configuration
+
+The default WSL2 kernel does not load the `dm_thin_pool` kernel module,
+which means the `devmapper` snapshotter will not work out of the box.
+
+Verify this by running:
+```bash
+lsmod | grep dm_thin
+```
+
+If the output is empty, you can use the `overlayfs` snapshotter instead,
+which works without any additional configuration on WSL2.
+
+When running containers, use the `--snapshotter overlayfs` flag:
+```bash
+sudo nerdctl run --snapshotter overlayfs --runtime io.containerd.urunc.v2 ...
+```
+
+## Using `nerdctl` or Docker
+
+You can use either `nerdctl` or Docker to run containers with `urunc`.
+An installation of Docker inside the WSL2 Ubuntu instance works fine.
+Alternatively, you can use standalone `nerdctl` with a manually
+configured containerd.
+
+To install `nerdctl`, follow the official
+[nerdctl documentation](https://github.com/containerd/nerdctl#install).
+
+## Running a unikernel
+
+Once everything is set up, you can run a unikernel container. For
+example, to run the Unikraft nginx image with QEMU:
+
+```bash
+sudo nerdctl run --rm --snapshotter overlayfs \
+  --runtime io.containerd.urunc.v2 \
+  harbor.nbfc.io/nubificus/urunc/nginx-qemu-unikraft:latest
+```
+
+To verify the unikernel is running, check its IP address from the
+`nerdctl` output and send a request:
+```bash
+curl http://<unikernel-ip>
+```
+
+You should see the default nginx welcome page.

--- a/docs/tutorials/Running-urunc-on-wsl2.md
+++ b/docs/tutorials/Running-urunc-on-wsl2.md
@@ -82,7 +82,7 @@ example, to run the Unikraft nginx image with QEMU:
 ```bash
 sudo nerdctl run --rm --snapshotter overlayfs \
   --runtime io.containerd.urunc.v2 \
-  harbor.nbfc.io/nubificus/urunc/nginx-qemu-unikraft:latest
+  harbor.nbfc.io/nubificus/urunc/nginx-qemu-unikraft-initrd:latest
 ```
 
 To verify the unikernel is running, check its IP address from the

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -8,3 +8,4 @@ In this section we include some end-to-end tutorials on deploying
 - [Running existing containers over Linux](../tutorials/existing-container-linux)
 - [Running vAccel-enabled Containers with `urunc`](../tutorials/Running-vaccel-with-urunc.md)
 - [Running `urunc` with kind](../tutorials/Running-urunc-with-kind)
+- [Running `urunc` on WSL2](../tutorials/Running-urunc-on-wsl2.md)


### PR DESCRIPTION
Add a tutorial describing how to set up and run urunc on WSL2, covering KVM verification, snapshotter configuration (overlayfs vs devmapper), and nerdctl usage.

Refs: #643

## Description

Add a new tutorial (`docs/tutorials/Running-urunc-on-wsl2.md`) that guides Windows/WSL2 users through running urunc on their environment. The tutorial covers:

- Verifying KVM availability and enabling nested virtualization
- Why `nerdctl` is recommended over Docker Desktop on WSL2
- Using the `overlayfs` snapshotter since WSL2 lacks the `dm_thin_pool` kernel module
- Running a sample unikernel container end-to-end

The tutorial links back to the main installation guide for standard steps to avoid documentation drift, as discussed in #643.

Also updates `docs/tutorials/index.md` to list the new tutorial.

### Related issues

- Fixes #643

### How was this tested?

Verified the tutorial steps manually on a WSL2 (Ubuntu) instance running on Windows 11 with KVM enabled. Confirmed that the markdown renders correctly and all links resolve properly.

### LLM usage

no LLM usage.

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [ ] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
