### PR TITLE
fix(unikernels): use actual subnet mask in Unikraft netdev.ip args

### DIFF
--- a/pkg/unikontainers/unikernels/unikraft.go
+++ b/pkg/unikontainers/unikernels/unikraft.go
@@ -111,17 +111,6 @@ func (u *Unikraft) Init(data types.UnikernelParams) error {
 }
 
 func (u *Unikraft) configureUnikraftArgs(rootFsType, ethDeviceIP, ethDeviceGateway, ethDeviceMask string) error {
-	// Fall back to /24 when no mask is provided (no-network case), to
-	// keep the previous behavior for unikernels spawned without network.
-	maskCIDR := 24
-	if ethDeviceMask != "" {
-		var err error
-		maskCIDR, err = subnetMaskToCIDR(ethDeviceMask)
-		if err != nil {
-			return err
-		}
-	}
-
 	setCompatArgs := func() {
 		u.Net.Address = "netdev.ipv4_addr=" + ethDeviceIP
 		u.Net.Gateway = "netdev.ipv4_gw_addr=" + ethDeviceGateway
@@ -135,7 +124,18 @@ func (u *Unikraft) configureUnikraftArgs(rootFsType, ethDeviceIP, ethDeviceGatew
 		}
 	}
 
-	setCurrentArgs := func() {
+	setCurrentArgs := func() error {
+		// Fall back to /24 when no mask is provided (no-network case), to
+		// keep the previous behavior for unikernels spawned without network.
+		maskCIDR := 24
+		if ethDeviceMask != "" {
+			var err error
+			maskCIDR, err = subnetMaskToCIDR(ethDeviceMask)
+			if err != nil {
+				return err
+			}
+		}
+
 		u.Net.Address = fmt.Sprintf("netdev.ip=%s/%d:%s:8.8.8.8", ethDeviceIP, maskCIDR, ethDeviceGateway)
 		switch rootFsType {
 		case "initrd":
@@ -148,16 +148,21 @@ func (u *Unikraft) configureUnikraftArgs(rootFsType, ethDeviceIP, ethDeviceGatew
 		default:
 			u.VFS.RootFS = ""
 		}
+		return nil
 	}
 
 	if u.Version == "" {
-		setCurrentArgs()
+		if err := setCurrentArgs(); err != nil {
+			return err
+		}
 		return ErrUndefinedVersion
 	}
 
 	unikernelVersion, err := version.NewVersion(u.Version)
 	if err != nil {
-		setCurrentArgs()
+		if err := setCurrentArgs(); err != nil {
+			return err
+		}
 		return ErrVersionParsing
 	}
 
@@ -167,7 +172,9 @@ func (u *Unikraft) configureUnikraftArgs(rootFsType, ethDeviceIP, ethDeviceGatew
 	}
 
 	if unikernelVersion.GreaterThanOrEqual(targetVersion) {
-		setCurrentArgs()
+		if err := setCurrentArgs(); err != nil {
+			return err
+		}
 	} else {
 		setCompatArgs()
 		// Remove environment variables, since old versions do not

--- a/pkg/unikontainers/unikernels/unikraft.go
+++ b/pkg/unikontainers/unikernels/unikraft.go
@@ -111,6 +111,17 @@ func (u *Unikraft) Init(data types.UnikernelParams) error {
 }
 
 func (u *Unikraft) configureUnikraftArgs(rootFsType, ethDeviceIP, ethDeviceGateway, ethDeviceMask string) error {
+	// Fall back to /24 when no mask is provided (no-network case), to
+	// keep the previous behavior for unikernels spawned without network.
+	maskCIDR := 24
+	if ethDeviceMask != "" {
+		var err error
+		maskCIDR, err = subnetMaskToCIDR(ethDeviceMask)
+		if err != nil {
+			return err
+		}
+	}
+
 	setCompatArgs := func() {
 		u.Net.Address = "netdev.ipv4_addr=" + ethDeviceIP
 		u.Net.Gateway = "netdev.ipv4_gw_addr=" + ethDeviceGateway
@@ -125,7 +136,7 @@ func (u *Unikraft) configureUnikraftArgs(rootFsType, ethDeviceIP, ethDeviceGatew
 	}
 
 	setCurrentArgs := func() {
-		u.Net.Address = "netdev.ip=" + ethDeviceIP + "/24:" + ethDeviceGateway + ":8.8.8.8"
+		u.Net.Address = fmt.Sprintf("netdev.ip=%s/%d:%s:8.8.8.8", ethDeviceIP, maskCIDR, ethDeviceGateway)
 		switch rootFsType {
 		case "initrd":
 			// TODO: This needs better handling. We need to revisit this

--- a/pkg/unikontainers/unikernels/unikraft_test.go
+++ b/pkg/unikontainers/unikernels/unikraft_test.go
@@ -81,6 +81,14 @@ func TestUnikraftInitSubnetMask(t *testing.T) {
 			gateway:  "10.0.0.14",
 			wantMask: "netdev.ipv4_subnet_mask=255.255.255.240",
 		},
+		{
+			name:     "old version passes invalid mask through compat args",
+			version:  "0.15.0",
+			mask:     "255.255.255",
+			ip:       "10.0.0.1",
+			gateway:  "10.0.0.14",
+			wantMask: "netdev.ipv4_subnet_mask=255.255.255",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/unikontainers/unikernels/unikraft_test.go
+++ b/pkg/unikontainers/unikernels/unikraft_test.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unikernels
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
+)
+
+func TestUnikraftInitSubnetMask(t *testing.T) {
+	tests := []struct {
+		name        string
+		version     string
+		mask        string
+		ip          string
+		gateway     string
+		wantAddress string
+		wantMask    string
+		wantErr     error
+	}{
+		{
+			name:        "non-/24 mask is used correctly",
+			version:     "0.17.0",
+			mask:        "255.255.255.240",
+			ip:          "10.0.0.1",
+			gateway:     "10.0.0.14",
+			wantAddress: "netdev.ip=10.0.0.1/28:10.0.0.14:8.8.8.8",
+		},
+		{
+			name:        "/16 mask is used correctly",
+			version:     "0.17.0",
+			mask:        "255.255.0.0",
+			ip:          "10.244.1.3",
+			gateway:     "10.244.0.1",
+			wantAddress: "netdev.ip=10.244.1.3/16:10.244.0.1:8.8.8.8",
+		},
+		{
+			name:        "/24 mask still works",
+			version:     "0.17.0",
+			mask:        "255.255.255.0",
+			ip:          "192.168.1.5",
+			gateway:     "192.168.1.1",
+			wantAddress: "netdev.ip=192.168.1.5/24:192.168.1.1:8.8.8.8",
+		},
+		{
+			name:        "empty mask falls back to /24",
+			version:     "0.17.0",
+			mask:        "",
+			ip:          "192.168.1.5",
+			gateway:     "192.168.1.1",
+			wantAddress: "netdev.ip=192.168.1.5/24:192.168.1.1:8.8.8.8",
+		},
+		{
+			name:        "undefined version uses actual mask with sentinel error",
+			version:     "",
+			mask:        "255.255.255.128",
+			ip:          "10.0.0.2",
+			gateway:     "10.0.0.1",
+			wantAddress: "netdev.ip=10.0.0.2/25:10.0.0.1:8.8.8.8",
+			wantErr:     ErrUndefinedVersion,
+		},
+		{
+			name:     "old version passes mask through compat args",
+			version:  "0.15.0",
+			mask:     "255.255.255.240",
+			ip:       "10.0.0.1",
+			gateway:  "10.0.0.14",
+			wantMask: "netdev.ipv4_subnet_mask=255.255.255.240",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u := newUnikraft()
+			params := types.UnikernelParams{
+				Version: tt.version,
+				Net: types.NetDevParams{
+					IP:      tt.ip,
+					Mask:    tt.mask,
+					Gateway: tt.gateway,
+				},
+			}
+			err := u.Init(params)
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+			if tt.wantAddress != "" {
+				assert.Equal(t, tt.wantAddress, u.Net.Address)
+			}
+			if tt.wantMask != "" {
+				assert.Equal(t, tt.wantMask, u.Net.Mask)
+			}
+		})
+	}
+}
+
+func TestUnikraftInitInvalidMask(t *testing.T) {
+	u := newUnikraft()
+	params := types.UnikernelParams{
+		Version: "0.17.0",
+		Net: types.NetDevParams{
+			IP:      "10.0.0.1",
+			Mask:    "255.255.255",
+			Gateway: "10.0.0.14",
+		},
+	}
+	err := u.Init(params)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Description

The current Unikraft `netdev.ip=` argument path was hardcoding a `/24` CIDR prefix and ignoring the container interface subnet mask. This caused guests on non-/24 networks, such as /16 CNI subnets, to boot with the wrong netmask and make incorrect on-link routing decisions.

This PR converts the provided subnet mask to CIDR for current Unikraft versions and keeps `/24` only as the fallback when no mask is provided. For compat/old Unikraft versions, the subnet mask is still passed through untouched so existing behavior is preserved.

## Related issues

* Fixes #827

## How was this tested?

* `go test ./pkg/unikontainers/unikernels`
* `git diff --check`

## LLM usage

LLM was used to help update the implementation and add regression test coverage.

## Checklist

* [x] I have read the contribution guide.
* [ ] The linter passes locally (`make lint`).
* [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
* [] If LLMs were used: I have read the LLM policy.