### PR TITLE
feat(e2e): run tests in dedicated urunc-test namespace

### DIFF
--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -71,10 +71,11 @@ type containerTestArgs struct {
 }
 
 const (
-	testCtr     = "TestCtr"
-	testCrictl  = "TestCrictl"
-	testDocker  = "TestDocker"
-	testNerdctl = "TestNerdctl"
+	testCtr       = "TestCtr"
+	testCrictl    = "TestCrictl"
+	testDocker    = "TestDocker"
+	testNerdctl   = "TestNerdctl"
+	testNamespace = "urunc-test"
 )
 
 var errToolDoesNotSupport = errors.New("Operation not support")

--- a/tests/e2e/ctr.go
+++ b/tests/e2e/ctr.go
@@ -19,6 +19,7 @@ import (
 )
 
 const ctrName = "ctr"
+const ctrCmd = ctrName + " --namespace " + testNamespace
 
 type ctrInfo struct {
 	testArgs    containerTestArgs
@@ -90,7 +91,7 @@ func (i *ctrInfo) createPod() (string, error) {
 }
 
 func (i *ctrInfo) createContainer() (string, error) {
-	cmdBase := ctrName
+	cmdBase := ctrCmd
 	cmdBase += " c create "
 	cmdBase += ctrNewContainerCmd(i.testArgs)
 	return commonCmdExec(cmdBase)
@@ -106,11 +107,11 @@ func (i *ctrInfo) startContainer(detach bool) (string, error) {
 	if detach {
 		i.detached = true
 	}
-	return commonStart(ctrName+" t", i.containerID, detach)
+	return commonStart(ctrCmd+" t", i.containerID, detach)
 }
 
 func (i *ctrInfo) runContainer(detach bool) (string, error) {
-	cmdBase := ctrName
+	cmdBase := ctrCmd
 	cmdBase += " run "
 	if detach {
 		cmdBase += "-d "
@@ -124,7 +125,7 @@ func (i *ctrInfo) stopContainer() error {
 	if !i.detached {
 		return nil
 	}
-	cmdBase := ctrName
+	cmdBase := ctrCmd
 	cmdBase += " t kill "
 	cmdBase += i.containerID
 	output, err := commonCmdExec(cmdBase)
@@ -141,12 +142,12 @@ func (i *ctrInfo) stopPod() error {
 }
 
 func (i *ctrInfo) rmContainer() error {
-	output, err := commonRmContainer(ctrName+" c", i.containerID)
+	output, err := commonRmContainer(ctrCmd+" c", i.containerID)
 	err = checkExpectedOut("", output, err)
 	if err != nil {
 		return fmt.Errorf("Failed to remove %s: %v", i.containerID, err)
 	}
-	output, err = commonRmContainer(ctrName+" s", i.testArgs.Name)
+	output, err = commonRmContainer(ctrCmd+" s", i.testArgs.Name)
 	err = checkExpectedOut("", output, err)
 	if err != nil {
 		return fmt.Errorf("Failed to remove snapshot %s: %v", i.testArgs.Name, err)
@@ -168,7 +169,7 @@ func (i *ctrInfo) logContainer() (string, error) {
 }
 
 func (i *ctrInfo) searchContainer(cID string) (bool, error) {
-	cmd := ctrName + " c ls -q"
+	cmd := ctrCmd + " c ls -q"
 
 	output, err := commonCmdExec(cmd)
 	if err != nil {
@@ -183,7 +184,7 @@ func (i *ctrInfo) searchPod(string) (bool, error) {
 }
 
 func (i *ctrInfo) inspectCAndGet(key string) (string, error) {
-	cmdBase := ctrName
+	cmdBase := ctrCmd
 	cmdBase += " c info "
 	cmdBase += i.containerID
 	output, err := commonCmdExec(cmdBase)

--- a/tests/e2e/nerdctl.go
+++ b/tests/e2e/nerdctl.go
@@ -19,6 +19,7 @@ import (
 )
 
 const nerdctlName = "nerdctl"
+const nerdctlCmd = nerdctlName + " --namespace " + testNamespace
 
 type nerdctlInfo struct {
 	testArgs    containerTestArgs
@@ -63,7 +64,7 @@ func (i *nerdctlInfo) createPod() (string, error) {
 }
 
 func (i *nerdctlInfo) createContainer() (string, error) {
-	return commonCreate(nerdctlName, i.testArgs)
+	return commonCreate(nerdctlCmd, i.testArgs)
 }
 
 // nolint:unused
@@ -73,15 +74,15 @@ func (i *nerdctlInfo) startPod() (string, error) {
 }
 
 func (i *nerdctlInfo) startContainer(detach bool) (string, error) {
-	return commonStart(nerdctlName, i.containerID, detach)
+	return commonStart(nerdctlCmd, i.containerID, detach)
 }
 
 func (i *nerdctlInfo) runContainer(detach bool) (string, error) {
-	return commonRun(nerdctlName, i.testArgs, detach)
+	return commonRun(nerdctlCmd, i.testArgs, detach)
 }
 
 func (i *nerdctlInfo) stopContainer() error {
-	output, err := commonStopContainer(nerdctlName, i.containerID)
+	output, err := commonStopContainer(nerdctlCmd, i.containerID)
 	err = checkExpectedOut(i.containerID, output, err)
 	if err != nil {
 		return fmt.Errorf("Failed to stop %s: %v", i.containerID, err)
@@ -95,7 +96,7 @@ func (i *nerdctlInfo) stopPod() error {
 }
 
 func (i *nerdctlInfo) rmContainer() error {
-	output, err := commonRmContainer(nerdctlName, i.containerID)
+	output, err := commonRmContainer(nerdctlCmd, i.containerID)
 	err = checkExpectedOut(i.containerID, output, err)
 	if err != nil {
 		return fmt.Errorf("Failed to stop %s: %v", i.containerID, err)
@@ -109,11 +110,11 @@ func (i *nerdctlInfo) rmPod() error {
 }
 
 func (i *nerdctlInfo) logContainer() (string, error) {
-	return commonLogs(nerdctlName, i.containerID)
+	return commonLogs(nerdctlCmd, i.containerID)
 }
 
 func (i *nerdctlInfo) searchContainer(cID string) (bool, error) {
-	return commonSearchContainer(nerdctlName, cID)
+	return commonSearchContainer(nerdctlCmd, cID)
 }
 
 func (i *nerdctlInfo) searchPod(string) (bool, error) {
@@ -122,7 +123,7 @@ func (i *nerdctlInfo) searchPod(string) (bool, error) {
 }
 
 func (i *nerdctlInfo) inspectCAndGet(key string) (string, error) {
-	return commonInspectCAndGet(nerdctlName, i.containerID, key)
+	return commonInspectCAndGet(nerdctlCmd, i.containerID, key)
 }
 
 func (i *nerdctlInfo) inspectPAndGet(string) (string, error) {

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -31,6 +31,20 @@ const (
 	defaultInterval = 1 * time.Second
 )
 
+var _ = BeforeSuite(func() {
+	_, err := commonCmdExec("ctr namespaces create " + testNamespace)
+	if err != nil {
+		GinkgoLogr.Info("namespace setup: " + err.Error())
+	}
+})
+
+var _ = AfterSuite(func() {
+	_, err := commonCmdExec("ctr namespaces remove " + testNamespace)
+	if err != nil {
+		GinkgoLogr.Error(err, "failed to remove namespace "+testNamespace+"; manual cleanup may be required")
+	}
+})
+
 func TestE2E(t *testing.T) {
 	format.MaxLength = 0 // Do not truncate failure output
 	RegisterFailHandler(Fail)

--- a/tests/e2e/test_functions.go
+++ b/tests/e2e/test_functions.go
@@ -229,15 +229,19 @@ func namespaceTest(tool testTool) error {
 	// We need to retrieve the container's config, in order to get
 	// the namespaces that the container should have joined.
 	containerID := tool.getContainerID()
-	// Try /run/containerd/io.containerd.runtime.v2.task/default/containerID first
-	configPath := filepath.Join("/var/run/containerd/io.containerd.runtime.v2.task/default/", containerID, "/config.json")
+	// Try testNamespace first, then fall back to default, k8s.io, and moby.
+	configPath := filepath.Join("/var/run/containerd/io.containerd.runtime.v2.task/"+testNamespace+"/", containerID, "/config.json")
 	_, err := os.Stat(configPath)
 	if os.IsNotExist(err) {
-		configPath = filepath.Join("/var/run/containerd/io.containerd.runtime.v2.task/k8s.io/", containerID, "/config.json")
+		configPath = filepath.Join("/var/run/containerd/io.containerd.runtime.v2.task/default/", containerID, "/config.json")
 		_, err = os.Stat(configPath)
 		if os.IsNotExist(err) {
-			configPath = filepath.Join("/var/run/containerd/io.containerd.runtime.v2.task/moby/", containerID, "/config.json")
+			configPath = filepath.Join("/var/run/containerd/io.containerd.runtime.v2.task/k8s.io/", containerID, "/config.json")
 			_, err = os.Stat(configPath)
+			if os.IsNotExist(err) {
+				configPath = filepath.Join("/var/run/containerd/io.containerd.runtime.v2.task/moby/", containerID, "/config.json")
+				_, err = os.Stat(configPath)
+			}
 		}
 	}
 	if err != nil {

--- a/tests/e2e/utils.go
+++ b/tests/e2e/utils.go
@@ -88,11 +88,11 @@ func pullImageForTest(testFunc string, image string) error {
 		}
 		return nil
 	case testNerdctl:
-		return commonPull(nerdctlName, image)
+		return commonPull(nerdctlCmd, image)
 	case testDocker:
 		return commonPull(dockerName, image)
 	default:
-		return commonPull(ctrName, image)
+		return commonPull(ctrCmd, image)
 	}
 }
 
@@ -106,11 +106,11 @@ func removeImageForTest(testFunc string, image string) error {
 		}
 		return nil
 	case testNerdctl:
-		return commonRmImage(nerdctlName, image)
+		return commonRmImage(nerdctlCmd, image)
 	case testDocker:
 		return commonRmImage(dockerName, image)
 	default:
-		return commonRmImage(ctrName, image)
+		return commonRmImage(ctrCmd, image)
 	}
 }
 
@@ -219,6 +219,13 @@ func verifyNoStaleFiles(containerID string) error {
 
 	// Check /run/containerd/io.containerd.runtime.v2.task/k8s.io/containerID directory does not exist
 	dirPath = "/run/containerd/io.containerd.runtime.v2.task/k8s.io/" + containerID
+	_, err = os.Stat(dirPath)
+	if !os.IsNotExist(err) {
+		return fmt.Errorf("bundle directory %s still exists", dirPath)
+	}
+
+	// Check /run/containerd/io.containerd.runtime.v2.task/urunc-test/containerID directory does not exist
+	dirPath = "/run/containerd/io.containerd.runtime.v2.task/" + testNamespace + "/" + containerID
 	_, err = os.Stat(dirPath)
 	if !os.IsNotExist(err) {
 		return fmt.Errorf("bundle directory %s still exists", dirPath)


### PR DESCRIPTION
## Description
nerdctl and ctr e2e tests previously ran in the default containerd namespace, leaving containers and images mixed with host workloads and risking cross-test contamination. This change introduces a dedicated `urunc-test` namespace: `BeforeSuite` creates it, `AfterSuite` removes it, and every nerdctl and ctr command is prefixed with `--namespace urunc-test`.

crictl is unaffected  it uses the `k8s.io` namespace via the CRI endpoint. docker is unaffected  it has its own daemon with no containerd namespace concept.

`verifyNoStaleFiles` and the `namespaceTest` config path lookup are also updated to cover the `urunc-test` namespace.

### Related issues
- Fixes #122

### How was this tested?
Build and lint pass locally:

go build ./...           # no errors
golangci-lint run --timeout=5m  # 0 issues

**To verify namespace creation and cleanup on a host with containerd running:**

```bash
# Before running tests — namespace should not exist yet:
sudo ctr namespaces ls | grep urunc-test || echo "namespace absent"

# Run the test suite (nerdctl or ctr):
make test_nerdctl   # or: make test_ctr

# Namespace exists while tests run:
sudo ctr namespaces ls | grep urunc-test

# After suite completes — AfterSuite removes it:
sudo ctr namespaces ls | grep urunc-test || echo "namespace cleaned up"

# Confirm test images were pulled into urunc-test, not default:
sudo ctr --namespace urunc-test images ls | head -5
sudo ctr images ls | grep -c harbor.nbfc.io || echo "0 images in default"
```
Full e2e verification requires a host with containerd, nerdctl, and ctr installed alongside a supported VMM (QEMU, Firecracker, or Solo5).


### LLM usage
N/A

### Checklist
- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [ ] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).