### PR TITLE
Fix Delete() for invalid PID values

### DIFF
--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -1293,6 +1293,9 @@ func (u *Unikontainer) SendMessage(message IPCMessage) error {
 func (u *Unikontainer) isRunning() bool {
 	vmmType := hypervisors.VmmType(u.State.Annotations[annotHypervisor])
 	if vmmType != hypervisors.HedgeVmm {
+		if u.State.Pid <= 0 {
+			return false
+		}
 		return syscall.Kill(u.State.Pid, syscall.Signal(0)) == nil
 	}
 	hedge := hypervisors.Hedge{}


### PR DESCRIPTION
## Summary

Fixes #778

This PR fixes `Delete()` incorrectly treating containers with invalid PIDs (`Pid <= 0`) as running.

## Changes

- Return `false` from `isRunning()` when `Pid <= 0`.
- Prevent `syscall.Kill()` from being invoked with invalid PID values.

## Why

`InitialSetup()` persists container state with `Pid = -1` before container creation completes. If creation fails before the PID is updated, `Delete()` eventually calls `isRunning()`, which previously executed `syscall.Kill(-1, 0)`. On Unix systems, this can incorrectly succeed and cause the container to be considered running, preventing cleanup.

With this change, containers in an incomplete state (`Pid <= 0`) are correctly treated as not running, allowing `Delete()` to clean them up.