### PR TITLE
fix(unikernels): validate inputs in IsIPInSubnet

### DIFF
--- a/pkg/unikontainers/unikernels/linux.go
+++ b/pkg/unikontainers/unikernels/linux.go
@@ -60,6 +60,9 @@ func IsIPInSubnet(ln LinuxNet) bool {
 	ip := net.ParseIP(ln.Address)
 	gw := net.ParseIP(ln.Gateway)
 	mask := net.IPMask(net.ParseIP(ln.Mask).To4())
+	if ip == nil || gw == nil || mask == nil {
+		return false
+	}
 	subnet := gw.Mask(mask)
 
 	return ip.Mask(mask).Equal(subnet)

--- a/pkg/unikontainers/unikernels/linux_network_test.go
+++ b/pkg/unikontainers/unikernels/linux_network_test.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unikernels
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsIPInSubnet(t *testing.T) {
+	tests := []struct {
+		name string
+		net  LinuxNet
+		want bool
+	}{
+		{
+			name: "same subnet",
+			net:  LinuxNet{Address: "10.0.0.5", Gateway: "10.0.0.1", Mask: "255.255.255.0"},
+			want: true,
+		},
+		{
+			name: "different subnet",
+			net:  LinuxNet{Address: "10.244.0.5", Gateway: "169.254.1.1", Mask: "255.255.255.0"},
+			want: false,
+		},
+		{
+			name: "empty mask",
+			net:  LinuxNet{Address: "10.244.0.5", Gateway: "169.254.1.1", Mask: ""},
+			want: false,
+		},
+		{
+			name: "garbage mask",
+			net:  LinuxNet{Address: "10.244.0.5", Gateway: "169.254.1.1", Mask: "abc"},
+			want: false,
+		},
+		{
+			name: "truncated mask",
+			net:  LinuxNet{Address: "10.244.0.5", Gateway: "169.254.1.1", Mask: "255.255.255"},
+			want: false,
+		},
+		{
+			name: "IPv6 mask",
+			net:  LinuxNet{Address: "10.244.0.5", Gateway: "169.254.1.1", Mask: "ffff:ffff::"},
+			want: false,
+		},
+		{
+			name: "CIDR-style mask",
+			net:  LinuxNet{Address: "10.244.0.5", Gateway: "169.254.1.1", Mask: "/24"},
+			want: false,
+		},
+		{
+			name: "all empty",
+			net:  LinuxNet{},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsIPInSubnet(tt.net))
+		})
+	}
+}


### PR DESCRIPTION
## Description
This just adds a small nil-check to `IsIPInSubnet` in `pkg/unikontainers/unikernels/linux.go`. `IsIPInSubnet` decides if Linux unikernel needs `URUNIT_DEFROUTE=1` boot param, and currently it just returns true if any of its three string parameters (`Address`, `Gateway`, `Mask`) fails to parse-effectively silently turning off the flag added in #284. 

 Default to false seems safer. If we're using this for Docker with a malformed mask, we just enable one extra optional `URUNIT_DEFROUTE=1` flag which will harmlessly overwrite the eth0 default route, which would likely work fine anyways. The previous default risked silently losing egress in k8s, which is worse.

I've also added a small table-driven test, in a new file `pkg/unikontainers/unikernels/linux_network_test.go` covering two known-good cases (same subnet, different subnet) as regression guards, plus the 5 malformed-mask cases mentioned in the issue (empty string, garbage string, partial mask, IP literal mask, `/24` style mask) plus the fully empty cases.

### Related issues

<!-- Include links to relevant issues or other pages. -->
 - Fixes #754 

### How was this tested?

Locally, inside a Linux container (host is macOS, so e2e is left to CI).

```bash
docker run --rm -v "$PWD":/src -w /src -e CGO_ENABLED=0 golang:1.25 \
    go test -v -count=1 -run TestIsIPInSubnet ./pkg/unikontainers/unikernels/
```
<img width="972" height="310" alt="Screenshot 2026-06-08 at 5 56 08 PM" src="https://github.com/user-attachments/assets/8b286ae1-0b94-4201-809f-510b165c6c58" />

### LLM usage

N/A

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [ ] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
