### PR TITLE
feat(firecracker): add an api boot mode over the control socket

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -166,6 +166,7 @@ Each monitor subsection supports the following options:
 | `data_path` | string | (empty) | Optional custom path for the monitor's data file directory |
 | `vhost` | boolean | `false` | Optional: enable `vhost-net` for the monitor's network device, to improve network performance. Currently only honored by the `qemu` monitor |
 | `socket_path` | string | (empty) | Optional custom path for the monitor's control socket. If not specified, the monitor uses its default. Currently only used by Firecracker. |
+| `boot_mode` | string | `api` | Optional: `api` drives the monitor's boot over its control socket, `config-file` lets the monitor boot itself from a config file (socket only used afterward). Currently only used by Firecracker. |
 
 Since Qemu is the only currently supported monitor which requires extra data to
 boot a VM, `urunc` will first check `/usr/local/share` and then `/usr/share` for
@@ -186,6 +187,7 @@ default_memory_mb = 512
 default_vcpus = 2
 path = "/opt/firecracker/firecracker"
 socket_path = "/run/urunc/fc.sock"
+boot_mode = "config-file"
 ```
 
 ### Extra binaries Configuration

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -165,7 +165,7 @@ Each monitor subsection supports the following options:
 | `path` | string | (empty) | Optional custom path to the monitor binary. If not specified, urunc will search for the binary in PATH |
 | `data_path` | string | (empty) | Optional custom path for the monitor's data file directory |
 | `vhost` | boolean | `false` | Optional: enable `vhost-net` for the monitor's network device, to improve network performance. Currently only honored by the `qemu` monitor |
-| `socket_path` | string | (empty) | Optional custom path for the monitor's control socket. If not specified, the monitor uses its default. Currently only used by Firecracker. |
+| `socket_path` | string | (empty) | Optional path for the monitor's control socket. If not specified, urunc uses a per-container default under `/tmp`. When a custom path is set, urunc creates its parent directory; setting it to an invalid location (a file already exists on the path) makes the monitor fail to start. Currently only used by Firecracker. |
 | `boot_mode` | string | `api` | Optional: `api` drives the monitor's boot over its control socket, `config-file` lets the monitor boot itself from a config file (socket only used afterward). Currently only used by Firecracker. |
 
 Since Qemu is the only currently supported monitor which requires extra data to

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -165,6 +165,7 @@ Each monitor subsection supports the following options:
 | `path` | string | (empty) | Optional custom path to the monitor binary. If not specified, urunc will search for the binary in PATH |
 | `data_path` | string | (empty) | Optional custom path for the monitor's data file directory |
 | `vhost` | boolean | `false` | Optional: enable `vhost-net` for the monitor's network device, to improve network performance. Currently only honored by the `qemu` monitor |
+| `socket_path` | string | (empty) | Optional custom path for the monitor's control socket. If not specified, the monitor uses its default. Currently only used by Firecracker. |
 
 Since Qemu is the only currently supported monitor which requires extra data to
 boot a VM, `urunc` will first check `/usr/local/share` and then `/usr/share` for
@@ -184,6 +185,7 @@ vhost = false
 default_memory_mb = 512
 default_vcpus = 2
 path = "/opt/firecracker/firecracker"
+socket_path = "/run/urunc/fc.sock"
 ```
 
 ### Extra binaries Configuration

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -38,10 +38,6 @@ type UnikernelNetworkInfo struct {
 	EthDevice Interface
 }
 type Manager interface {
-	// HasNetwork does a cheap check for whether this container has a network
-	// interface to configure, without doing the more expensive tap device
-	// creation and configuration. It lets callers learn this fact early,
-	// before the full NetworkSetup (which does the expensive work) finishes.
 	HasNetwork() (bool, error)
 	NetworkSetup(uid uint32, gid uint32) (*UnikernelNetworkInfo, error)
 }
@@ -135,18 +131,6 @@ func createTapDevice(name string, mtu int, ownerUID, ownerGID uint32) (netlink.L
 		if err != nil {
 			return nil, fmt.Errorf("failed to close the fd of tap %s: %w", name, err)
 		}
-	}
-
-	// LinkAdd opens the tap device's file descriptor with O_CLOEXEC and sets
-	// TUNSETPERSIST, so the interface survives independent of any open fd.
-	// We don't need to keep it open past this point (the rest of setup, and
-	// whatever process later attaches to this tap by name, uses netlink/its
-	// own independent open, not this fd) - closing it now, rather than
-	// relying on a future exec to do it, matters because a process that
-	// keeps this fd open (instead of exec-ing away) would otherwise block
-	// anything else from opening the same single-queue tap device.
-	for _, tapFd := range tapLink.Fds {
-		_ = tapFd.Close()
 	}
 
 	err = netlink.LinkSetMTU(tapLink, mtu)

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -38,6 +38,11 @@ type UnikernelNetworkInfo struct {
 	EthDevice Interface
 }
 type Manager interface {
+	// HasNetwork does a cheap check for whether this container has a network
+	// interface to configure, without doing the more expensive tap device
+	// creation and configuration. It lets callers learn this fact early,
+	// before the full NetworkSetup (which does the expensive work) finishes.
+	HasNetwork() (bool, error)
 	NetworkSetup(uid uint32, gid uint32) (*UnikernelNetworkInfo, error)
 }
 
@@ -130,6 +135,18 @@ func createTapDevice(name string, mtu int, ownerUID, ownerGID uint32) (netlink.L
 		if err != nil {
 			return nil, fmt.Errorf("failed to close the fd of tap %s: %w", name, err)
 		}
+	}
+
+	// LinkAdd opens the tap device's file descriptor with O_CLOEXEC and sets
+	// TUNSETPERSIST, so the interface survives independent of any open fd.
+	// We don't need to keep it open past this point (the rest of setup, and
+	// whatever process later attaches to this tap by name, uses netlink/its
+	// own independent open, not this fd) - closing it now, rather than
+	// relying on a future exec to do it, matters because a process that
+	// keeps this fd open (instead of exec-ing away) would otherwise block
+	// anything else from opening the same single-queue tap device.
+	for _, tapFd := range tapLink.Fds {
+		_ = tapFd.Close()
 	}
 
 	err = netlink.LinkSetMTU(tapLink, mtu)

--- a/pkg/network/network_dynamic.go
+++ b/pkg/network/network_dynamic.go
@@ -32,6 +32,17 @@ type DynamicNetwork struct {
 // FIXME: CUrrently only one tap device per netns can provide functional networking. We need to find a proper way to handle networking
 // for multiple unikernels in the same pod/network namespace.
 // See: https://github.com/urunc-dev/urunc/issues/13
+// HasNetwork checks, cheaply, whether a container network interface exists
+// in the current netns, without creating the tap device or doing any of the
+// other, more expensive setup NetworkSetup does.
+func (n DynamicNetwork) HasNetwork() (bool, error) {
+	_, err := discoverContainerIface()
+	if err != nil {
+		return false, nil
+	}
+	return true, nil
+}
+
 func (n DynamicNetwork) NetworkSetup(uid uint32, gid uint32) (*UnikernelNetworkInfo, error) {
 	tapIndex, err := getTapIndex()
 	if err != nil {

--- a/pkg/network/network_dynamic.go
+++ b/pkg/network/network_dynamic.go
@@ -32,9 +32,6 @@ type DynamicNetwork struct {
 // FIXME: CUrrently only one tap device per netns can provide functional networking. We need to find a proper way to handle networking
 // for multiple unikernels in the same pod/network namespace.
 // See: https://github.com/urunc-dev/urunc/issues/13
-// HasNetwork checks, cheaply, whether a container network interface exists
-// in the current netns, without creating the tap device or doing any of the
-// other, more expensive setup NetworkSetup does.
 func (n DynamicNetwork) HasNetwork() (bool, error) {
 	_, err := discoverContainerIface()
 	if err != nil {

--- a/pkg/network/network_static.go
+++ b/pkg/network/network_static.go
@@ -88,6 +88,17 @@ func setNATRule(iface string, sourceIP string) error {
 	return nil
 }
 
+// HasNetwork checks, cheaply, whether a container network interface exists
+// in the current netns, without creating the tap device or doing any of the
+// other, more expensive setup NetworkSetup does.
+func (n StaticNetwork) HasNetwork() (bool, error) {
+	_, err := discoverContainerIface()
+	if err != nil {
+		return false, nil
+	}
+	return true, nil
+}
+
 func (n StaticNetwork) NetworkSetup(uid uint32, gid uint32) (*UnikernelNetworkInfo, error) {
 	newTapName := strings.ReplaceAll(DefaultTap, "X", "0")
 	addTCRules := false

--- a/pkg/network/network_static.go
+++ b/pkg/network/network_static.go
@@ -88,9 +88,6 @@ func setNATRule(iface string, sourceIP string) error {
 	return nil
 }
 
-// HasNetwork checks, cheaply, whether a container network interface exists
-// in the current netns, without creating the tap device or doing any of the
-// other, more expensive setup NetworkSetup does.
 func (n StaticNetwork) HasNetwork() (bool, error) {
 	_, err := discoverContainerIface()
 	if err != nil {

--- a/pkg/unikontainers/hypervisors/firecracker.go
+++ b/pkg/unikontainers/hypervisors/firecracker.go
@@ -113,6 +113,11 @@ func (fc *Firecracker) BuildExecCmd(args types.ExecArgs, ukernel types.Unikernel
 	}
 	exArgs := []string{fc.Path(), "--api-sock", apiSockPath}
 	JSONConfigFile := filepath.Join("/tmp/", FCJsonFilename)
+	if args.BootMode == "config-file" {
+		// config-file-based: Firecracker boots itself from the JSON config file
+		// below; the socket stays open only for use after the guest is running.
+		cmdString += " --config-file " + JSONConfigFile
+	}
 	if !args.Seccomp {
 		exArgs = append(exArgs, "--no-seccomp")
 	}

--- a/pkg/unikontainers/hypervisors/firecracker.go
+++ b/pkg/unikontainers/hypervisors/firecracker.go
@@ -263,6 +263,7 @@ func (fc *Firecracker) SpawnSocketVMM(args types.ExecArgs, uid, gid uint32) (*Fi
 
 	cmd := exec.Command(execCmd[0], execCmd[1:]...) //nolint: gosec
 	cmd.Env = args.Environment
+	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if uid != 0 || gid != 0 {

--- a/pkg/unikontainers/hypervisors/firecracker.go
+++ b/pkg/unikontainers/hypervisors/firecracker.go
@@ -117,8 +117,6 @@ func (fc *Firecracker) BuildExecCmd(args types.ExecArgs, ukernel types.Unikernel
 	exArgs := []string{fc.Path(), "--api-sock", apiSockPath}
 	JSONConfigFile := filepath.Join("/tmp/", FCJsonFilename)
 	if args.BootMode == "config-file" {
-		// config-file-based: Firecracker boots itself from the JSON config file
-		// below; the socket stays open only for use after the guest is running.
 		exArgs = append(exArgs, "--config-file", JSONConfigFile)
 	}
 	if !args.Seccomp {
@@ -138,16 +136,12 @@ func (fc *Firecracker) BuildExecCmd(args types.ExecArgs, ukernel types.Unikernel
 	return exArgs, nil
 }
 
-// PreExec performs pre-execution setup. Firecracker has no special pre-exec requirements.
 func (fc *Firecracker) PreExec(_ types.ExecArgs) error {
 	return nil
 }
 
-// buildFirecrackerConfig builds the microVM configuration from args and
-// ukernel. Used both to write the JSON config file (config-file-based boot)
-// and to drive the same configuration over the API socket (API-based boot),
-// so both paths always agree on what the guest actually gets configured
-// with.
+// buildFirecrackerConfig builds the microVM configuration. Both boot modes
+// use it, so they always configure the guest the same way.
 func buildFirecrackerConfig(args types.ExecArgs, ukernel types.Unikernel) *FirecrackerConfig {
 	// VM config for Firecracker
 	fcMem := DefaultMemory
@@ -227,32 +221,18 @@ func buildFirecrackerConfig(args types.ExecArgs, ukernel types.Unikernel) *Firec
 	}
 }
 
-// FirecrackerSession is a Firecracker child process configured over its API
-// socket, one resource at a time. Create it with SpawnSocketVMM, send the
-// configuration with the Configure* methods, boot the guest with StartGuest
-// once the caller's start handshake allows it, then hand the calling process
-// over with Supervise.
+// FirecrackerSession is a Firecracker child process that urunc configures
+// over its API socket, one resource at a time.
 type FirecrackerSession struct {
 	cmd    *exec.Cmd
 	client *firecrackerClient
 }
 
-// SpawnSocketVMM starts Firecracker as a child process with only its API
-// socket enabled, and establishes the single persistent connection all later
-// configuration stages use.
-//
-// This is called after changeRoot, so the child inherits the already-pivoted
-// root: its control socket and every path it opens live inside the monitor
-// rootfs, the same confinement the exec path gets. It also inherits the
-// sandbox's network namespace, which Exec has already joined. The caller is
-// still privileged here and only drops its own privileges just after
-// (setupUser), so when uid/gid are non-zero the child is started directly
-// under that credential.
+// SpawnSocketVMM starts Firecracker with only its API socket. It must run
+// after changeRoot, so the socket stays inside the monitor rootfs.
 func (fc *Firecracker) SpawnSocketVMM(args types.ExecArgs, uid, gid uint32) (*FirecrackerSession, error) {
 	socketPath := ResolveSocketPath(args)
-	// Firecracker binds this path itself; a stale socket file left from an
-	// earlier run (e.g. a crash) would make its bind fail with "address
-	// already in use", so remove any leftover first.
+	// Firecracker binds this path, and a leftover file makes the bind fail.
 	if err := os.Remove(socketPath); err != nil && !os.IsNotExist(err) {
 		return nil, fmt.Errorf("failed to remove stale socket %q: %w", socketPath, err)
 	}
@@ -285,9 +265,7 @@ func (fc *Firecracker) SpawnSocketVMM(args types.ExecArgs, uid, gid uint32) (*Fi
 	return &FirecrackerSession{cmd: cmd, client: client}, nil
 }
 
-// ConfigureMachine sends the vCPU/memory configuration. Nothing but the
-// container spec is needed for this, so it is the first stage, sent right
-// after the spawn.
+// ConfigureMachine sends the vCPU and memory configuration.
 func (s *FirecrackerSession) ConfigureMachine(ctx context.Context, args types.ExecArgs) error {
 	fcMem := DefaultMemory
 	if args.MemSizeB != 0 {
@@ -307,8 +285,8 @@ func (s *FirecrackerSession) ConfigureMachine(ctx context.Context, args types.Ex
 }
 
 // ConfigureNetwork attaches the container's network interface. Firecracker
-// opens the tap device during this call, so it must only run once the
-// network setup that creates the tap has finished. No-op without a tap.
+// opens the tap device here, so the tap must exist first. It does nothing
+// when there is no tap.
 func (s *FirecrackerSession) ConfigureNetwork(ctx context.Context, net types.NetDevParams) error {
 	if net.TapDev == "" {
 		return nil
@@ -322,12 +300,9 @@ func (s *FirecrackerSession) ConfigureNetwork(ctx context.Context, net types.Net
 	return s.client.putNetworkIface(ctx, iface)
 }
 
-// ConfigureGuest sends everything that depends on unikernel.Init having run:
-// the block devices (their IDs/paths come from the unikernel's
-// MonitorBlockCli), the boot source (its boot args are the unikernel command
-// line, which bakes in the resolved network), and the vsock device if any.
-// The child runs inside the monitor rootfs, so every path is sent exactly as
-// the exec path would use it.
+// ConfigureGuest sends the block devices, the boot source and the vsock
+// device. It must run after unikernel.Init, which produces the block device
+// list and the boot arguments.
 func (s *FirecrackerSession) ConfigureGuest(ctx context.Context, args types.ExecArgs, ukernel types.Unikernel) error {
 	cfg := buildFirecrackerConfig(args, ukernel)
 
@@ -347,25 +322,17 @@ func (s *FirecrackerSession) StartGuest(ctx context.Context) error {
 	return s.client.startGuest(ctx)
 }
 
-// Kill terminates the child and reaps it. For error paths before Supervise.
+// Kill terminates the child process and reaps it.
 func (s *FirecrackerSession) Kill() {
 	_ = s.cmd.Process.Kill()
 	_, _ = s.cmd.Process.Wait()
 }
 
-// Supervise hands the calling process over to the child for the rest of its
-// life: it forwards SIGTERM/SIGINT and, once the child exits, exits this
-// process with the child's exit code, mirroring the semantics syscall.Exec
-// would have had. The caller must not exit before the child, since it is
-// the container's init process.
-//
-// On success this function does not return: it calls os.Exit with the
-// child's exit status once the child exits.
+// Supervise forwards signals to Firecracker and exits with its exit code once
+// it exits. It does not return on success.
 func (s *FirecrackerSession) Supervise() error {
-	// Forward the signals containerd would send to stop the container.
-	// SIGKILL cannot be caught, so it is not listed here: if it arrives,
-	// this process dies immediately and the child is left running, a known
-	// gap for this bounded experiment, not yet handled.
+	// Forward the signals that stop a container. SIGKILL cannot be caught,
+	// so this process dies at once and leaves Firecracker running.
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
 	go func() {

--- a/pkg/unikontainers/hypervisors/firecracker.go
+++ b/pkg/unikontainers/hypervisors/firecracker.go
@@ -239,15 +239,15 @@ type FirecrackerSession struct {
 
 // SpawnSocketVMM starts Firecracker as a child process with only its API
 // socket enabled, and establishes the single persistent connection all later
-// configuration stages use (it survives a later changeRoot; see
-// firecrackerClient).
+// configuration stages use.
 //
-// This is called early in Exec, before the monitor rootfs is prepared and
-// before changeRoot, so unlike the exec path the child keeps the caller's
-// current (pre-pivot) mount view for its lifetime. It does inherit the
-// sandbox's network namespace, which Exec has already joined. When uid/gid
-// are non-zero the child is started directly under that credential, since
-// the caller only drops its own privileges (setupUser) much later.
+// This is called after changeRoot, so the child inherits the already-pivoted
+// root: its control socket and every path it opens live inside the monitor
+// rootfs, the same confinement the exec path gets. It also inherits the
+// sandbox's network namespace, which Exec has already joined. The caller is
+// still privileged here and only drops its own privileges just after
+// (setupUser), so when uid/gid are non-zero the child is started directly
+// under that credential.
 func (fc *Firecracker) SpawnSocketVMM(args types.ExecArgs, uid, gid uint32) (*FirecrackerSession, error) {
 	socketPath := ResolveSocketPath(args)
 	// Firecracker binds this path itself; a stale socket file left from an
@@ -325,23 +325,10 @@ func (s *FirecrackerSession) ConfigureNetwork(ctx context.Context, net types.Net
 // the block devices (their IDs/paths come from the unikernel's
 // MonitorBlockCli), the boot source (its boot args are the unikernel command
 // line, which bakes in the resolved network), and the vsock device if any.
-//
-// The child was spawned before changeRoot, so it resolves paths in the
-// pre-pivot mount view; monRootfs (the directory the caller will pivot into)
-// is therefore prefixed onto every path the child has to open.
-func (s *FirecrackerSession) ConfigureGuest(ctx context.Context, args types.ExecArgs, ukernel types.Unikernel, monRootfs string) error {
+// The child runs inside the monitor rootfs, so every path is sent exactly as
+// the exec path would use it.
+func (s *FirecrackerSession) ConfigureGuest(ctx context.Context, args types.ExecArgs, ukernel types.Unikernel) error {
 	cfg := buildFirecrackerConfig(args, ukernel)
-
-	cfg.Source.ImagePath = filepath.Join(monRootfs, cfg.Source.ImagePath)
-	if cfg.Source.InitrdPath != "" {
-		cfg.Source.InitrdPath = filepath.Join(monRootfs, cfg.Source.InitrdPath)
-	}
-	for i := range cfg.Drives {
-		cfg.Drives[i].HostPath = filepath.Join(monRootfs, cfg.Drives[i].HostPath)
-	}
-	if cfg.VSock.UDSPath != "" {
-		cfg.VSock.UDSPath = filepath.Join(monRootfs, cfg.VSock.UDSPath)
-	}
 
 	vmmLog.Debug("staged boot: sending drives, boot-source and vsock")
 	if err := s.client.putDrives(ctx, cfg.Drives); err != nil {

--- a/pkg/unikontainers/hypervisors/firecracker.go
+++ b/pkg/unikontainers/hypervisors/firecracker.go
@@ -113,10 +113,7 @@ func (fc *Firecracker) BuildExecCmd(args types.ExecArgs, ukernel types.Unikernel
 	// options in FC, since the string return value of the Monitor related
 	// functions in the unikernel interface do not integrate well with FC's
 	// json configuration.
-	apiSockPath := args.SocketPath
-	if apiSockPath == "" {
-		apiSockPath = filepath.Join("/tmp/", args.ContainerID+".sock")
-	}
+	apiSockPath := ResolveSocketPath(args)
 	exArgs := []string{fc.Path(), "--api-sock", apiSockPath}
 	JSONConfigFile := filepath.Join("/tmp/", FCJsonFilename)
 	if args.BootMode == "config-file" {
@@ -252,10 +249,7 @@ type FirecrackerSession struct {
 // are non-zero the child is started directly under that credential, since
 // the caller only drops its own privileges (setupUser) much later.
 func (fc *Firecracker) SpawnSocketVMM(args types.ExecArgs, uid, gid uint32) (*FirecrackerSession, error) {
-	socketPath := args.SocketPath
-	if socketPath == "" {
-		socketPath = filepath.Join("/tmp/", args.ContainerID+".sock")
-	}
+	socketPath := ResolveSocketPath(args)
 	// Firecracker binds this path itself; a stale socket file left from an
 	// earlier run (e.g. a crash) would make its bind fail with "address
 	// already in use", so remove any leftover first.

--- a/pkg/unikontainers/hypervisors/firecracker.go
+++ b/pkg/unikontainers/hypervisors/firecracker.go
@@ -107,8 +107,9 @@ func (fc *Firecracker) BuildExecCmd(args types.ExecArgs, ukernel types.Unikernel
 	// options in FC, since the string return value of the Monitor related
 	// functions in the unikernel interface do not integrate well with FC's
 	// json configuration.
+	apiSockPath := filepath.Join("/tmp/", args.ContainerID+".sock")
+	exArgs := []string{fc.Path(), "--api-sock", apiSockPath}
 	JSONConfigFile := filepath.Join("/tmp/", FCJsonFilename)
-	exArgs := []string{fc.Path(), "--no-api", "--config-file", JSONConfigFile}
 	if !args.Seccomp {
 		exArgs = append(exArgs, "--no-seccomp")
 	}

--- a/pkg/unikontainers/hypervisors/firecracker.go
+++ b/pkg/unikontainers/hypervisors/firecracker.go
@@ -227,11 +227,11 @@ func buildFirecrackerConfig(args types.ExecArgs, ukernel types.Unikernel) *Firec
 	}
 }
 
-// FirecrackerSession is a Firecracker child process being configured over its
-// API socket in stages, while the caller performs its own setup work between
-// the stages. Create it with SpawnSocketVMM, feed it configuration with the
-// Configure* methods as each piece becomes available, boot the guest with
-// StartGuest, then hand the calling process over with Supervise.
+// FirecrackerSession is a Firecracker child process configured over its API
+// socket, one resource at a time. Create it with SpawnSocketVMM, send the
+// configuration with the Configure* methods, boot the guest with StartGuest
+// once the caller's start handshake allows it, then hand the calling process
+// over with Supervise.
 type FirecrackerSession struct {
 	cmd    *exec.Cmd
 	client *firecrackerClient

--- a/pkg/unikontainers/hypervisors/firecracker.go
+++ b/pkg/unikontainers/hypervisors/firecracker.go
@@ -230,57 +230,150 @@ func buildFirecrackerConfig(args types.ExecArgs, ukernel types.Unikernel) *Firec
 	}
 }
 
-// RunSocketBoot starts Firecracker as a child process instead of replacing
-// the current process via exec. Since nothing here changes the process's
-// root (no SysProcAttr.Chroot is set), the child simply inherits whatever
-// confinement changeRoot already established on the caller earlier in Exec
-// (pivot_root or chroot, whichever the container spec calls for) - so it
-// ends up exactly as confined as the exec path would have made it, with no
-// separate confinement step needed here.
+// FirecrackerSession is a Firecracker child process being configured over its
+// API socket in stages, while the caller performs its own setup work between
+// the stages. Create it with SpawnSocketVMM, feed it configuration with the
+// Configure* methods as each piece becomes available, boot the guest with
+// StartGuest, then hand the calling process over with Supervise.
+type FirecrackerSession struct {
+	cmd    *exec.Cmd
+	client *firecrackerClient
+}
+
+// SpawnSocketVMM starts Firecracker as a child process with only its API
+// socket enabled, and establishes the single persistent connection all later
+// configuration stages use (it survives a later changeRoot; see
+// firecrackerClient).
 //
-// It configures the guest over the API socket using the same config
-// BuildExecCmd would have written to a file, starts the guest, then
-// supervises the child until it exits: forwarding SIGTERM/SIGINT, and
-// exiting this process with the child's exit code once it's done, mirroring
-// the semantics syscall.Exec would have had.
-//
-// On success this function does not return: it calls os.Exit with the
-// child's exit status once the child exits. It returns an error only if
-// startup or configuration fails before the guest could ever run.
-func (fc *Firecracker) RunSocketBoot(args types.ExecArgs, ukernel types.Unikernel, execCmd []string) error {
-	cfg := buildFirecrackerConfig(args, ukernel)
+// This is called early in Exec, before the monitor rootfs is prepared and
+// before changeRoot, so unlike the exec path the child keeps the caller's
+// current (pre-pivot) mount view for its lifetime. It does inherit the
+// sandbox's network namespace, which Exec has already joined. When uid/gid
+// are non-zero the child is started directly under that credential, since
+// the caller only drops its own privileges (setupUser) much later.
+func (fc *Firecracker) SpawnSocketVMM(args types.ExecArgs, uid, gid uint32) (*FirecrackerSession, error) {
+	socketPath := args.SocketPath
+	if socketPath == "" {
+		socketPath = filepath.Join("/tmp/", args.ContainerID+".sock")
+	}
+	execCmd := []string{fc.Path(), "--api-sock", socketPath}
+	if !args.Seccomp {
+		execCmd = append(execCmd, "--no-seccomp")
+	}
 
 	cmd := exec.Command(execCmd[0], execCmd[1:]...) //nolint: gosec
 	cmd.Env = args.Environment
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	if uid != 0 || gid != 0 {
+		cmd.SysProcAttr = &syscall.SysProcAttr{
+			Credential: &syscall.Credential{Uid: uid, Gid: gid},
+		}
+	}
+	vmmLog.WithField("command", execCmd).Debug("starting Firecracker as a supervised child")
 	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("failed to start firecracker: %w", err)
+		return nil, fmt.Errorf("failed to start firecracker: %w", err)
 	}
 
-	socketPath := args.SocketPath
-	if socketPath == "" {
-		socketPath = filepath.Join("/tmp/", args.ContainerID+".sock")
-	}
 	client := newFirecrackerClient(socketPath)
-	ctx := context.Background()
+	if err := client.connect(5 * time.Second); err != nil {
+		s := &FirecrackerSession{cmd: cmd, client: client}
+		s.Kill()
+		return nil, fmt.Errorf("firecracker socket never became ready: %w", err)
+	}
+	return &FirecrackerSession{cmd: cmd, client: client}, nil
+}
 
-	if err := client.waitForSocket(5 * time.Second); err != nil {
-		_ = cmd.Process.Kill()
-		_, _ = cmd.Process.Wait()
-		return fmt.Errorf("firecracker socket never became ready: %w", err)
+// ConfigureMachine sends the vCPU/memory configuration. Nothing but the
+// container spec is needed for this, so it is the first stage, sent right
+// after the spawn.
+func (s *FirecrackerSession) ConfigureMachine(ctx context.Context, args types.ExecArgs) error {
+	fcMem := DefaultMemory
+	if args.MemSizeB != 0 {
+		fcMem = bytesToMiB(args.MemSizeB)
+		if fcMem == 0 {
+			fcMem = DefaultMemory
+		}
 	}
-	if err := client.configure(ctx, cfg); err != nil {
-		_ = cmd.Process.Kill()
-		_, _ = cmd.Process.Wait()
-		return fmt.Errorf("failed to configure firecracker over the socket: %w", err)
+	machine := FirecrackerMachine{
+		VcpuCount:       args.VCPUs,
+		MemSizeMiB:      fcMem,
+		Smt:             false,
+		TrackDirtyPages: false,
 	}
-	if err := client.startGuest(ctx); err != nil {
-		_ = cmd.Process.Kill()
-		_, _ = cmd.Process.Wait()
-		return fmt.Errorf("failed to start the guest: %w", err)
+	vmmLog.Debug("staged boot: sending machine-config")
+	return s.client.putMachineConfig(ctx, machine)
+}
+
+// ConfigureNetwork attaches the container's network interface. Firecracker
+// opens the tap device during this call, so it must only run once the
+// network setup that creates the tap has finished. No-op without a tap.
+func (s *FirecrackerSession) ConfigureNetwork(ctx context.Context, net types.NetDevParams) error {
+	if net.TapDev == "" {
+		return nil
+	}
+	iface := FirecrackerNet{
+		IfaceID:  "net1",
+		GuestMAC: net.MAC,
+		HostIF:   net.TapDev,
+	}
+	vmmLog.Debug("staged boot: sending network-interfaces")
+	return s.client.putNetworkIface(ctx, iface)
+}
+
+// ConfigureGuest sends everything that depends on unikernel.Init having run:
+// the block devices (their IDs/paths come from the unikernel's
+// MonitorBlockCli), the boot source (its boot args are the unikernel command
+// line, which bakes in the resolved network), and the vsock device if any.
+//
+// The child was spawned before changeRoot, so it resolves paths in the
+// pre-pivot mount view; monRootfs (the directory the caller will pivot into)
+// is therefore prefixed onto every path the child has to open.
+func (s *FirecrackerSession) ConfigureGuest(ctx context.Context, args types.ExecArgs, ukernel types.Unikernel, monRootfs string) error {
+	cfg := buildFirecrackerConfig(args, ukernel)
+
+	cfg.Source.ImagePath = filepath.Join(monRootfs, cfg.Source.ImagePath)
+	if cfg.Source.InitrdPath != "" {
+		cfg.Source.InitrdPath = filepath.Join(monRootfs, cfg.Source.InitrdPath)
+	}
+	for i := range cfg.Drives {
+		cfg.Drives[i].HostPath = filepath.Join(monRootfs, cfg.Drives[i].HostPath)
+	}
+	if cfg.VSock.UDSPath != "" {
+		cfg.VSock.UDSPath = filepath.Join(monRootfs, cfg.VSock.UDSPath)
 	}
 
+	vmmLog.Debug("staged boot: sending drives, boot-source and vsock")
+	if err := s.client.putDrives(ctx, cfg.Drives); err != nil {
+		return err
+	}
+	if err := s.client.putBootSource(ctx, cfg.Source); err != nil {
+		return err
+	}
+	return s.client.putVSock(ctx, cfg.VSock)
+}
+
+// StartGuest powers on the configured microVM.
+func (s *FirecrackerSession) StartGuest(ctx context.Context) error {
+	vmmLog.Debug("staged boot: sending InstanceStart")
+	return s.client.startGuest(ctx)
+}
+
+// Kill terminates the child and reaps it. For error paths before Supervise.
+func (s *FirecrackerSession) Kill() {
+	_ = s.cmd.Process.Kill()
+	_, _ = s.cmd.Process.Wait()
+}
+
+// Supervise hands the calling process over to the child for the rest of its
+// life: it forwards SIGTERM/SIGINT and, once the child exits, exits this
+// process with the child's exit code, mirroring the semantics syscall.Exec
+// would have had. The caller must not exit before the child, since it is
+// the container's init process.
+//
+// On success this function does not return: it calls os.Exit with the
+// child's exit status once the child exits.
+func (s *FirecrackerSession) Supervise() error {
 	// Forward the signals containerd would send to stop the container.
 	// SIGKILL cannot be caught, so it is not listed here: if it arrives,
 	// this process dies immediately and the child is left running, a known
@@ -292,12 +385,12 @@ func (fc *Firecracker) RunSocketBoot(args types.ExecArgs, ukernel types.Unikerne
 		if !ok {
 			return
 		}
-		if s, ok := sig.(syscall.Signal); ok {
-			_ = cmd.Process.Signal(s)
+		if sg, ok := sig.(syscall.Signal); ok {
+			_ = s.cmd.Process.Signal(sg)
 		}
 	}()
 
-	waitErr := cmd.Wait()
+	waitErr := s.cmd.Wait()
 	signal.Stop(sigCh)
 	close(sigCh)
 

--- a/pkg/unikontainers/hypervisors/firecracker.go
+++ b/pkg/unikontainers/hypervisors/firecracker.go
@@ -15,10 +15,16 @@
 package hypervisors
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
+	"os/signal"
 	"path/filepath"
+	"syscall"
+	"time"
 
 	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
 	"golang.org/x/sys/unix"
@@ -116,12 +122,36 @@ func (fc *Firecracker) BuildExecCmd(args types.ExecArgs, ukernel types.Unikernel
 	if args.BootMode == "config-file" {
 		// config-file-based: Firecracker boots itself from the JSON config file
 		// below; the socket stays open only for use after the guest is running.
-		cmdString += " --config-file " + JSONConfigFile
+		exArgs = append(exArgs, "--config-file", JSONConfigFile)
 	}
 	if !args.Seccomp {
 		exArgs = append(exArgs, "--no-seccomp")
 	}
 
+	FCConfig := buildFirecrackerConfig(args, ukernel)
+	FCConfigJSON, err := json.Marshal(FCConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal Firecracker config: %w", err)
+	}
+	if err = os.WriteFile(JSONConfigFile, FCConfigJSON, 0o644); err != nil { //nolint: gosec
+		return nil, fmt.Errorf("failed to save Firecracker json config: %w", err)
+	}
+	vmmLog.WithField("Json", string(FCConfigJSON)).Debug("Firecracker json config")
+
+	return exArgs, nil
+}
+
+// PreExec performs pre-execution setup. Firecracker has no special pre-exec requirements.
+func (fc *Firecracker) PreExec(_ types.ExecArgs) error {
+	return nil
+}
+
+// buildFirecrackerConfig builds the microVM configuration from args and
+// ukernel. Used both to write the JSON config file (config-file-based boot)
+// and to drive the same configuration over the API socket (API-based boot),
+// so both paths always agree on what the guest actually gets configured
+// with.
+func buildFirecrackerConfig(args types.ExecArgs, ukernel types.Unikernel) *FirecrackerConfig {
 	// VM config for Firecracker
 	fcMem := DefaultMemory
 	if args.MemSizeB != 0 {
@@ -191,26 +221,96 @@ func (fc *Firecracker) BuildExecCmd(args types.ExecArgs, ukernel types.Unikernel
 		}
 	}
 
-	FCConfig := &FirecrackerConfig{
+	return &FirecrackerConfig{
 		Source:  FCSource,
 		Machine: FCMachine,
 		Drives:  FCDrives,
 		NetIfs:  FCNet,
 		VSock:   FCVSockDev,
 	}
-	FCConfigJSON, err := json.Marshal(FCConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal Firecracker config: %w", err)
-	}
-	if err = os.WriteFile(JSONConfigFile, FCConfigJSON, 0o644); err != nil { //nolint: gosec
-		return nil, fmt.Errorf("failed to save Firecracker json config: %w", err)
-	}
-	vmmLog.WithField("Json", string(FCConfigJSON)).Debug("Firecracker json config")
-
-	return exArgs, nil
 }
 
-// PreExec performs pre-execution setup. Firecracker has no special pre-exec requirements.
-func (fc *Firecracker) PreExec(_ types.ExecArgs) error {
-	return nil
+// RunSocketBoot starts Firecracker as a child process instead of replacing
+// the current process via exec. Since nothing here changes the process's
+// root (no SysProcAttr.Chroot is set), the child simply inherits whatever
+// confinement changeRoot already established on the caller earlier in Exec
+// (pivot_root or chroot, whichever the container spec calls for) - so it
+// ends up exactly as confined as the exec path would have made it, with no
+// separate confinement step needed here.
+//
+// It configures the guest over the API socket using the same config
+// BuildExecCmd would have written to a file, starts the guest, then
+// supervises the child until it exits: forwarding SIGTERM/SIGINT, and
+// exiting this process with the child's exit code once it's done, mirroring
+// the semantics syscall.Exec would have had.
+//
+// On success this function does not return: it calls os.Exit with the
+// child's exit status once the child exits. It returns an error only if
+// startup or configuration fails before the guest could ever run.
+func (fc *Firecracker) RunSocketBoot(args types.ExecArgs, ukernel types.Unikernel, execCmd []string) error {
+	cfg := buildFirecrackerConfig(args, ukernel)
+
+	cmd := exec.Command(execCmd[0], execCmd[1:]...) //nolint: gosec
+	cmd.Env = args.Environment
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start firecracker: %w", err)
+	}
+
+	socketPath := args.SocketPath
+	if socketPath == "" {
+		socketPath = filepath.Join("/tmp/", args.ContainerID+".sock")
+	}
+	client := newFirecrackerClient(socketPath)
+	ctx := context.Background()
+
+	if err := client.waitForSocket(5 * time.Second); err != nil {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+		return fmt.Errorf("firecracker socket never became ready: %w", err)
+	}
+	if err := client.configure(ctx, cfg); err != nil {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+		return fmt.Errorf("failed to configure firecracker over the socket: %w", err)
+	}
+	if err := client.startGuest(ctx); err != nil {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+		return fmt.Errorf("failed to start the guest: %w", err)
+	}
+
+	// Forward the signals containerd would send to stop the container.
+	// SIGKILL cannot be caught, so it is not listed here: if it arrives,
+	// this process dies immediately and the child is left running, a known
+	// gap for this bounded experiment, not yet handled.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+	go func() {
+		sig, ok := <-sigCh
+		if !ok {
+			return
+		}
+		if s, ok := sig.(syscall.Signal); ok {
+			_ = cmd.Process.Signal(s)
+		}
+	}()
+
+	waitErr := cmd.Wait()
+	signal.Stop(sigCh)
+	close(sigCh)
+
+	exitCode := 0
+	if waitErr != nil {
+		var exitErr *exec.ExitError
+		if errors.As(waitErr, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else {
+			vmmLog.WithError(waitErr).Error("firecracker exited with an unexpected error")
+			exitCode = 1
+		}
+	}
+	os.Exit(exitCode)
+	return nil // unreachable
 }

--- a/pkg/unikontainers/hypervisors/firecracker.go
+++ b/pkg/unikontainers/hypervisors/firecracker.go
@@ -256,6 +256,12 @@ func (fc *Firecracker) SpawnSocketVMM(args types.ExecArgs, uid, gid uint32) (*Fi
 	if socketPath == "" {
 		socketPath = filepath.Join("/tmp/", args.ContainerID+".sock")
 	}
+	// Firecracker binds this path itself; a stale socket file left from an
+	// earlier run (e.g. a crash) would make its bind fail with "address
+	// already in use", so remove any leftover first.
+	if err := os.Remove(socketPath); err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("failed to remove stale socket %q: %w", socketPath, err)
+	}
 	execCmd := []string{fc.Path(), "--api-sock", socketPath}
 	if !args.Seccomp {
 		execCmd = append(execCmd, "--no-seccomp")

--- a/pkg/unikontainers/hypervisors/firecracker.go
+++ b/pkg/unikontainers/hypervisors/firecracker.go
@@ -107,7 +107,10 @@ func (fc *Firecracker) BuildExecCmd(args types.ExecArgs, ukernel types.Unikernel
 	// options in FC, since the string return value of the Monitor related
 	// functions in the unikernel interface do not integrate well with FC's
 	// json configuration.
-	apiSockPath := filepath.Join("/tmp/", args.ContainerID+".sock")
+	apiSockPath := args.SocketPath
+	if apiSockPath == "" {
+		apiSockPath = filepath.Join("/tmp/", args.ContainerID+".sock")
+	}
 	exArgs := []string{fc.Path(), "--api-sock", apiSockPath}
 	JSONConfigFile := filepath.Join("/tmp/", FCJsonFilename)
 	if !args.Seccomp {

--- a/pkg/unikontainers/hypervisors/firecracker_client.go
+++ b/pkg/unikontainers/hypervisors/firecracker_client.go
@@ -31,10 +31,8 @@ import (
 // piece of configuration as soon as it becomes available.
 //
 // The client establishes a single connection in connect() and keeps it alive
-// for all requests. This matters because the caller may change its root
-// (pivot_root/chroot) between configuration stages: the socket path stops
-// being resolvable from the new root, but the already-open connection keeps
-// working, since open file descriptors survive a root change.
+// for all requests, so every configuration stage reuses the connection whose
+// readiness connect() already waited for, instead of re-dialing.
 //
 // This type is the API driver only; starting (and owning) the Firecracker
 // process is handled by the caller (see SpawnSocketVMM).
@@ -53,10 +51,8 @@ func newFirecrackerClient(socketPath string) *firecrackerClient {
 	c := &firecrackerClient{socketPath: socketPath}
 	transport := &http.Transport{
 		DialContext: c.dialContext,
-		// Keep the single connection alive for the whole staged boot: it is
-		// established before the caller may change root, and the socket path
-		// is not resolvable afterwards, so an idle close between stages
-		// would break every later stage.
+		// Keep the single connection alive for the whole staged boot so an
+		// idle close between stages does not force a re-dial.
 		IdleConnTimeout:     0,
 		MaxIdleConns:        1,
 		MaxIdleConnsPerHost: 1,
@@ -67,7 +63,7 @@ func newFirecrackerClient(socketPath string) *firecrackerClient {
 
 // dialContext hands the transport the connection pre-established by connect(),
 // and falls back to dialing the socket path directly if that connection was
-// already consumed (which only works while the path is still resolvable).
+// already consumed.
 func (c *firecrackerClient) dialContext(ctx context.Context, _, _ string) (net.Conn, error) {
 	c.dialMu.Lock()
 	defer c.dialMu.Unlock()

--- a/pkg/unikontainers/hypervisors/firecracker_client.go
+++ b/pkg/unikontainers/hypervisors/firecracker_client.go
@@ -26,15 +26,8 @@ import (
 	"time"
 )
 
-// firecrackerClient drives a running Firecracker process over its HTTP-over-Unix
-// API socket, one configuration resource at a time.
-//
-// The client establishes a single connection in connect() and keeps it alive
-// for all requests, so every configuration stage reuses the connection whose
-// readiness connect() already waited for, instead of re-dialing.
-//
-// This type is the API driver only; starting (and owning) the Firecracker
-// process is handled by the caller (see SpawnSocketVMM).
+// firecrackerClient drives a running Firecracker process over its HTTP API on
+// a unix socket. connect() opens one connection, and every request reuses it.
 type firecrackerClient struct {
 	socketPath string
 	httpClient *http.Client
@@ -43,15 +36,13 @@ type firecrackerClient struct {
 	heldConn net.Conn
 }
 
-// newFirecrackerClient returns a client that talks to the Firecracker API socket
-// at socketPath. "http://localhost/<endpoint>" requests actually travel over the
-// socket. Call connect() before issuing any request.
+// newFirecrackerClient returns a client for the API socket at socketPath.
+// Requests are addressed to "http://localhost" but travel over that socket.
 func newFirecrackerClient(socketPath string) *firecrackerClient {
 	c := &firecrackerClient{socketPath: socketPath}
 	transport := &http.Transport{
 		DialContext: c.dialContext,
-		// Keep the single connection alive for the whole staged boot so an
-		// idle close between stages does not force a re-dial.
+		// Keep the connection alive between stages, so no stage re-dials.
 		IdleConnTimeout:     0,
 		MaxIdleConns:        1,
 		MaxIdleConnsPerHost: 1,
@@ -60,9 +51,8 @@ func newFirecrackerClient(socketPath string) *firecrackerClient {
 	return c
 }
 
-// dialContext hands the transport the connection pre-established by connect(),
-// and falls back to dialing the socket path directly if that connection was
-// already consumed.
+// dialContext hands over the connection connect() made, or dials again if it
+// was already used.
 func (c *firecrackerClient) dialContext(ctx context.Context, _, _ string) (net.Conn, error) {
 	c.dialMu.Lock()
 	defer c.dialMu.Unlock()
@@ -75,10 +65,8 @@ func (c *firecrackerClient) dialContext(ctx context.Context, _, _ string) (net.C
 	return d.DialContext(ctx, "unix", c.socketPath)
 }
 
-// connect blocks until the Firecracker API socket exists and accepts
-// connections, or the timeout elapses. Firecracker creates the socket shortly
-// after it starts. The successful connection is kept and reused for all
-// requests (see the type comment for why).
+// connect blocks until the Firecracker API socket accepts connections, or the
+// timeout elapses. It keeps the connection for the requests that follow.
 func (c *firecrackerClient) connect(timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	var lastErr error
@@ -91,9 +79,7 @@ func (c *firecrackerClient) connect(timeout time.Duration) error {
 			return nil
 		}
 		lastErr = err
-		// Firecracker binds the socket within ~1ms of starting, so poll
-		// tightly: a 1ms interval captures nearly all of the readiness
-		// latency a coarser interval would waste, without busy-spinning.
+		// Firecracker binds the socket within about 1ms of starting.
 		time.Sleep(1 * time.Millisecond)
 	}
 	if lastErr == nil {
@@ -102,8 +88,6 @@ func (c *firecrackerClient) connect(timeout time.Duration) error {
 	return fmt.Errorf("firecracker API socket %q not ready within %s: %w", c.socketPath, timeout, lastErr)
 }
 
-// putMachineConfig configures vCPUs and memory. This needs nothing but the
-// container spec, so it can be sent as the very first stage.
 func (c *firecrackerClient) putMachineConfig(ctx context.Context, machine FirecrackerMachine) error {
 	return c.put(ctx, "/machine-config", machine)
 }
@@ -114,7 +98,6 @@ func (c *firecrackerClient) putNetworkIface(ctx context.Context, iface Firecrack
 	return c.put(ctx, "/network-interfaces/"+iface.IfaceID, iface)
 }
 
-// putDrives attaches the guest's block devices.
 func (c *firecrackerClient) putDrives(ctx context.Context, drives []FirecrackerDrive) error {
 	for _, drive := range drives {
 		if err := c.put(ctx, "/drives/"+drive.DriveID, drive); err != nil {
@@ -124,12 +107,10 @@ func (c *firecrackerClient) putDrives(ctx context.Context, drives []FirecrackerD
 	return nil
 }
 
-// putBootSource configures the kernel image, boot arguments and initrd.
 func (c *firecrackerClient) putBootSource(ctx context.Context, source FirecrackerBootSource) error {
 	return c.put(ctx, "/boot-source", source)
 }
 
-// putVSock configures the vsock device. No-op when unset (empty uds_path).
 func (c *firecrackerClient) putVSock(ctx context.Context, vsock FirecrackerVSockDev) error {
 	if vsock.UDSPath == "" {
 		return nil
@@ -137,14 +118,11 @@ func (c *firecrackerClient) putVSock(ctx context.Context, vsock FirecrackerVSock
 	return c.put(ctx, "/vsock", vsock)
 }
 
-// startGuest issues the InstanceStart action, which powers on the microVM and
-// boots the guest. Firecracker allows this to succeed only once.
+// startGuest boots the guest. Firecracker accepts this only once.
 func (c *firecrackerClient) startGuest(ctx context.Context) error {
 	return c.put(ctx, "/actions", map[string]string{"action_type": "InstanceStart"})
 }
 
-// put marshals body to JSON and sends it as an HTTP PUT to the given API path
-// over the Unix socket, returning an error for any non-2xx response.
 func (c *firecrackerClient) put(ctx context.Context, path string, body any) error {
 	payload, err := json.Marshal(body)
 	if err != nil {

--- a/pkg/unikontainers/hypervisors/firecracker_client.go
+++ b/pkg/unikontainers/hypervisors/firecracker_client.go
@@ -1,0 +1,132 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hypervisors
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"time"
+)
+
+// firecrackerClient drives a running Firecracker process over its HTTP-over-Unix
+// API socket: it waits for the socket, configures the microVM and starts the
+// guest.
+//
+// This type is the API driver only; starting (and owning) the Firecracker
+// process is handled by the caller (see RunSocketBoot).
+type firecrackerClient struct {
+	socketPath string
+	httpClient *http.Client
+}
+
+// newFirecrackerClient returns a client that talks to the Firecracker API socket
+// at socketPath. The HTTP transport dials that Unix socket for every request, so
+// "http://localhost/<endpoint>" requests actually travel over the socket.
+func newFirecrackerClient(socketPath string) *firecrackerClient {
+	transport := &http.Transport{
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			var d net.Dialer
+			return d.DialContext(ctx, "unix", socketPath)
+		},
+	}
+	return &firecrackerClient{
+		socketPath: socketPath,
+		httpClient: &http.Client{Transport: transport},
+	}
+}
+
+// waitForSocket blocks until the Firecracker API socket exists and accepts
+// connections, or the timeout elapses. Firecracker creates the socket shortly
+// after it starts, so the caller polls here before sending any configuration.
+func (c *firecrackerClient) waitForSocket(timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("unix", c.socketPath, 50*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return nil
+		}
+		lastErr = err
+		time.Sleep(10 * time.Millisecond)
+	}
+	if lastErr == nil {
+		lastErr = context.DeadlineExceeded
+	}
+	return fmt.Errorf("firecracker API socket %q not ready within %s: %w", c.socketPath, timeout, lastErr)
+}
+
+// configure sends the full microVM configuration over the API socket, in the
+// order Firecracker expects, before the guest is started.
+func (c *firecrackerClient) configure(ctx context.Context, cfg *FirecrackerConfig) error {
+	if err := c.put(ctx, "/machine-config", cfg.Machine); err != nil {
+		return err
+	}
+	if err := c.put(ctx, "/boot-source", cfg.Source); err != nil {
+		return err
+	}
+	for _, drive := range cfg.Drives {
+		if err := c.put(ctx, "/drives/"+drive.DriveID, drive); err != nil {
+			return err
+		}
+	}
+	for _, iface := range cfg.NetIfs {
+		if err := c.put(ctx, "/network-interfaces/"+iface.IfaceID, iface); err != nil {
+			return err
+		}
+	}
+	// vsock is only configured when vAccel-over-vsock is enabled (uds_path set).
+	if cfg.VSock.UDSPath != "" {
+		if err := c.put(ctx, "/vsock", cfg.VSock); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// startGuest issues the InstanceStart action, which powers on the microVM and
+// boots the guest. Firecracker allows this to succeed only once.
+func (c *firecrackerClient) startGuest(ctx context.Context) error {
+	return c.put(ctx, "/actions", map[string]string{"action_type": "InstanceStart"})
+}
+
+// put marshals body to JSON and sends it as an HTTP PUT to the given API path
+// over the Unix socket, returning an error for any non-2xx response.
+func (c *firecrackerClient) put(ctx context.Context, path string, body any) error {
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal %s request: %w", path, err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, "http://localhost"+path, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("build %s request: %w", path, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("send %s request: %w", path, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("%s returned HTTP %d: %s", path, resp.StatusCode, string(respBody))
+	}
+	return nil
+}

--- a/pkg/unikontainers/hypervisors/firecracker_client.go
+++ b/pkg/unikontainers/hypervisors/firecracker_client.go
@@ -22,46 +22,77 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"sync"
 	"time"
 )
 
 // firecrackerClient drives a running Firecracker process over its HTTP-over-Unix
-// API socket: it waits for the socket, configures the microVM and starts the
-// guest.
+// API socket, one configuration resource at a time, so the caller can send each
+// piece of configuration as soon as it becomes available.
+//
+// The client establishes a single connection in connect() and keeps it alive
+// for all requests. This matters because the caller may change its root
+// (pivot_root/chroot) between configuration stages: the socket path stops
+// being resolvable from the new root, but the already-open connection keeps
+// working, since open file descriptors survive a root change.
 //
 // This type is the API driver only; starting (and owning) the Firecracker
-// process is handled by the caller (see RunSocketBoot).
+// process is handled by the caller (see SpawnSocketVMM).
 type firecrackerClient struct {
 	socketPath string
 	httpClient *http.Client
+
+	dialMu   sync.Mutex
+	heldConn net.Conn
 }
 
 // newFirecrackerClient returns a client that talks to the Firecracker API socket
-// at socketPath. The HTTP transport dials that Unix socket for every request, so
-// "http://localhost/<endpoint>" requests actually travel over the socket.
+// at socketPath. "http://localhost/<endpoint>" requests actually travel over the
+// socket. Call connect() before issuing any request.
 func newFirecrackerClient(socketPath string) *firecrackerClient {
+	c := &firecrackerClient{socketPath: socketPath}
 	transport := &http.Transport{
-		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
-			var d net.Dialer
-			return d.DialContext(ctx, "unix", socketPath)
-		},
+		DialContext: c.dialContext,
+		// Keep the single connection alive for the whole staged boot: it is
+		// established before the caller may change root, and the socket path
+		// is not resolvable afterwards, so an idle close between stages
+		// would break every later stage.
+		IdleConnTimeout:     0,
+		MaxIdleConns:        1,
+		MaxIdleConnsPerHost: 1,
 	}
-	return &firecrackerClient{
-		socketPath: socketPath,
-		httpClient: &http.Client{Transport: transport},
-	}
+	c.httpClient = &http.Client{Transport: transport}
+	return c
 }
 
-// waitForSocket blocks until the Firecracker API socket exists and accepts
+// dialContext hands the transport the connection pre-established by connect(),
+// and falls back to dialing the socket path directly if that connection was
+// already consumed (which only works while the path is still resolvable).
+func (c *firecrackerClient) dialContext(ctx context.Context, _, _ string) (net.Conn, error) {
+	c.dialMu.Lock()
+	defer c.dialMu.Unlock()
+	if c.heldConn != nil {
+		conn := c.heldConn
+		c.heldConn = nil
+		return conn, nil
+	}
+	var d net.Dialer
+	return d.DialContext(ctx, "unix", c.socketPath)
+}
+
+// connect blocks until the Firecracker API socket exists and accepts
 // connections, or the timeout elapses. Firecracker creates the socket shortly
-// after it starts, so the caller polls here before sending any configuration.
-func (c *firecrackerClient) waitForSocket(timeout time.Duration) error {
+// after it starts. The successful connection is kept and reused for all
+// requests (see the type comment for why).
+func (c *firecrackerClient) connect(timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	var lastErr error
 	for time.Now().Before(deadline) {
 		conn, err := net.DialTimeout("unix", c.socketPath, 50*time.Millisecond)
 		if err == nil {
-			_ = conn.Close()
+			c.dialMu.Lock()
+			c.heldConn = conn
+			c.dialMu.Unlock()
 			return nil
 		}
 		lastErr = err
@@ -73,32 +104,39 @@ func (c *firecrackerClient) waitForSocket(timeout time.Duration) error {
 	return fmt.Errorf("firecracker API socket %q not ready within %s: %w", c.socketPath, timeout, lastErr)
 }
 
-// configure sends the full microVM configuration over the API socket, in the
-// order Firecracker expects, before the guest is started.
-func (c *firecrackerClient) configure(ctx context.Context, cfg *FirecrackerConfig) error {
-	if err := c.put(ctx, "/machine-config", cfg.Machine); err != nil {
-		return err
-	}
-	if err := c.put(ctx, "/boot-source", cfg.Source); err != nil {
-		return err
-	}
-	for _, drive := range cfg.Drives {
+// putMachineConfig configures vCPUs and memory. This needs nothing but the
+// container spec, so it can be sent as the very first stage.
+func (c *firecrackerClient) putMachineConfig(ctx context.Context, machine FirecrackerMachine) error {
+	return c.put(ctx, "/machine-config", machine)
+}
+
+// putNetworkIface attaches one network interface. Firecracker opens the tap
+// device during this call, so it must not be sent before the tap exists.
+func (c *firecrackerClient) putNetworkIface(ctx context.Context, iface FirecrackerNet) error {
+	return c.put(ctx, "/network-interfaces/"+iface.IfaceID, iface)
+}
+
+// putDrives attaches the guest's block devices.
+func (c *firecrackerClient) putDrives(ctx context.Context, drives []FirecrackerDrive) error {
+	for _, drive := range drives {
 		if err := c.put(ctx, "/drives/"+drive.DriveID, drive); err != nil {
 			return err
 		}
 	}
-	for _, iface := range cfg.NetIfs {
-		if err := c.put(ctx, "/network-interfaces/"+iface.IfaceID, iface); err != nil {
-			return err
-		}
-	}
-	// vsock is only configured when vAccel-over-vsock is enabled (uds_path set).
-	if cfg.VSock.UDSPath != "" {
-		if err := c.put(ctx, "/vsock", cfg.VSock); err != nil {
-			return err
-		}
-	}
 	return nil
+}
+
+// putBootSource configures the kernel image, boot arguments and initrd.
+func (c *firecrackerClient) putBootSource(ctx context.Context, source FirecrackerBootSource) error {
+	return c.put(ctx, "/boot-source", source)
+}
+
+// putVSock configures the vsock device. No-op when unset (empty uds_path).
+func (c *firecrackerClient) putVSock(ctx context.Context, vsock FirecrackerVSockDev) error {
+	if vsock.UDSPath == "" {
+		return nil
+	}
+	return c.put(ctx, "/vsock", vsock)
 }
 
 // startGuest issues the InstanceStart action, which powers on the microVM and

--- a/pkg/unikontainers/hypervisors/firecracker_client.go
+++ b/pkg/unikontainers/hypervisors/firecracker_client.go
@@ -27,8 +27,7 @@ import (
 )
 
 // firecrackerClient drives a running Firecracker process over its HTTP-over-Unix
-// API socket, one configuration resource at a time, so the caller can send each
-// piece of configuration as soon as it becomes available.
+// API socket, one configuration resource at a time.
 //
 // The client establishes a single connection in connect() and keeps it alive
 // for all requests, so every configuration stage reuses the connection whose

--- a/pkg/unikontainers/hypervisors/firecracker_client.go
+++ b/pkg/unikontainers/hypervisors/firecracker_client.go
@@ -96,7 +96,10 @@ func (c *firecrackerClient) connect(timeout time.Duration) error {
 			return nil
 		}
 		lastErr = err
-		time.Sleep(10 * time.Millisecond)
+		// Firecracker binds the socket within ~1ms of starting, so poll
+		// tightly: a 1ms interval captures nearly all of the readiness
+		// latency a coarser interval would waste, without busy-spinning.
+		time.Sleep(1 * time.Millisecond)
 	}
 	if lastErr == nil {
 		lastErr = context.DeadlineExceeded

--- a/pkg/unikontainers/hypervisors/firecracker_session_test.go
+++ b/pkg/unikontainers/hypervisors/firecracker_session_test.go
@@ -58,14 +58,17 @@ func startFakeFirecrackerAPI(t *testing.T) (*fakeFirecrackerAPI, string) {
 	}
 
 	api := &fakeFirecrackerAPI{}
-	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var body map[string]any
-		_ = json.NewDecoder(r.Body).Decode(&body)
-		api.mu.Lock()
-		api.requests = append(api.requests, recordedRequest{path: r.URL.Path, body: body})
-		api.mu.Unlock()
-		w.WriteHeader(http.StatusNoContent)
-	})}
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			api.mu.Lock()
+			api.requests = append(api.requests, recordedRequest{path: r.URL.Path, body: body})
+			api.mu.Unlock()
+			w.WriteHeader(http.StatusNoContent)
+		}),
+		ReadHeaderTimeout: time.Second,
+	}
 	go func() { _ = srv.Serve(ln) }()
 	t.Cleanup(func() { _ = srv.Close() })
 	return api, sockPath
@@ -90,7 +93,7 @@ func TestConfigureGuestSendsUnprefixedPaths(t *testing.T) {
 	session := newTestSession(t, sockPath)
 
 	args := types.ExecArgs{
-		ContainerID:   "testct",
+		ContainerID:   "test-container",
 		Command:       "app -arg",
 		UnikernelPath: "/unikernel/app.bin",
 		InitrdPath:    "/unikernel/initrd",
@@ -141,7 +144,7 @@ func TestSessionSendsStagesInOrder(t *testing.T) {
 	ctx := context.Background()
 
 	args := types.ExecArgs{
-		ContainerID:   "testct",
+		ContainerID:   "test-container",
 		Command:       "app",
 		UnikernelPath: "/unikernel/app.bin",
 		MemSizeB:      256 * 1024 * 1024,

--- a/pkg/unikontainers/hypervisors/firecracker_session_test.go
+++ b/pkg/unikontainers/hypervisors/firecracker_session_test.go
@@ -1,0 +1,179 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hypervisors
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
+)
+
+// recordedRequest is one PUT the fake Firecracker API received.
+type recordedRequest struct {
+	path string
+	body map[string]any
+}
+
+// fakeFirecrackerAPI records every request the client sends, in order.
+type fakeFirecrackerAPI struct {
+	mu       sync.Mutex
+	requests []recordedRequest
+}
+
+func (f *fakeFirecrackerAPI) recorded() []recordedRequest {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]recordedRequest, len(f.requests))
+	copy(out, f.requests)
+	return out
+}
+
+// startFakeFirecrackerAPI serves a fake Firecracker API on a Unix socket in a
+// temporary directory and returns the recorder plus the socket path.
+func startFakeFirecrackerAPI(t *testing.T) (*fakeFirecrackerAPI, string) {
+	t.Helper()
+	sockPath := filepath.Join(t.TempDir(), "fc.sock")
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("failed to listen on %s: %v", sockPath, err)
+	}
+
+	api := &fakeFirecrackerAPI{}
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		api.mu.Lock()
+		api.requests = append(api.requests, recordedRequest{path: r.URL.Path, body: body})
+		api.mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+	return api, sockPath
+}
+
+// newTestSession connects a client to the fake API and wraps it in a session.
+func newTestSession(t *testing.T, sockPath string) *FirecrackerSession {
+	t.Helper()
+	client := newFirecrackerClient(sockPath)
+	if err := client.connect(2 * time.Second); err != nil {
+		t.Fatalf("connect failed: %v", err)
+	}
+	return &FirecrackerSession{client: client}
+}
+
+// TestConfigureGuestSendsUnprefixedPaths verifies that the session sends the
+// kernel, initrd and drive paths exactly as given: the child runs inside the
+// monitor rootfs, so no path may be prefixed with a host-side rootfs
+// directory.
+func TestConfigureGuestSendsUnprefixedPaths(t *testing.T) {
+	api, sockPath := startFakeFirecrackerAPI(t)
+	session := newTestSession(t, sockPath)
+
+	args := types.ExecArgs{
+		ContainerID:   "testct",
+		Command:       "app -arg",
+		UnikernelPath: "/unikernel/app.bin",
+		InitrdPath:    "/unikernel/initrd",
+		MemSizeB:      256 * 1024 * 1024,
+		VCPUs:         1,
+	}
+	ukernel := &fakeUnikernel{
+		blockCli: []types.MonitorBlockArgs{
+			{ID: "rootfs", Path: "/dev/mapper/test-snap-1"},
+		},
+	}
+
+	if err := session.ConfigureGuest(context.Background(), args, ukernel); err != nil {
+		t.Fatalf("ConfigureGuest failed: %v", err)
+	}
+
+	reqs := api.recorded()
+	if len(reqs) != 2 {
+		t.Fatalf("expected 2 requests (drive, boot-source), got %d: %+v", len(reqs), reqs)
+	}
+
+	drive := reqs[0]
+	if drive.path != "/drives/rootfs" {
+		t.Errorf("expected first PUT to /drives/rootfs, got %s", drive.path)
+	}
+	if got := drive.body["path_on_host"]; got != "/dev/mapper/test-snap-1" {
+		t.Errorf("drive path_on_host = %v, want unprefixed /dev/mapper/test-snap-1", got)
+	}
+
+	boot := reqs[1]
+	if boot.path != "/boot-source" {
+		t.Errorf("expected second PUT to /boot-source, got %s", boot.path)
+	}
+	if got := boot.body["kernel_image_path"]; got != "/unikernel/app.bin" {
+		t.Errorf("kernel_image_path = %v, want unprefixed /unikernel/app.bin", got)
+	}
+	if got := boot.body["initrd_path"]; got != "/unikernel/initrd" {
+		t.Errorf("initrd_path = %v, want unprefixed /unikernel/initrd", got)
+	}
+}
+
+// TestSessionSendsStagesInOrder verifies the full post-pivot sequence lands on
+// the API in the order Firecracker requires: machine-config, network
+// interface, boot source, and InstanceStart last.
+func TestSessionSendsStagesInOrder(t *testing.T) {
+	api, sockPath := startFakeFirecrackerAPI(t)
+	session := newTestSession(t, sockPath)
+	ctx := context.Background()
+
+	args := types.ExecArgs{
+		ContainerID:   "testct",
+		Command:       "app",
+		UnikernelPath: "/unikernel/app.bin",
+		MemSizeB:      256 * 1024 * 1024,
+		VCPUs:         1,
+	}
+	if err := session.ConfigureMachine(ctx, args); err != nil {
+		t.Fatalf("ConfigureMachine failed: %v", err)
+	}
+	netParams := types.NetDevParams{TapDev: "tap0", MAC: "aa:bb:cc:dd:ee:ff"}
+	if err := session.ConfigureNetwork(ctx, netParams); err != nil {
+		t.Fatalf("ConfigureNetwork failed: %v", err)
+	}
+	if err := session.ConfigureGuest(ctx, args, &fakeUnikernel{}); err != nil {
+		t.Fatalf("ConfigureGuest failed: %v", err)
+	}
+	if err := session.StartGuest(ctx); err != nil {
+		t.Fatalf("StartGuest failed: %v", err)
+	}
+
+	want := []string{
+		"/machine-config",
+		"/network-interfaces/net1",
+		"/boot-source",
+		"/actions",
+	}
+	reqs := api.recorded()
+	if len(reqs) != len(want) {
+		t.Fatalf("expected %d requests, got %d: %+v", len(want), len(reqs), reqs)
+	}
+	for i, w := range want {
+		if reqs[i].path != w {
+			t.Errorf("request %d: got %s, want %s", i, reqs[i].path, w)
+		}
+	}
+}

--- a/pkg/unikontainers/hypervisors/firecracker_session_test.go
+++ b/pkg/unikontainers/hypervisors/firecracker_session_test.go
@@ -135,6 +135,43 @@ func TestConfigureGuestSendsUnprefixedPaths(t *testing.T) {
 	}
 }
 
+// TestConfigureGuestSendsUnprefixedVSockPath verifies the vsock device, when
+// enabled, is sent with its socket path exactly as given, with no rootfs
+// prefixing, and after the boot source.
+func TestConfigureGuestSendsUnprefixedVSockPath(t *testing.T) {
+	api, sockPath := startFakeFirecrackerAPI(t)
+	session := newTestSession(t, sockPath)
+
+	args := types.ExecArgs{
+		ContainerID:   "test-container",
+		Command:       "app",
+		UnikernelPath: "/unikernel/app.bin",
+		MemSizeB:      256 * 1024 * 1024,
+		VCPUs:         1,
+		VAccelType:    "vsock",
+		VSockDevPath:  "/tmp/vaccel",
+		VSockDevID:    3,
+	}
+	if err := session.ConfigureGuest(context.Background(), args, &fakeUnikernel{}); err != nil {
+		t.Fatalf("ConfigureGuest failed: %v", err)
+	}
+
+	reqs := api.recorded()
+	if len(reqs) != 2 {
+		t.Fatalf("expected 2 requests (boot-source, vsock), got %d: %+v", len(reqs), reqs)
+	}
+	vsock := reqs[1]
+	if vsock.path != "/vsock" {
+		t.Errorf("expected last PUT to /vsock, got %s", vsock.path)
+	}
+	if got := vsock.body["uds_path"]; got != "/tmp/vaccel/vaccel.sock" {
+		t.Errorf("uds_path = %v, want unprefixed /tmp/vaccel/vaccel.sock", got)
+	}
+	if got := vsock.body["guest_cid"]; got != float64(3) {
+		t.Errorf("guest_cid = %v, want 3", got)
+	}
+}
+
 // TestSessionSendsStagesInOrder verifies the full post-pivot sequence lands on
 // the API in the order Firecracker requires: machine-config, network
 // interface, boot source, and InstanceStart last.

--- a/pkg/unikontainers/hypervisors/utils.go
+++ b/pkg/unikontainers/hypervisors/utils.go
@@ -66,9 +66,6 @@ func BytesToStringMB(argMem uint64) string {
 // no socket_path is configured. It always exists inside the monitor rootfs.
 const DefaultSocketDir = "/tmp"
 
-// ResolveSocketPath returns the path for a monitor's control socket: the
-// configured SocketPath when set, otherwise a per-container default under
-// DefaultSocketDir.
 func ResolveSocketPath(args types.ExecArgs) string {
 	if args.SocketPath != "" {
 		return args.SocketPath

--- a/pkg/unikontainers/hypervisors/utils.go
+++ b/pkg/unikontainers/hypervisors/utils.go
@@ -17,11 +17,14 @@ package hypervisors
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"time"
 
 	"golang.org/x/sys/unix"
+
+	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
 )
 
 func cpuArch() string {
@@ -57,6 +60,20 @@ func BytesToStringMB(argMem uint64) string {
 	}
 
 	return stringMem
+}
+
+// DefaultSocketDir is the directory used for a monitor's control socket when
+// no socket_path is configured. It always exists inside the monitor rootfs.
+const DefaultSocketDir = "/tmp"
+
+// ResolveSocketPath returns the path for a monitor's control socket: the
+// configured SocketPath when set, otherwise a per-container default under
+// DefaultSocketDir.
+func ResolveSocketPath(args types.ExecArgs) string {
+	if args.SocketPath != "" {
+		return args.SocketPath
+	}
+	return filepath.Join(DefaultSocketDir, args.ContainerID+".sock")
 }
 
 func killProcess(pid int) error {

--- a/pkg/unikontainers/hypervisors/utils_test.go
+++ b/pkg/unikontainers/hypervisors/utils_test.go
@@ -18,7 +18,19 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
 )
+
+func TestResolveSocketPath(t *testing.T) {
+	t.Parallel()
+	if got := ResolveSocketPath(types.ExecArgs{SocketPath: "/run/urunc/x.sock"}); got != "/run/urunc/x.sock" {
+		t.Fatalf("configured path: got %q", got)
+	}
+	if got := ResolveSocketPath(types.ExecArgs{ContainerID: "abc"}); got != "/tmp/abc.sock" {
+		t.Fatalf("default path: got %q", got)
+	}
+}
 
 func TestBytesToMiB(t *testing.T) {
 	t.Parallel()

--- a/pkg/unikontainers/hypervisors/vmm.go
+++ b/pkg/unikontainers/hypervisors/vmm.go
@@ -27,6 +27,17 @@ const DefaultMemory uint64 = 256 // The default memory for every hypervisor: 256
 
 type VmmType string
 
+// UsesControlSocket reports whether a monitor exposes a control socket whose
+// path (socket_path) urunc must make reachable before the monitor launches.
+func UsesControlSocket(vmmType VmmType) bool {
+	switch vmmType {
+	case FirecrackerVmm:
+		return true
+	default:
+		return false
+	}
+}
+
 var ErrVMMNotInstalled = errors.New("vmm not found")
 var vmmLog = logrus.WithField("subsystem", "monitors")
 

--- a/pkg/unikontainers/hypervisors/vmm_test.go
+++ b/pkg/unikontainers/hypervisors/vmm_test.go
@@ -69,3 +69,13 @@ func TestVMMFactoryNonQemuIgnoresVhost(t *testing.T) {
 	_, ok = vmm.(*Firecracker)
 	assert.True(t, ok, "factory should return *Firecracker")
 }
+
+func TestUsesControlSocket(t *testing.T) {
+	t.Parallel()
+	if !UsesControlSocket(FirecrackerVmm) {
+		t.Fatal("firecracker should use a control socket")
+	}
+	if UsesControlSocket(HvtVmm) {
+		t.Fatal("hvt should not use a control socket")
+	}
+}

--- a/pkg/unikontainers/types/types.go
+++ b/pkg/unikontainers/types/types.go
@@ -106,6 +106,7 @@ type UnikernelParams struct {
 type ExecArgs struct {
 	ContainerID   string   // The container ID
 	SocketPath    string   // Optional user-configured path for the monitor's control socket. Empty means the monitor uses its default.
+	BootMode      string   // "api" (default) drives the monitor over its control socket. "config-file" lets the monitor boot itself from a config file, socket only for later use.
 	Environment   []string // The environment variables of the monitor
 	Command       string   // The unikernel's command line
 	Seccomp       bool     // Enable or disable seccomp filters for the VMM
@@ -147,4 +148,5 @@ type MonitorConfig struct {
 	DataPath        string `toml:"data_path,omitempty"`   // Optional path to the hypervisor data files (e.g. qemu bios stuff)
 	Vhost           bool   `toml:"vhost,omitempty"`       // Optional: enable vhost for network performance optimization
 	SocketPath      string `toml:"socket_path,omitempty"` // Optional path for the monitor's control socket. If not specified, the monitor uses its default.
+	BootMode        string `toml:"boot_mode,omitempty"`   // Optional: "api" (default) or "config-file". Currently only used by Firecracker.
 }

--- a/pkg/unikontainers/types/types.go
+++ b/pkg/unikontainers/types/types.go
@@ -105,6 +105,7 @@ type UnikernelParams struct {
 // FIXME: add extra fields if required by additional VMM's
 type ExecArgs struct {
 	ContainerID   string   // The container ID
+	SocketPath    string   // Optional user-configured path for the monitor's control socket. Empty means the monitor uses its default.
 	Environment   []string // The environment variables of the monitor
 	Command       string   // The unikernel's command line
 	Seccomp       bool     // Enable or disable seccomp filters for the VMM
@@ -142,7 +143,8 @@ type ExtraBinConfig struct {
 type MonitorConfig struct {
 	DefaultMemoryMB uint   `toml:"default_memory_mb"`
 	DefaultVCPUs    uint   `toml:"default_vcpus"`
-	BinaryPath      string `toml:"path,omitempty"`      // Optional path to the hypervisor binary
-	DataPath        string `toml:"data_path,omitempty"` // Optional path to the hypervisor data files (e.g. qemu bios stuff)
-	Vhost           bool   `toml:"vhost,omitempty"`     // Optional: enable vhost for network performance optimization
+	BinaryPath      string `toml:"path,omitempty"`        // Optional path to the hypervisor binary
+	DataPath        string `toml:"data_path,omitempty"`   // Optional path to the hypervisor data files (e.g. qemu bios stuff)
+	Vhost           bool   `toml:"vhost,omitempty"`       // Optional: enable vhost for network performance optimization
+	SocketPath      string `toml:"socket_path,omitempty"` // Optional path for the monitor's control socket. If not specified, the monitor uses its default.
 }

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -314,6 +314,19 @@ func SetupNet(networkType string, uid, gid uint32) (types.NetDevParams, error) {
 	return netArgs, nil
 }
 
+// HasNetwork does a cheap check for whether this container has a network
+// interface to configure, without doing the more expensive tap device
+// creation and configuration that SetupNet does. It exists so callers can
+// learn this fact early, while the full SetupNet runs concurrently.
+func (u *Unikontainer) HasNetwork() (bool, error) {
+	networkType := u.getNetworkType()
+	netManager, err := network.NewNetworkManager(networkType)
+	if err != nil {
+		return false, fmt.Errorf("failed to create network manager for %s type: %v", networkType, err)
+	}
+	return netManager.HasNetwork()
+}
+
 // chooseRootfs determines the best rootfs configuration based on available options
 // Priority order:
 //  1. Initrd (if specified)
@@ -639,23 +652,67 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 	}
 
 	// handle network
-	netArgs, err := SetupNet(u.getNetworkType(), u.Spec.Process.User.UID, u.Spec.Process.User.GID)
-	if err != nil {
-		uniklog.Errorf("failed to setup network: %v", err)
-		return err
+	//
+	// For Firecracker's API-based boot mode, the monitor rootfs setup below
+	// only needs the cheap "does this container have a network interface"
+	// fact, not the fully finished network setup - the expensive part
+	// (creating the tap device, TC rules, fetching interface info) doesn't
+	// need to block it. So in that case we run the real SetupNet
+	// concurrently with the rootfs setup, and only wait for it once we
+	// actually need the resolved IP/gateway/MAC - which is right before
+	// buildUnikernelCommand, since every supported unikernel type bakes the
+	// resolved network info into the guest's boot command line. For every
+	// other case, this stays exactly as sequential as before.
+	isAPIBoot := ms.MonitorType == string(hypervisors.FirecrackerVmm) && vmmArgs.BootMode != "config-file"
+
+	var netArgs types.NetDevParams
+	var netSetupErr error
+	var netWG sync.WaitGroup
+	var withTUNTAP bool
+
+	if isAPIBoot {
+		hasNet, err := u.HasNetwork()
+		if err != nil {
+			uniklog.Errorf("failed to check for a container network: %v", err)
+			return err
+		}
+		withTUNTAP = hasNet
+		netWG.Add(1)
+		go func() {
+			defer netWG.Done()
+			netArgs, netSetupErr = SetupNet(u.getNetworkType(), u.Spec.Process.User.UID, u.Spec.Process.User.GID)
+		}()
+	} else {
+		netArgs, err = SetupNet(u.getNetworkType(), u.Spec.Process.User.UID, u.Spec.Process.User.GID)
+		if err != nil {
+			uniklog.Errorf("failed to setup network: %v", err)
+			return err
+		}
+		withTUNTAP = netArgs.IP != ""
 	}
 	metrics.Capture(m.TS16)
-	withTUNTAP := netArgs.IP != ""
-	// SetupNet does not resolve DNS; carry the server resolved at spec build.
-	netArgs.DNSServer = ms.DNSServer
-	unikernelParams.Net = netArgs
-	vmmArgs.Net = netArgs
 
 	err = u.setupMonitorRootfs(rootfsParams.MonRootfs, monRes, withTUNTAP)
 	if err != nil {
 		return err
 	}
 	metrics.Capture(m.TS17)
+
+	// If network setup is still running concurrently (isAPIBoot), this is
+	// where we actually need its result: every supported unikernel type
+	// bakes the resolved IP/gateway/MAC into the guest's boot command line
+	// inside buildUnikernelCommand below.
+	if isAPIBoot {
+		netWG.Wait()
+		if netSetupErr != nil {
+			uniklog.Errorf("failed to setup network: %v", netSetupErr)
+			return netSetupErr
+		}
+	}
+	// SetupNet does not resolve DNS; carry the server resolved at spec build.
+	netArgs.DNSServer = ms.DNSServer
+	unikernelParams.Net = netArgs
+	vmmArgs.Net = netArgs
 
 	// vAccel setup
 	vAccelType, vAccelSocketPath, rpcAddress, err := resolveVAccelConfig(u.State.Annotations[annotHypervisor], u.State.Annotations)
@@ -764,6 +821,16 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 	err = u.SendMessage(StartSuccess)
 	if err != nil {
 		return err
+	}
+
+	if isAPIBoot {
+		fc, ok := vmm.(*hypervisors.Firecracker)
+		if !ok {
+			return fmt.Errorf("boot_mode=api is only supported for the firecracker monitor")
+		}
+		metrics.Capture(m.TS18)
+		uniklog.WithField("command", execCmd).Debug("Starting Firecracker as a supervised child, driving it over its control socket")
+		return fc.RunSocketBoot(vmmArgs, unikernel, execCmd)
 	}
 
 	return execMonitor(metrics, vmm, vmmArgs, execCmd)

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -511,10 +511,12 @@ func (u *Unikontainer) buildMonitorSpec(rootfsParams types.RootfsParams, monRes 
 	}
 	defaultMemSizeMB := u.UruncCfg.Monitors[vmmType].DefaultMemoryMB
 	socketPath := u.UruncCfg.Monitors[vmmType].SocketPath
+	bootMode := u.UruncCfg.Monitors[vmmType].BootMode
 
 	vmmArgs := types.ExecArgs{
 		ContainerID:   u.State.ID,
 		SocketPath:    socketPath,
+		BootMode:      bootMode,
 		UnikernelPath: unikernelPath,
 		InitrdPath:    initrdPath,
 		Seccomp:       true, // Enable Seccomp by default

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -693,6 +693,9 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 		if !ok {
 			return fmt.Errorf("boot_mode=api is only supported for the firecracker monitor")
 		}
+		if err = ensureSocketDir(ms.MonitorType, vmmArgs); err != nil {
+			return err
+		}
 		fcSession, err = fc.SpawnSocketVMM(vmmArgs, u.Spec.Process.User.UID, u.Spec.Process.User.GID)
 		if err != nil {
 			uniklog.Errorf("failed to spawn firecracker: %v", err)
@@ -830,6 +833,12 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 	vmmArgs.Command, err = buildUnikernelCommand(unikernel, unikernelParams)
 	if err != nil {
 		return err
+	}
+
+	if !isAPIBoot {
+		if err = ensureSocketDir(ms.MonitorType, vmmArgs); err != nil {
+			return err
+		}
 	}
 
 	// uid/gid
@@ -970,6 +979,22 @@ func execMonitor(metrics m.Writer, vmm types.VMM, execArgs types.ExecArgs, execC
 	// Execute the VMM using the command we built earlier.
 	uniklog.WithField("command", execCmd).Debug("Ready to execve VMM")
 	return syscall.Exec(vmm.Path(), execCmd, execArgs.Environment) //nolint: gosec
+}
+
+// ensureSocketDir creates the directory of the monitor's control socket so the
+// monitor can bind its socket there. For a custom socket_path this may be a
+// directory that does not exist yet; MkdirAll fails only if the location is
+// invalid (e.g. a file already exists on the path). No-op for monitors without
+// a control socket.
+func ensureSocketDir(vmmType string, vmmArgs types.ExecArgs) error {
+	if !hypervisors.UsesControlSocket(hypervisors.VmmType(vmmType)) {
+		return nil
+	}
+	sockDir := filepath.Dir(hypervisors.ResolveSocketPath(vmmArgs))
+	if err := os.MkdirAll(sockDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create control socket directory %q: %w", sockDir, err)
+	}
+	return nil
 }
 
 func setupUser(user specs.User) error {

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -654,14 +654,12 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 
 	// handle network
 	//
-	// For Firecracker's API-based boot mode, the VMM is spawned right here,
-	// before any of the expensive setup work, and configured in stages while
-	// that work runs: machine-config immediately (it needs nothing but the
-	// spec), the network interface as soon as network setup finishes, and
-	// everything unikernel-dependent (drives, boot source) right after the
-	// guest command is built. The guest itself is only started
-	// (InstanceStart) after the start-success handshake, preserving OCI start
-	// ordering.
+	// For Firecracker's API-based boot mode, the VMM is spawned right after
+	// changeRoot below, so the monitor and its control socket are confined
+	// inside the monitor rootfs, exactly like the exec path. Everything the
+	// VMM needs to be told is known by that point, so its configuration is
+	// sent over the socket in one sequence; only InstanceStart waits for
+	// the start-success handshake, preserving OCI start ordering.
 	//
 	// The monitor rootfs setup below only needs the cheap "does this
 	// container have a network interface" fact, not the fully finished
@@ -688,23 +686,13 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 	}()
 	ctx := context.Background()
 
+	var fcVmm *hypervisors.Firecracker
 	if isAPIBoot {
 		fc, ok := vmm.(*hypervisors.Firecracker)
 		if !ok {
 			return fmt.Errorf("boot_mode=api is only supported for the firecracker monitor")
 		}
-		if err = ensureSocketDir(ms.MonitorType, vmmArgs); err != nil {
-			return err
-		}
-		fcSession, err = fc.SpawnSocketVMM(vmmArgs, u.Spec.Process.User.UID, u.Spec.Process.User.GID)
-		if err != nil {
-			uniklog.Errorf("failed to spawn firecracker: %v", err)
-			return err
-		}
-		if err = fcSession.ConfigureMachine(ctx, vmmArgs); err != nil {
-			uniklog.Errorf("failed to configure the machine over the socket: %v", err)
-			return err
-		}
+		fcVmm = fc
 
 		hasNet, err := u.HasNetwork()
 		if err != nil {
@@ -736,17 +724,12 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 	// If network setup is still running concurrently (isAPIBoot), this is
 	// where we actually need its result: every supported unikernel type
 	// bakes the resolved IP/gateway/MAC into the guest's boot command line
-	// inside buildUnikernelCommand below. The tap device exists from this
-	// point on, so the network interface is also sent to the VMM right away.
+	// inside buildUnikernelCommand below.
 	if isAPIBoot {
 		netWG.Wait()
 		if netSetupErr != nil {
 			uniklog.Errorf("failed to setup network: %v", netSetupErr)
 			return netSetupErr
-		}
-		if err = fcSession.ConfigureNetwork(ctx, netArgs); err != nil {
-			uniklog.Errorf("failed to configure the network over the socket: %v", err)
-			return err
 		}
 	}
 	// SetupNet does not resolve DNS; carry the server resolved at spec build.
@@ -783,16 +766,6 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 		vmmArgs.VAccelType = vAccelType
 		vmmArgs.VSockDevPath = vAccelMountPath
 		vmmArgs.VSockDevID = idToGuestCID(u.State.ID)
-	}
-
-	// Everything unikernel-dependent is known now, so it goes to the VMM
-	// before changeRoot below: the child kept the pre-pivot mount view, so
-	// ConfigureGuest prefixes the monitor rootfs onto the paths it sends.
-	if isAPIBoot {
-		if err = fcSession.ConfigureGuest(ctx, vmmArgs, unikernel, rootfsParams.MonRootfs); err != nil {
-			uniklog.Errorf("failed to configure the guest over the socket: %v", err)
-			return err
-		}
 	}
 
 	// pivot
@@ -835,8 +808,32 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 		return err
 	}
 
-	if !isAPIBoot {
-		if err = ensureSocketDir(ms.MonitorType, vmmArgs); err != nil {
+	if err = ensureSocketDir(ms.MonitorType, vmmArgs); err != nil {
+		return err
+	}
+
+	// For the API-based boot the monitor is spawned here, after changeRoot,
+	// so the child inherits the pivoted root: its control socket and every
+	// path it opens (kernel, initrd, drives, vsock) resolve inside the
+	// monitor rootfs. urunc is still privileged at this point — the child
+	// is started directly under the container user's credentials, and urunc
+	// drops its own privileges right after (setupUser below).
+	if isAPIBoot {
+		fcSession, err = fcVmm.SpawnSocketVMM(vmmArgs, u.Spec.Process.User.UID, u.Spec.Process.User.GID)
+		if err != nil {
+			uniklog.Errorf("failed to spawn firecracker: %v", err)
+			return err
+		}
+		if err = fcSession.ConfigureMachine(ctx, vmmArgs); err != nil {
+			uniklog.Errorf("failed to configure the machine over the socket: %v", err)
+			return err
+		}
+		if err = fcSession.ConfigureNetwork(ctx, netArgs); err != nil {
+			uniklog.Errorf("failed to configure the network over the socket: %v", err)
+			return err
+		}
+		if err = fcSession.ConfigureGuest(ctx, vmmArgs, unikernel); err != nil {
+			uniklog.Errorf("failed to configure the guest over the socket: %v", err)
 			return err
 		}
 	}

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -315,10 +315,6 @@ func SetupNet(networkType string, uid, gid uint32) (types.NetDevParams, error) {
 	return netArgs, nil
 }
 
-// HasNetwork does a cheap check for whether this container has a network
-// interface to configure, without doing the more expensive tap device
-// creation and configuration that SetupNet does. It exists so callers can
-// learn this fact early, while the full SetupNet runs concurrently.
 func (u *Unikontainer) HasNetwork() (bool, error) {
 	networkType := u.getNetworkType()
 	netManager, err := network.NewNetworkManager(networkType)
@@ -654,19 +650,8 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 
 	// handle network
 	//
-	// For Firecracker's API-based boot mode, the VMM is spawned right after
-	// changeRoot below, so the monitor and its control socket are confined
-	// inside the monitor rootfs, exactly like the exec path. Everything the
-	// VMM needs to be told is known by that point, so its configuration is
-	// sent over the socket in one sequence; only InstanceStart waits for
-	// the start-success handshake, preserving OCI start ordering.
-	//
-	// The monitor rootfs setup below only needs the cheap "does this
-	// container have a network interface" fact, not the fully finished
-	// network setup, so the real SetupNet runs concurrently with it, joined
-	// right before buildUnikernelCommand, since every supported unikernel
-	// type bakes the resolved IP/gateway/MAC into the guest's boot command
-	// line. For every other case, this stays exactly as sequential as before.
+	// In api boot mode, SetupNet runs concurrently with the rootfs prep below,
+	// which only needs to know whether a network interface exists.
 	isAPIBoot := ms.MonitorType == string(hypervisors.FirecrackerVmm) && vmmArgs.BootMode != "config-file"
 
 	var netArgs types.NetDevParams
@@ -677,9 +662,8 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 	var fcSession *hypervisors.FirecrackerSession
 	fcHandedOff := false
 	defer func() {
-		// Any error return after the spawn must not leave the VMM child
-		// behind. Supervise never returns (os.Exit), so this only fires on
-		// error paths.
+		// Supervise never returns, so this only runs when Exec fails after
+		// the spawn.
 		if fcSession != nil && !fcHandedOff {
 			fcSession.Kill()
 		}
@@ -721,10 +705,8 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 	}
 	metrics.Capture(m.TS17)
 
-	// If network setup is still running concurrently (isAPIBoot), this is
-	// where we actually need its result: every supported unikernel type
-	// bakes the resolved IP/gateway/MAC into the guest's boot command line
-	// inside buildUnikernelCommand below.
+	// buildUnikernelCommand below bakes the resolved IP, gateway and MAC into
+	// the guest command line, so the concurrent network setup must be finished.
 	if isAPIBoot {
 		netWG.Wait()
 		if netSetupErr != nil {
@@ -812,12 +794,6 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 		return err
 	}
 
-	// For the API-based boot the monitor is spawned here, after changeRoot,
-	// so the child inherits the pivoted root: its control socket and every
-	// path it opens (kernel, initrd, drives, vsock) resolve inside the
-	// monitor rootfs. urunc is still privileged at this point; the child
-	// is started directly under the container user's credentials, and urunc
-	// drops its own privileges right after (setupUser below).
 	if isAPIBoot {
 		fcSession, err = fcVmm.SpawnSocketVMM(vmmArgs, u.Spec.Process.User.UID, u.Spec.Process.User.GID)
 		if err != nil {
@@ -882,9 +858,6 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 	}
 
 	if isAPIBoot {
-		// The VMM is configured; boot the guest and hand this process over
-		// to supervising the child. This process must not exit before the
-		// child, since it is the container's init process.
 		metrics.Capture(m.TS18)
 		if err = fcSession.StartGuest(ctx); err != nil {
 			uniklog.Errorf("failed to start the guest: %v", err)
@@ -978,11 +951,6 @@ func execMonitor(metrics m.Writer, vmm types.VMM, execArgs types.ExecArgs, execC
 	return syscall.Exec(vmm.Path(), execCmd, execArgs.Environment) //nolint: gosec
 }
 
-// ensureSocketDir creates the directory of the monitor's control socket so the
-// monitor can bind its socket there. For a custom socket_path this may be a
-// directory that does not exist yet; MkdirAll fails only if the location is
-// invalid (e.g. a file already exists on the path). No-op for monitors without
-// a control socket.
 func ensureSocketDir(vmmType string, vmmArgs types.ExecArgs) error {
 	if !hypervisors.UsesControlSocket(hypervisors.VmmType(vmmType)) {
 		return nil

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -16,6 +16,7 @@ package unikontainers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -653,16 +654,21 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 
 	// handle network
 	//
-	// For Firecracker's API-based boot mode, the monitor rootfs setup below
-	// only needs the cheap "does this container have a network interface"
-	// fact, not the fully finished network setup - the expensive part
-	// (creating the tap device, TC rules, fetching interface info) doesn't
-	// need to block it. So in that case we run the real SetupNet
-	// concurrently with the rootfs setup, and only wait for it once we
-	// actually need the resolved IP/gateway/MAC - which is right before
-	// buildUnikernelCommand, since every supported unikernel type bakes the
-	// resolved network info into the guest's boot command line. For every
-	// other case, this stays exactly as sequential as before.
+	// For Firecracker's API-based boot mode, the VMM is spawned right here,
+	// before any of the expensive setup work, and configured in stages while
+	// that work runs: machine-config immediately (it needs nothing but the
+	// spec), the network interface as soon as network setup finishes, and
+	// everything unikernel-dependent (drives, boot source) right after the
+	// guest command is built. The guest itself is only started
+	// (InstanceStart) after the start-success handshake, preserving OCI start
+	// ordering.
+	//
+	// The monitor rootfs setup below only needs the cheap "does this
+	// container have a network interface" fact, not the fully finished
+	// network setup, so the real SetupNet runs concurrently with it, joined
+	// right before buildUnikernelCommand, since every supported unikernel
+	// type bakes the resolved IP/gateway/MAC into the guest's boot command
+	// line. For every other case, this stays exactly as sequential as before.
 	isAPIBoot := ms.MonitorType == string(hypervisors.FirecrackerVmm) && vmmArgs.BootMode != "config-file"
 
 	var netArgs types.NetDevParams
@@ -670,7 +676,33 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 	var netWG sync.WaitGroup
 	var withTUNTAP bool
 
+	var fcSession *hypervisors.FirecrackerSession
+	fcHandedOff := false
+	defer func() {
+		// Any error return after the spawn must not leave the VMM child
+		// behind. Supervise never returns (os.Exit), so this only fires on
+		// error paths.
+		if fcSession != nil && !fcHandedOff {
+			fcSession.Kill()
+		}
+	}()
+	ctx := context.Background()
+
 	if isAPIBoot {
+		fc, ok := vmm.(*hypervisors.Firecracker)
+		if !ok {
+			return fmt.Errorf("boot_mode=api is only supported for the firecracker monitor")
+		}
+		fcSession, err = fc.SpawnSocketVMM(vmmArgs, u.Spec.Process.User.UID, u.Spec.Process.User.GID)
+		if err != nil {
+			uniklog.Errorf("failed to spawn firecracker: %v", err)
+			return err
+		}
+		if err = fcSession.ConfigureMachine(ctx, vmmArgs); err != nil {
+			uniklog.Errorf("failed to configure the machine over the socket: %v", err)
+			return err
+		}
+
 		hasNet, err := u.HasNetwork()
 		if err != nil {
 			uniklog.Errorf("failed to check for a container network: %v", err)
@@ -701,12 +733,17 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 	// If network setup is still running concurrently (isAPIBoot), this is
 	// where we actually need its result: every supported unikernel type
 	// bakes the resolved IP/gateway/MAC into the guest's boot command line
-	// inside buildUnikernelCommand below.
+	// inside buildUnikernelCommand below. The tap device exists from this
+	// point on, so the network interface is also sent to the VMM right away.
 	if isAPIBoot {
 		netWG.Wait()
 		if netSetupErr != nil {
 			uniklog.Errorf("failed to setup network: %v", netSetupErr)
 			return netSetupErr
+		}
+		if err = fcSession.ConfigureNetwork(ctx, netArgs); err != nil {
+			uniklog.Errorf("failed to configure the network over the socket: %v", err)
+			return err
 		}
 	}
 	// SetupNet does not resolve DNS; carry the server resolved at spec build.
@@ -743,6 +780,16 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 		vmmArgs.VAccelType = vAccelType
 		vmmArgs.VSockDevPath = vAccelMountPath
 		vmmArgs.VSockDevID = idToGuestCID(u.State.ID)
+	}
+
+	// Everything unikernel-dependent is known now, so it goes to the VMM
+	// before changeRoot below: the child kept the pre-pivot mount view, so
+	// ConfigureGuest prefixes the monitor rootfs onto the paths it sends.
+	if isAPIBoot {
+		if err = fcSession.ConfigureGuest(ctx, vmmArgs, unikernel, rootfsParams.MonRootfs); err != nil {
+			uniklog.Errorf("failed to configure the guest over the socket: %v", err)
+			return err
+		}
 	}
 
 	// pivot
@@ -810,10 +857,15 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 
 	// Build the VMM command once and verify it can be constructed successfully, so
 	// we do not report the container as started if command building fails.
-	execCmd, err := vmm.BuildExecCmd(vmmArgs, unikernel)
-	if err != nil {
-		uniklog.WithError(err).Error("failed to build VMM command")
-		return err
+	// For the API-based boot the VMM is already running and fully configured
+	// (the equivalent validation), so there is no command to build.
+	var execCmd []string
+	if !isAPIBoot {
+		execCmd, err = vmm.BuildExecCmd(vmmArgs, unikernel)
+		if err != nil {
+			uniklog.WithError(err).Error("failed to build VMM command")
+			return err
+		}
 	}
 
 	// Notify urunc start that the monitor is ready to execute, only after the
@@ -824,13 +876,16 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 	}
 
 	if isAPIBoot {
-		fc, ok := vmm.(*hypervisors.Firecracker)
-		if !ok {
-			return fmt.Errorf("boot_mode=api is only supported for the firecracker monitor")
-		}
+		// The VMM is configured; boot the guest and hand this process over
+		// to supervising the child. This process must not exit before the
+		// child, since it is the container's init process.
 		metrics.Capture(m.TS18)
-		uniklog.WithField("command", execCmd).Debug("Starting Firecracker as a supervised child, driving it over its control socket")
-		return fc.RunSocketBoot(vmmArgs, unikernel, execCmd)
+		if err = fcSession.StartGuest(ctx); err != nil {
+			uniklog.Errorf("failed to start the guest: %v", err)
+			return err
+		}
+		fcHandedOff = true
+		return fcSession.Supervise()
 	}
 
 	return execMonitor(metrics, vmm, vmmArgs, execCmd)

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -510,9 +510,11 @@ func (u *Unikontainer) buildMonitorSpec(rootfsParams types.RootfsParams, monRes 
 		defaultVCPUs = 1
 	}
 	defaultMemSizeMB := u.UruncCfg.Monitors[vmmType].DefaultMemoryMB
+	socketPath := u.UruncCfg.Monitors[vmmType].SocketPath
 
 	vmmArgs := types.ExecArgs{
 		ContainerID:   u.State.ID,
+		SocketPath:    socketPath,
 		UnikernelPath: unikernelPath,
 		InitrdPath:    initrdPath,
 		Seccomp:       true, // Enable Seccomp by default

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -815,7 +815,7 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 	// For the API-based boot the monitor is spawned here, after changeRoot,
 	// so the child inherits the pivoted root: its control socket and every
 	// path it opens (kernel, initrd, drives, vsock) resolve inside the
-	// monitor rootfs. urunc is still privileged at this point — the child
+	// monitor rootfs. urunc is still privileged at this point; the child
 	// is started directly under the container user's credentials, and urunc
 	// drops its own privileges right after (setupUser below).
 	if isAPIBoot {

--- a/pkg/unikontainers/urunc_config.go
+++ b/pkg/unikontainers/urunc_config.go
@@ -220,6 +220,7 @@ func (p *UruncConfig) Map() map[string]string {
 		cfgMap[prefix+"binary_path"] = hvCfg.BinaryPath
 		cfgMap[prefix+"data_path"] = hvCfg.DataPath
 		cfgMap[prefix+"vhost"] = strconv.FormatBool(hvCfg.Vhost)
+		cfgMap[prefix+"socket_path"] = hvCfg.SocketPath
 	}
 	for eb, ebCfg := range p.ExtraBins {
 		prefix := "urunc_config.extra_binaries." + eb + "."
@@ -274,6 +275,8 @@ func UruncConfigFromMap(cfgMap map[string]string) *UruncConfig {
 			} else {
 				hvCfg.Vhost = boolVal
 			}
+		case "socket_path":
+			hvCfg.SocketPath = val
 		}
 		cfg.Monitors[hv] = hvCfg
 	}

--- a/pkg/unikontainers/urunc_config.go
+++ b/pkg/unikontainers/urunc_config.go
@@ -221,6 +221,7 @@ func (p *UruncConfig) Map() map[string]string {
 		cfgMap[prefix+"data_path"] = hvCfg.DataPath
 		cfgMap[prefix+"vhost"] = strconv.FormatBool(hvCfg.Vhost)
 		cfgMap[prefix+"socket_path"] = hvCfg.SocketPath
+		cfgMap[prefix+"boot_mode"] = hvCfg.BootMode
 	}
 	for eb, ebCfg := range p.ExtraBins {
 		prefix := "urunc_config.extra_binaries." + eb + "."
@@ -277,6 +278,8 @@ func UruncConfigFromMap(cfgMap map[string]string) *UruncConfig {
 			}
 		case "socket_path":
 			hvCfg.SocketPath = val
+		case "boot_mode":
+			hvCfg.BootMode = val
 		}
 		cfg.Monitors[hv] = hvCfg
 	}


### PR DESCRIPTION
## Description

Expose Firecracker's control socket for both boot modes, so the runtime can talk to the VMM after the guest starts (for graceful shutdown, and later snapshots), instead of everything being driven through a static config file.

- **config-file-based** (`boot_mode = "config-file"`): Firecracker launches with `--api-sock` alongside `--config-file`, so it still boots itself from the config file and the socket stays open and reachable afterwards.
- **api-based** (`boot_mode = "api"`, default): the whole boot is driven over the socket. urunc spawns Firecracker as a supervised child and configures it in stages (machine-config immediately, the network interface once the tap device exists, drives and boot-source after `unikernel.Init`) while doing its own setup, then sends `InstanceStart`. The runtime stays alive and supervises the child.
- The control socket path is configurable via a `socket_path` field; urunc creates the directory of a custom path so it can be placed outside `/tmp`.
- The API client polls the socket every 1ms and removes a stale socket before spawning.

### Related issues

- Related to #112
- Related to #756

### How was this tested?

- `go build ./...` and `go test ./internal/... ./pkg/...` pass; `make lint` reports no findings in the changed files; cspell and commitlint pass (Ubuntu 24.04 aarch64 VM, KVM, Firecracker v1.7.0).
- Live, through real containerd + nerdctl: the chttp-firecracker image boots and the guest serves HTTP 200 in **both** boot modes, with the default socket path and a configured `socket_path`; an invalid `socket_path` (a file already on the path) fails cleanly.
- Block-based rootfs via devmapper (`ubuntu-firecracker-linux-raw`): the guest boots off the block device and mounts its root in both boot modes.

### LLM usage

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
