### PR TITLE
docs(timestamps): fix outdated enabling timestamping section

### DIFF
--- a/docs/developer-guide/timestamps.md
+++ b/docs/developer-guide/timestamps.md
@@ -40,52 +40,36 @@ Timestamp logging is now handled through a fixed schema using zerolog. The previ
 
 ## How to enable timestamping
 
-In order to capture the timestamps, a separate `containerd-shim` and container runtime must be configured in your system.
+Timestamping is enabled via urunc's configuration file at `/etc/urunc/config.toml`:
 
-To create the "timestamping" version of `containerd-shim-urunc-v2`:
-
-```bash
-sudo tee -a /usr/local/bin/containerd-shim-uruncts-v2 > /dev/null << 'EOT'
-#!/bin/bash
-URUNC_TIMESTAMPS=1 /usr/local/bin/containerd-shim-urunc-v2 $@
-EOT
-sudo chmod +x /usr/local/bin/containerd-shim-uruncts-v2
+```toml
+[timestamps]
+enabled     = true
+destination = "/var/log/urunc/timestamps.log"
 ```
 
-To add the "timestamping" urunc to containerd config:
+No separate `containerd-shim` or container runtime configuration is required — urunc reads this setting directly at startup.
 
-```bash
-sudo tee -a /etc/containerd/config.toml > /dev/null << 'EOT'
-# timestamping urunc
-[plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.uruncts]
-    runtime_type = "io.containerd.uruncts.v2"
-    container_annotations = ["com.urunc.unikernel.*"]
-    pod_annotations = ["com.urunc.unikernel.*"]
-    snapshotter = "devmapper"
-EOT
-sudo systemctl restart containerd.service
-```
+If the destination directory does not exist, urunc logs a warning and disables metrics gracefully instead of crashing.
 
 ## How to gather timestamps
 
-Now we need to run a unikernel using the new container runtime `uruncts`:
+Now we need to run a unikernel with timestamping enabled in the config:
 
 ```bash
-sudo nerdctl run --rm --snapshotter devmapper --runtime io.containerd.uruncts.v2 harbor.nbfc.io/nubificus/urunc/hello-hvt-rumprun:latest
+sudo nerdctl run --rm --snapshotter devmapper --runtime io.containerd.urunc.v2 harbor.nbfc.io/nubificus/urunc/hello-hvt-rumprun:latest
 ```
 
-The timestamp logs are located at `/tmp/urunc.zlog`:
+The timestamp logs are located at `/var/log/urunc/timestamps.log`:
 
 ```console
-$ cat /tmp/urunc.zlog | grep TS
+$ cat /var/log/urunc/timestamps.log | grep TS
 {"containerID":"faaf830245ffab0df81927cebd7f11065e70c7703121fbc1b11d4bca49bab461","timestampID":"TS00","timestampName":"CR.invoked","timestampOrder":0,"time":1703676366849599657}
 {"containerID":"faaf830245ffab0df81927cebd7f11065e70c7703121fbc1b11d4bca49bab461","timestampID":"TS01","timestampName":"CR.unikontainer_created","timestampOrder":1,"time":1703676366850466038}
 {"containerID":"faaf830245ffab0df81927cebd7f11065e70c7703121fbc1b11d4bca49bab461","timestampID":"TS02","timestampName":"CR.initial_setup","timestampOrder":2,"time":1703676366850709857}
 {"containerID":"faaf830245ffab0df81927cebd7f11065e70c7703121fbc1b11d4bca49bab461","timestampID":"TS03","timestampName":"CR.start_reexec","timestampOrder":3,"time":1703676366850900287}
 # ... (rest of the output)
 ```
-
-> Note: the timestamp destination (`/tmp/urunc.zlog`) is hardcoded for the time being.
 
 ## Gathering the timestamps
 


### PR DESCRIPTION
## Description

The "How to enable timestamping" section in `docs/developer-guide/timestamps.md` described an outdated method (creating a separate containerd-shim wrapper + `URUNC_TIMESTAMPS=1` env var). urunc has since moved to a config.toml-based approach (confirmed via #596).

This PR updates the docs to:
- Show the current config.toml approach for enabling timestamps
- Fix the example runtime command from `io.containerd.uruncts.v2` to `io.containerd.urunc.v2`
- Correct the log path from `/tmp/urunc.zlog` to `/var/log/urunc/timestamps.log`
- Remove the outdated "hardcoded path" note, since the destination is now configurable
- Mention the graceful degradation behavior introduced in #596

### Related issues

- Fixes #624

### How was this tested?

Verified no other files reference the outdated method:
```bash
grep -rn "URUNC_TIMESTAMPS\|uruncts\|urunc.zlog" docs/
# (no results)
```
Manually reviewed the full rendered file for correct markdown formatting and accuracy against the current `urunc_config.go` defaults and PR #596.

### LLM usage

N/A

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [ ] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
