### PR TITLE
fix(unikontainers): reject non-positive pid in kill/signal paths

### DIFF
--- a/pkg/unikontainers/hypervisors/utils.go
+++ b/pkg/unikontainers/hypervisors/utils.go
@@ -68,6 +68,13 @@ func BytesToStringMB(argMem uint64) string {
 
 func killProcess(pid int) error {
 	const timeout = 2 * time.Second
+	// Guard against non-positive PIDs. unix.Kill interprets pid <= 0 as a
+	// process-group/broadcast target (e.g. -1 means every process the caller
+	// may signal), so a sentinel PID (-1) from a partially-created container
+	// would SIGKILL the whole host.
+	if pid <= 0 {
+		return fmt.Errorf("refusing to kill invalid pid %d", pid)
+	}
 	err := unix.Kill(pid, unix.SIGKILL)
 	if err != nil {
 		if errors.Is(err, unix.ESRCH) {

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -692,6 +692,13 @@ func setupUser(user specs.User) error {
 
 // Signal sends a specified signal to container's init.
 func (u *Unikontainer) Signal(signal unix.Signal) error {
+	// Guard against non-positive PIDs. A partially-created container persists
+	// a sentinel PID (-1) in its state, and unix.Kill treats pid <= 0 as a
+	// process-group/broadcast target, which would signal every process on the
+	// host instead of the container's monitor.
+	if u.State.Pid <= 0 {
+		return fmt.Errorf("container %s has no valid pid to signal", u.State.ID)
+	}
 	vmmType := u.State.Annotations[annotHypervisor]
 	vmm, err := hypervisors.NewVMM(hypervisors.VmmType(vmmType), u.UruncCfg.Monitors)
 	if err != nil {
@@ -1293,6 +1300,14 @@ func (u *Unikontainer) SendMessage(message IPCMessage) error {
 func (u *Unikontainer) isRunning() bool {
 	vmmType := hypervisors.VmmType(u.State.Annotations[annotHypervisor])
 	if vmmType != hypervisors.HedgeVmm {
+		// A non-positive PID means the container never reached a running
+		// state (e.g. it failed during creation while still holding the
+		// sentinel PID -1). Treat it as not running so it can be cleaned up.
+		// This also avoids syscall.Kill(-1, 0) returning nil and falsely
+		// reporting the container as running.
+		if u.State.Pid <= 0 {
+			return false
+		}
 		return syscall.Kill(u.State.Pid, syscall.Signal(0)) == nil
 	}
 	hedge := hypervisors.Hedge{}


### PR DESCRIPTION
## Description

A partially-created unikontainer can persist a sentinel PID value (`-1`) in its state before the monitor process is successfully created. Subsequent lifecycle operations trusted this stored PID and passed it directly to process-control paths.

On Unix systems, `kill(-1, sig)` does not target a single process. Instead, it broadcasts the signal to every process the caller is permitted to signal. Since urunc typically runs with elevated privileges, a failed container creation followed by a signal or force-delete operation could result in host-wide signal delivery.

This change adds validation for non-positive PIDs at all process-control boundaries:

- Reject signaling containers with invalid PIDs in `Unikontainer.Signal()`
- Reject killing invalid PIDs in `hypervisors.killProcess()`
- Treat non-positive PIDs as not running in `Unikontainer.isRunning()`

These checks prevent unsafe signal propagation and allow failed containers with invalid PIDs to be cleaned up correctly.

No changes to normal container lifecycle behavior. Containers with valid monitor PIDs continue to operate as before.

## Related issues

- Fixes node-wide signal broadcast caused by sentinel PID values reaching process-control paths

## How was this tested?

Verified by code inspection and local validation.

- Confirmed containers may persist `Pid: -1` during the creating state
- Verified signal and force-delete paths could previously reach `unix.Kill()` with non-positive PIDs
- Confirmed invalid PIDs are now rejected before any signal is sent
- Confirmed `isRunning()` returns `false` for invalid PIDs, allowing cleanup of failed containers
- Ran build and vet checks successfully

## LLM usage

N/A

## Checklist

- [x] I have read the contribution guide
- [x] The project builds successfully after the change
- [x] The fix is limited to PID validation and cleanup behavior
- [x] No functional changes for healthy containers with valid PIDs