### PR TITLE
fix(shim): do not abort Create on guest rootfs choice failure

### DIFF
--- a/pkg/containerd-shim/task_service.go
+++ b/pkg/containerd-shim/task_service.go
@@ -55,13 +55,21 @@ func (s *taskService) Create(ctx context.Context, r *taskAPI.CreateTaskRequest) 
 
 	// ChooseRootfs after inner task Create so bundle rootfs is mounted;
 	// params are persisted in bundle config.json for runtime Exec.
+	//
+	// This is only a pre-computation/optimization: the runtime Exec recomputes
+	// ChooseRootfs when the annotation is absent. Therefore a failure here must
+	// not abort Create, otherwise we would report Create as failed while the
+	// inner task service has already created the task and spawned the container
+	// init, orphaning a running process and leaking resources. Instead, we log
+	// and continue, deferring any genuine rootfs error to the runtime, where it
+	// surfaces during start with proper, containerd-tracked cleanup.
 	if err := chooseGuestRootfs(r); err != nil {
 		if errors.Is(err, errGuestRootfsChoiceSkipped) {
 			log.G(ctx).WithError(err).Debug("urunc(shim): guest rootfs choice skipped")
-			return resp, nil
+		} else {
+			log.G(ctx).WithError(err).Warn("urunc(shim): failed to choose guest rootfs; runtime will recompute at Exec")
 		}
-		log.G(ctx).WithError(err).Warn("urunc(shim): failed to choose guest rootfs")
-		return nil, err
+		return resp, nil
 	}
 
 	return resp, nil


### PR DESCRIPTION
## Description

`taskService.Create()` performs guest rootfs selection after the underlying task has already been successfully created by the inner containerd task service.

If `chooseGuestRootfs()` returns a non-skip error at that point, the shim currently aborts Create and returns an error to containerd even though the task has already been created, registered, and its reexec init process is running. This leaves containerd believing task creation failed while the runtime still has a live task, resulting in an inconsistent lifecycle state.

The guest rootfs selection performed during Create is only a pre-computation optimization. The same rootfs choice is already recomputed later during Exec when the annotation is absent. Treating failures in this best-effort step as fatal can therefore orphan partially-created containers, leak resources, and prevent successful reconciliation.

This change makes guest rootfs selection best-effort after task creation:

- Continue returning success when `chooseGuestRootfs()` fails after a successful inner Create
- Log guest rootfs selection failures for visibility
- Preserve the existing skip behavior for unsupported workloads
- Allow the runtime to recompute rootfs selection during Exec as designed

This restores a consistent Create lifecycle: once the inner task has been committed, Create no longer fails because of a recoverable rootfs pre-computation error.

## Related issues

- Fixes orphaned unikontainer init processes caused by post-create guest rootfs selection failures
- Fixes task lifecycle inconsistencies where containerd reports Create failure after the task has already been created
- Prevents resource leakage from unreconciled tasks created before guest rootfs pre-computation errors

## How was this tested?

Verified by code inspection and local validation.

- Confirmed `chooseGuestRootfs()` executes after `s.TaskService.Create()` successfully creates the task
- Verified non-skip guest rootfs selection errors previously caused Create to return failure after task creation had already been committed
- Confirmed runtime Exec already recomputes guest rootfs selection when the annotation is absent
- Verified Create now succeeds and preserves task lifecycle consistency when guest rootfs pre-computation fails
- Confirmed existing successful guest rootfs selection paths are unchanged
- Ran build and validation checks successfully

## LLM usage

N/A

## Checklist

- [x] I have read the contribution guide
- [x] The project builds successfully after the change
- [x] The fix is limited to post-create guest rootfs error handling
- [x] No functional changes for successful guest rootfs selection paths
- [x] Runtime rootfs recomputation behavior remains unchanged



#767 