### PR TITLE
docs: add talks and publications page

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,20 +160,9 @@ docs](https://urunc.io/tutorials/How-to-urunc-on-k8s/).
 
 ## Publications and talks
 
-A part of our work in `urunc` has been published in EuroSys'24 SESAME workshop,
-under the title [Sandboxing Functions for Efficient and Secure Multi-tenant
-Serverless Deployments](https://dl.acm.org/doi/10.1145/3642977.3652096). Feel
-free to ask us if you can not have access to the paper.
-
-Furthermore, `urunc` has appeared in various open source summits and events,
-such as:
-
-- [Open Source Summit
-  2023](https://osseu2023.sched.com/event/1OGgY/urunc-a-unikernel-container-runtime-georgios-ntoutsos-anastassios-nanos-nubificus-ltd)
-- [FOSDEM 2024 -- Containers devroom](https://archive.fosdem.org/2024/schedule/event/fosdem-2024-3402-from-containers-to-unikernels-navigating-integration-challenges-in-cloud-native-environments/)
-- [KubeCon 2024](https://kccnceu2024.sched.com/event/1YeRd/unikernels-in-k8s-performance-and-isolation-for-serverless-computing-with-knative-anastassios-nanos-ioannis-plakas-nubis-pc)
-- [FOSDEM 2025 -- Containers devroom](https://fosdem.org/2025/schedule/event/fosdem-2025-6284-less-overhead-strong-isolation-running-containers-in-minimal-specialized-linux-vms/)
-- [FOSDEM 2025 -- WASM devroom](https://fosdem.org/2025/schedule/event/fosdem-2025-6292-wasm-meets-unikernels-secure-and-efficient-cloud-native-deployments/)
+Find our papers, conference talks, and events featuring `urunc` on the
+[Talks & Publications](https://urunc.io/talks-and-publications/) page of the
+documentation.
 
 ## Bug reporting
 

--- a/docs/talks-and-publications.md
+++ b/docs/talks-and-publications.md
@@ -1,0 +1,20 @@
+# Talks & Publications
+
+A collection of papers, conference talks, and events featuring `urunc`.
+
+## Publications
+
+A part of our work in `urunc` has been published in EuroSys'24 SESAME
+workshop, under the title [Sandboxing Functions for Efficient and Secure
+Multi-tenant Serverless Deployments](https://dl.acm.org/doi/10.1145/3642977.3652096).
+Feel free to ask us if you can not have access to the paper.
+
+## Talks & events
+
+`urunc` has appeared in various open source summits and events, such as:
+
+- [Open Source Summit 2023](https://osseu2023.sched.com/event/1OGgY/urunc-a-unikernel-container-runtime-georgios-ntoutsos-anastassios-nanos-nubificus-ltd)
+- [FOSDEM 2024 — Containers devroom](https://archive.fosdem.org/2024/schedule/event/fosdem-2024-3402-from-containers-to-unikernels-navigating-integration-challenges-in-cloud-native-environments/)
+- [KubeCon 2024](https://kccnceu2024.sched.com/event/1YeRd/unikernels-in-k8s-performance-and-isolation-for-serverless-computing-with-knative-anastassios-nanos-ioannis-plakas-nubis-pc)
+- [FOSDEM 2025 — Containers devroom](https://fosdem.org/2025/schedule/event/fosdem-2025-6284-less-overhead-strong-isolation-running-containers-in-minimal-specialized-linux-vms/)
+- [FOSDEM 2025 — WASM devroom](https://fosdem.org/2025/schedule/event/fosdem-2025-6292-wasm-meets-unikernels-secure-and-efficient-cloud-native-deployments/)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,7 @@ nav:
       - API Reference: https://pkg.go.dev/github.com/urunc-dev/urunc/pkg/unikontainers
   - Tutorials:
       - tutorials/*.md
+  - Talks & Publications: talks-and-publications.md
 
 theme:
   name: material


### PR DESCRIPTION
## Description

Move the publications and talks resources from the README into a dedicated docs page so newcomers can find them while browsing the site. Replace the README section with a pointer to the new page.

Adds a new top-level "Talks & Publications" tab to the docs nav (`docs/talks-and-publications.md`) holding the existing EuroSys paper and the conference talks, and slims the README's `## Publications and talks` section to a pointer to that page. The README heading is kept so the existing table-of-contents anchor still resolves.

### Related issues

- Fixes #659

### How was this tested?

Built and served the docs locally with `mkdocs` (Material theme) and verified:

- the new "Talks & Publications" tab appears in the nav and the page renders both sections (Publications, Talks & events)
- the page is reachable (HTTP 200) at `/talks-and-publications/`
- all external links were copied verbatim from the README (none altered)
- `gofmt` is clean and the commit passes the conventional commitlint rules

This is a docs-only change (no Go touched), so build / unit / e2e tests are not applicable.

Current View -

https://github.com/user-attachments/assets/ceaa8f80-b5f3-4fc0-b98d-4446405daa28


### LLM usage

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`). <!-- N/A: docs-only, no Go changed -->
- [x] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`). <!-- N/A: docs-only -->
- [ ] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).