### PR TITLE
docs: clarify storage support tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,12 @@ supported VM/Sandbox monitors and unikernels:
 | Linux     | QEMU, Firecracker          | x86         | Initrd, Block/Devmapper, 9pfs, Virtiofs |
 | Hermit    | QEMU                       | x86         | Initrd                                  |
 
+The `Storage` column summarizes the storage modes supported by each
+guest across the listed monitors. Not every storage mode in a row is
+available on every monitor. For monitor-specific limitations, such as
+Firecracker only supporting initramfs today, refer to the
+[hypervisor support guide](https://urunc.io/hypervisor-support/).
+
 We plan to add support for more unikernel frameworks and other platforms too.
 Feel free to [contact](#Contact) us for a specific unikernel framework or similar
 technologies that you would like to see in `urunc`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,6 +62,11 @@ Sandbox monitors, along with the unikernels that can run on top of them.
 | [Linux](./unikernel-support#linux)| [Qemu](./hypervisor-support#qemu), [Firecracker](./hypervisor-support#aws-firecracker) | x86, aarch64 | Initrd, Block/Devmapper, 9pfs, Virtiofs |
 | [Hermit](./unikernel-support#hermit)| [Qemu](./hypervisor-support#qemu) | x86 | Initrd |
 
+The `Storage` column summarizes the storage modes supported by each
+guest across the listed monitors. Not every storage mode in a row is
+available on every monitor. For monitor-specific limitations, refer to
+the [hypervisor support guide](./hypervisor-support.md).
+
 <!-- ## urunc and the CNCF -->
 
 ## Community and Meetings


### PR DESCRIPTION
## Description

Clarify that the storage column in the supported-platform tables is the union
of storage modes across the monitors listed in the same row, and point readers
to the hypervisor guide for monitor-specific limitations.

This addresses the ambiguity called out in the issue without changing the
underlying support claims.

### Related issues

- Fixes #732

### How was this tested?

- `git diff --check`
- `npx --yes cspell --config .github/linters/.cspell.json README.md docs/index.md`

### LLM usage

- OpenAI GPT-5 (Codex)

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [ ] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
