### PR TITLE
test(qemu): improve helper and command coverage

### DIFF
--- a/pkg/unikontainers/hypervisors/qemu_test.go
+++ b/pkg/unikontainers/hypervisors/qemu_test.go
@@ -1,0 +1,130 @@
+package hypervisors
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
+)
+
+func TestQemuUsesKVM(t *testing.T) {
+	q := &Qemu{}
+
+	if !q.UsesKVM() {
+		t.Fatal("expected UsesKVM() to return true")
+	}
+}
+
+func TestQemuSupportsSharedfs(t *testing.T) {
+	q := &Qemu{}
+
+	if !q.SupportsSharedfs("9pfs") {
+		t.Fatal("expected SupportsSharedfs() to return true")
+	}
+}
+
+func TestQemuPath(t *testing.T) {
+	q := &Qemu{
+		binaryPath: "/usr/bin/qemu-system-x86_64",
+	}
+
+	if q.Path() != "/usr/bin/qemu-system-x86_64" {
+		t.Fatal("unexpected path")
+	}
+}
+
+func TestQemuPreExec(t *testing.T) {
+	q := &Qemu{}
+
+	err := q.PreExec(types.ExecArgs{})
+
+	if err != nil {
+		t.Fatalf("expected nil error got %v", err)
+	}
+}
+
+func TestGetVirtioNetArg(t *testing.T) {
+	got := getVirtioNetArg()
+
+	expected := "-device virtio-net-pci,netdev=net0"
+
+	if runtime.GOARCH == "arm64" {
+		expected = "-device virtio-net-device,netdev=net0"
+	}
+
+	if got != expected {
+		t.Fatalf(
+			"expected %s got %s",
+			expected,
+			got,
+		)
+	}
+}
+
+type mockUnikernel struct{}
+
+func (m mockUnikernel) Init(types.UnikernelParams) error {
+	return nil
+}
+
+func (m mockUnikernel) CommandString() (string, error) {
+	return "", nil
+}
+
+func (m mockUnikernel) SupportsBlock() bool {
+	return false
+}
+
+func (m mockUnikernel) SupportsFS(string) bool {
+	return false
+}
+
+func (m mockUnikernel) MonitorNetCli(string, string) string {
+	return ""
+}
+
+func (m mockUnikernel) MonitorBlockCli() []types.MonitorBlockArgs {
+	return nil
+}
+
+func (m mockUnikernel) MonitorCli() types.MonitorCliArgs {
+	return types.MonitorCliArgs{}
+}
+
+func TestQemuBuildExecCmd(t *testing.T) {
+	q := &Qemu{
+		binaryPath: "/usr/bin/qemu-system-x86_64",
+	}
+
+	args := types.ExecArgs{
+		MemSizeB:      512 * 1024 * 1024,
+		VCPUs:         2,
+		UnikernelPath: "/tmp/kernel",
+		Command:       "console=ttyS0",
+	}
+
+	cmd, err := q.BuildExecCmd(
+		args,
+		mockUnikernel{},
+	)
+
+	if err != nil {
+		t.Fatalf(
+			"unexpected error: %v",
+			err,
+		)
+	}
+
+	if len(cmd) == 0 {
+		t.Fatal(
+			"expected non-empty command",
+		)
+	}
+
+	if cmd[0] != "/usr/bin/qemu-system-x86_64" {
+		t.Fatalf(
+			"unexpected binary: %s",
+			cmd[0],
+		)
+	}
+}

--- a/pkg/unikontainers/hypervisors/qemu_test.go
+++ b/pkg/unikontainers/hypervisors/qemu_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package hypervisors
 
 import (


### PR DESCRIPTION
## Summary

Adds unit tests for QEMU helper methods and command construction.

Covered methods:

* UsesKVM
* SupportsSharedfs
* Path
* PreExec
* getVirtioNetArg
* BuildExecCmd

This increases coverage in `pkg/unikontainers/hypervisors` and improves validation around QEMU command generation.

## Testing

```bash
go test ./pkg/unikontainers/hypervisors -cover
```

Coverage increased from roughly `2.7%` to `15.2%`.

### LLM usage

OpenAI ChatGPT (GPT-5.5)

Used for discussion, test planning, and assistance while writing tests. All code was reviewed, modified, and tested locally before submission.

Related issues
FIxes #720 
