### PR TITLE
refactor(unikernels): drop redundant monitor check in Linux block cli formatting

### DIFF
--- a/pkg/unikontainers/unikernels/linux.go
+++ b/pkg/unikontainers/unikernels/linux.go
@@ -170,12 +170,8 @@ func (l *Linux) MonitorBlockCli() []types.MonitorBlockArgs {
 		}
 	case "firecracker":
 		for _, aBlock := range l.Blk {
-			id := aBlock.ID
-			if l.Monitor == "firecracker" {
-				id = "FC" + aBlock.ID
-			}
 			blkArgs = append(blkArgs, types.MonitorBlockArgs{
-				ID:   id,
+				ID:   "FC" + aBlock.ID,
 				Path: aBlock.Source,
 			})
 		}

--- a/pkg/unikontainers/unikernels/linux_test.go
+++ b/pkg/unikontainers/unikernels/linux_test.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unikernels
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
+)
+
+func TestLinuxMonitorBlockCli(t *testing.T) {
+	t.Parallel()
+
+	blocks := []types.BlockDevParams{
+		{ID: "rootfs", Source: "/host/rootfs.img"},
+		{ID: "vol0", Source: "/host/vol0.img"},
+	}
+
+	tests := []struct {
+		name    string
+		monitor string
+		blk     []types.BlockDevParams
+		want    []types.MonitorBlockArgs
+	}{
+		{
+			name:    "no blocks returns nil",
+			monitor: "qemu",
+			blk:     nil,
+			want:    nil,
+		},
+		{
+			name:    "qemu emits ExactArgs without FC prefix",
+			monitor: "qemu",
+			blk:     blocks,
+			want: []types.MonitorBlockArgs{
+				{ExactArgs: " -device virtio-blk-pci,serial=rootfs,drive=rootfs" +
+					" -drive format=raw,if=none,id=rootfs,file=/host/rootfs.img"},
+				{ExactArgs: " -device virtio-blk-pci,serial=vol0,drive=vol0" +
+					" -drive format=raw,if=none,id=vol0,file=/host/vol0.img"},
+			},
+		},
+		{
+			name:    "firecracker prefixes every ID with FC",
+			monitor: "firecracker",
+			blk:     blocks,
+			want: []types.MonitorBlockArgs{
+				{ID: "FCrootfs", Path: "/host/rootfs.img"},
+				{ID: "FCvol0", Path: "/host/vol0.img"},
+			},
+		},
+		{
+			name:    "unknown monitor returns nil",
+			monitor: "hvt",
+			blk:     blocks,
+			want:    nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			l := &Linux{Monitor: tc.monitor, Blk: tc.blk}
+			assert.Equal(t, tc.want, l.MonitorBlockCli())
+		})
+	}
+}


### PR DESCRIPTION
## Description

`Linux.MonitorBlockCli` in `pkg/unikontainers/unikernels/linux.go` had a dead conditional inside its `case "firecracker":` switch arm

Since execution only reaches this code when `l.Monitor == "firecracker"` (picked by the enclosing switch l.Monitor), the inner if is always true and the local id variable is always assigned "FC" + aBlock.ID. 

This PR removes the redundant conditional and the unused local , inlining `"FC" + aBlock.ID` directly into the struct literal matching the inline style used by similar one present `case "qemu":` arm a few lines above.


### Related issues

- Fixes : #747 

### How was this tested?


- Logical equivalence verified by inspection: inside `case "firecracker":` of switch `l.Monitor`, `l.Monitor == "firecracker"` is provably always true and is not mutated inside the loop body, so the rewritten arm produces the same MonitorBlockArgs slice for every input.
 - No linux_test.go exists for this unikernel; no test fixture depends on the removed local variable.
 - Couldn't invoke make lint directly because the Makefile rejects host arch arm64 (macOS Apple Silicon as, line 39 only knows about Linux aarch64, not macOS arm64). Ran the same golangci-lint v2.7 container the Makefile runs:
```bash
  docker run --rm --platform=linux/arm64 -v "$PWD":/app -w /app \
    golangci/golangci-lint:v2.7 golangci-lint run -v --timeout=5m
```
<img width="938" height="668" alt="Screenshot 2026-06-04 at 2 18 14 AM" src="https://github.com/user-attachments/assets/d652c5bf-4268-4936-9403-2e2a6002b6a5" />


### LLM usage 

N/A

<!-- Mention the LLm(s) that assisted with the creation of this PR. (N/A) if none was used-->

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [ ] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
