### PR TITLE
test: add table-based tests for resolveAgainstBase

### DIFF
--- a/pkg/unikontainers/utils_test.go
+++ b/pkg/unikontainers/utils_test.go
@@ -298,3 +298,66 @@ func TestLoadSpec(t *testing.T) {
 		assert.Contains(t, err.Error(), "failed to parse specification json", "Expected specific error message")
 	})
 }
+
+func TestResolveAgainstBase(t *testing.T) {
+	relBase := "relbase"
+	relBaseAbs, err := filepath.Abs(relBase)
+	assert.NoError(t, err)
+
+	tests := []struct {
+		name string
+		base string
+		path string
+		want string
+	}{
+		{
+			name: "absolute path is returned unchanged",
+			base: "/var/lib/urunc",
+			path: "/absolute/rootfs",
+			want: "/absolute/rootfs",
+		},
+		{
+			name: "relative path is joined with absolute base",
+			base: "/var/lib/urunc",
+			path: "rootfs/image",
+			want: "/var/lib/urunc/rootfs/image",
+		},
+		{
+			name: "relative path is joined with relative base",
+			base: relBase,
+			path: "rootfs/image",
+			want: filepath.Join(relBaseAbs, "rootfs", "image"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := resolveAgainstBase(tt.base, tt.path)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got, "resolveAgainstBase returned an unexpected path")
+		})
+	}
+}
+
+func TestResolveAgainstBaseError(t *testing.T) {
+	// Removing the working directory makes os.Getwd fail, which is the only way
+	// resolveAgainstBase errors. This mutates the process cwd, so no t.Parallel.
+	origWD, err := os.Getwd()
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, os.Chdir(origWD))
+	}()
+
+	tmpDir, err := os.MkdirTemp("", "urunc-resolve-test")
+	assert.NoError(t, err)
+
+	err = os.Chdir(tmpDir)
+	assert.NoError(t, err)
+
+	err = os.RemoveAll(tmpDir)
+	assert.NoError(t, err)
+
+	_, err = resolveAgainstBase("relative/base", "relative/path")
+	assert.Error(t, err, "expected an error when the working directory cannot be resolved")
+}


### PR DESCRIPTION
## Description

Adds unit tests for the `resolveAgainstBase` function in `pkg/unikontainers/utils.go`, which previously had no test coverage. The tests are added to the existing `pkg/unikontainers/utils_test.go` (rather than a new file) and are written as table-based tests, following the style already used in `vaccel_test.go`.

`resolveAgainstBase(base, path)` resolves `path` relative to `base` and returns an absolute path. The tests cover three success cases and one failure case:

- **Absolute path** — returned unchanged.
- **Relative path with absolute base** — joined onto the base (e.g. `/var/lib/urunc` + `rootfs/image` → `/var/lib/urunc/rootfs/image`).
- **Relative path with relative base** — the base is first resolved against the working directory, then joined. The test asserts the exact resolved absolute path rather than a substring.
- **Failure case** — the function only errors when it cannot resolve a relative base to an absolute path (i.e. when `os.Getwd()` fails). The test forces this by changing into a temporary directory and removing it, then asserts an error. This case is intentionally not run with `t.Parallel()` since it mutates the process working directory, and it restores the original working directory afterwards.

This implements the review feedback left on #592 for this function: update the existing test file instead of creating a new one, use table-based tests, add a failure case, assert the exact path instead of using `Contains`, and drop the hardcoded personal path.

This builds on the work started in #592. Since that PR went stale, I've implemented the maintainer's review feedback in a fresh PR, with credit to her for the original test cases.

### Related issues

<!-- Include links to relevant issues or other pages. -->

- Fixes #96

### How was this tested?

Tested locally on WSL with Go 1.26:

- `go test ./pkg/unikontainers/ -run TestResolveAgainstBase -v` — all cases pass, including the failure case.
- `go test ./pkg/unikontainers/ -count=2` — the whole package passes twice, confirming the failure test restores the working directory and doesn't disturb other tests.
- `gofmt -l` clean, `go vet ./pkg/unikontainers/` clean, `go build ./...` succeeds.

### LLM usage

Claude Opus 4.8 assisted with writing the tests and understanding the code. Every line was reviewed, understood, and tested before submission.

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).