### PR TITLE
fix(hypervisors): correct memory unit conversion and validation

### DIFF
--- a/pkg/unikontainers/hypervisors/cloud_hypervisor.go
+++ b/pkg/unikontainers/hypervisors/cloud_hypervisor.go
@@ -63,18 +63,19 @@ func (ch *CloudHypervisor) Path() string {
 	return ch.binaryPath
 }
 
-// BuildExecCmd builds and validates the Cloud Hypervisor command arguments without executing.
 func (ch *CloudHypervisor) BuildExecCmd(args types.ExecArgs, ukernel types.Unikernel) ([]string, error) {
-	chMem := BytesToStringMB(args.MemSizeB)
-
 	// Start building the command
 	exArgs := []string{ch.binaryPath}
 
 	// Memory configuration
+	memSize := args.MemSizeB
+	if memSize == 0 {
+		memSize = DefaultMemory * 1024 * 1024
+	}
 	if args.Sharedfs.Type == "virtiofs" {
-		exArgs = append(exArgs, "--memory", fmt.Sprintf("size=%sM,shared=on", chMem))
+		exArgs = append(exArgs, "--memory", fmt.Sprintf("size=%d,shared=on", memSize))
 	} else {
-		exArgs = append(exArgs, "--memory", fmt.Sprintf("size=%sM", chMem))
+		exArgs = append(exArgs, "--memory", fmt.Sprintf("size=%d", memSize))
 	}
 
 	// CPU configuration

--- a/pkg/unikontainers/hypervisors/firecracker.go
+++ b/pkg/unikontainers/hypervisors/firecracker.go
@@ -119,9 +119,9 @@ func (fc *Firecracker) BuildExecCmd(args types.ExecArgs, ukernel types.Unikernel
 	fcMem := DefaultMemory
 	if args.MemSizeB != 0 {
 		fcMem = bytesToMiB(args.MemSizeB)
-		// Check if memory is too small
-		if fcMem == 0 {
-			fcMem = DefaultMemory
+		if args.MemSizeB < 1024*1024 {
+			fcMem = 1
+			vmmLog.Warnf("Requested memory (%d bytes) is below Firecracker's minimum unit (1 MiB); clamping to 1 MiB", args.MemSizeB)
 		}
 	}
 	// NOTE: Firecracker supports only one initrd.

--- a/pkg/unikontainers/hypervisors/hvt.go
+++ b/pkg/unikontainers/hypervisors/hvt.go
@@ -153,7 +153,11 @@ func (h *HVT) Ok() error {
 }
 
 func (h *HVT) BuildExecCmd(args types.ExecArgs, ukernel types.Unikernel) ([]string, error) {
-	hvtMem := BytesToStringMB(args.MemSizeB)
+	hvtMem := BytesToMiBString(args.MemSizeB)
+	if args.MemSizeB > 0 && args.MemSizeB < 1024*1024 {
+		hvtMem = "1"
+		vmmLog.Warnf("Requested memory (%d bytes) is below Solo5's minimum unit (1 MiB); clamping to 1 MiB", args.MemSizeB)
+	}
 	cmdString := h.binaryPath + " --mem=" + hvtMem
 	if args.Net.TapDev != "" {
 		cmdString += " "

--- a/pkg/unikontainers/hypervisors/hvt_test.go
+++ b/pkg/unikontainers/hypervisors/hvt_test.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hypervisors
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
+)
+
+func TestHVTBuildExecCmd(t *testing.T) {
+	t.Parallel()
+
+	h := &HVT{
+		binaryPath: "/usr/local/bin/solo5-hvt",
+		binary:     "solo5-hvt",
+	}
+
+	tests := []struct {
+		name        string
+		args        types.ExecArgs
+		unikernel   types.Unikernel
+		mustContain []string
+	}{
+		{
+			name: "defaults render default memory",
+			args: types.ExecArgs{
+				UnikernelPath: "/path/to/unikernel",
+				Command:       "hello",
+			},
+			unikernel: &fakeUnikernel{},
+			mustContain: []string{
+				"/usr/local/bin/solo5-hvt",
+				"--mem=256",
+				"/path/to/unikernel",
+				"hello",
+			},
+		},
+		{
+			name: "custom memory above 1 MiB",
+			args: types.ExecArgs{
+				UnikernelPath: "/path/to/unikernel",
+				Command:       "hello",
+				MemSizeB:      16 * 1024 * 1024, // 16 MiB
+			},
+			unikernel: &fakeUnikernel{},
+			mustContain: []string{
+				"--mem=16",
+			},
+		},
+		{
+			name: "custom memory exactly 1 MiB",
+			args: types.ExecArgs{
+				UnikernelPath: "/path/to/unikernel",
+				Command:       "hello",
+				MemSizeB:      1024 * 1024, // 1 MiB
+			},
+			unikernel: &fakeUnikernel{},
+			mustContain: []string{
+				"--mem=1",
+			},
+		},
+		{
+			name: "custom memory sub-1-MiB clamps to 1 MiB",
+			args: types.ExecArgs{
+				UnikernelPath: "/path/to/unikernel",
+				Command:       "hello",
+				MemSizeB:      512 * 1024, // 512 KiB
+			},
+			unikernel: &fakeUnikernel{},
+			mustContain: []string{
+				"--mem=1",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmdArgs, err := h.BuildExecCmd(tc.args, tc.unikernel)
+			assert.NoError(t, err)
+			for _, expected := range tc.mustContain {
+				assert.Contains(t, cmdArgs, expected)
+			}
+		})
+	}
+}

--- a/pkg/unikontainers/hypervisors/qemu.go
+++ b/pkg/unikontainers/hypervisors/qemu.go
@@ -61,8 +61,8 @@ func (q *Qemu) Path() string {
 }
 
 func (q *Qemu) BuildExecCmd(args types.ExecArgs, ukernel types.Unikernel) ([]string, error) {
-	qemuMem := BytesToStringMB(args.MemSizeB)
-	cmdString := q.binaryPath + " -m " + qemuMem + "M"
+	qemuMem := BytesToBString(args.MemSizeB)
+	cmdString := q.binaryPath + " -m " + qemuMem + "B"
 	cmdString += " -L /usr/share/qemu"                                  // Set the path for qemu bios/data
 	cmdString += " -cpu host"                                           // Choose CPU
 	cmdString += " -enable-kvm"                                         // Enable KVM to use CPU virt extensions

--- a/pkg/unikontainers/hypervisors/qemu_test.go
+++ b/pkg/unikontainers/hypervisors/qemu_test.go
@@ -80,7 +80,7 @@ func TestQemuBuildExecCmd(t *testing.T) {
 				"-vga none",
 				"-serial stdio",
 				"-monitor null",
-				"-m 256M",
+				"-m 268435456B",
 				"-kernel " + testKernelPath,
 				"-nic none",
 			},
@@ -95,14 +95,14 @@ func TestQemuBuildExecCmd(t *testing.T) {
 			},
 		},
 		{
-			name: "custom MemSizeB renders -m in MB",
+			name: "custom MemSizeB renders -m in Bytes",
 			args: types.ExecArgs{
 				UnikernelPath: testKernelPath,
 				Command:       testCommand,
 				MemSizeB:      512 * 1000 * 1000,
 			},
 			unikernel:   &fakeUnikernel{},
-			mustContain: []string{"-m 512M"},
+			mustContain: []string{"-m 512000000B"},
 		},
 		{
 			name: "VCPUs set emits -smp",

--- a/pkg/unikontainers/hypervisors/spt.go
+++ b/pkg/unikontainers/hypervisors/spt.go
@@ -65,7 +65,11 @@ func (s *SPT) Ok() error {
 }
 
 func (s *SPT) BuildExecCmd(args types.ExecArgs, ukernel types.Unikernel) ([]string, error) {
-	sptMem := BytesToStringMB(args.MemSizeB)
+	sptMem := BytesToMiBString(args.MemSizeB)
+	if args.MemSizeB > 0 && args.MemSizeB < 1024*1024 {
+		sptMem = "1"
+		vmmLog.Warnf("Requested memory (%d bytes) is below Solo5's minimum unit (1 MiB); clamping to 1 MiB", args.MemSizeB)
+	}
 	cmdString := s.binaryPath + " --mem=" + sptMem
 	if args.Net.TapDev != "" {
 		cmdString += " "

--- a/pkg/unikontainers/hypervisors/spt_test.go
+++ b/pkg/unikontainers/hypervisors/spt_test.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hypervisors
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
+)
+
+func TestSPTBuildExecCmd(t *testing.T) {
+	t.Parallel()
+
+	s := &SPT{
+		binaryPath: "/usr/local/bin/solo5-spt",
+		binary:     "solo5-spt",
+	}
+
+	tests := []struct {
+		name        string
+		args        types.ExecArgs
+		unikernel   types.Unikernel
+		mustContain []string
+	}{
+		{
+			name: "defaults render default memory",
+			args: types.ExecArgs{
+				UnikernelPath: "/path/to/unikernel",
+				Command:       "hello",
+			},
+			unikernel: &fakeUnikernel{},
+			mustContain: []string{
+				"/usr/local/bin/solo5-spt",
+				"--mem=256",
+				"/path/to/unikernel",
+				"hello",
+			},
+		},
+		{
+			name: "custom memory above 1 MiB",
+			args: types.ExecArgs{
+				UnikernelPath: "/path/to/unikernel",
+				Command:       "hello",
+				MemSizeB:      16 * 1024 * 1024, // 16 MiB
+			},
+			unikernel: &fakeUnikernel{},
+			mustContain: []string{
+				"--mem=16",
+			},
+		},
+		{
+			name: "custom memory exactly 1 MiB",
+			args: types.ExecArgs{
+				UnikernelPath: "/path/to/unikernel",
+				Command:       "hello",
+				MemSizeB:      1024 * 1024, // 1 MiB
+			},
+			unikernel: &fakeUnikernel{},
+			mustContain: []string{
+				"--mem=1",
+			},
+		},
+		{
+			name: "custom memory sub-1-MiB clamps to 1 MiB",
+			args: types.ExecArgs{
+				UnikernelPath: "/path/to/unikernel",
+				Command:       "hello",
+				MemSizeB:      512 * 1024, // 512 KiB
+			},
+			unikernel: &fakeUnikernel{},
+			mustContain: []string{
+				"--mem=1",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmdArgs, err := s.BuildExecCmd(tc.args, tc.unikernel)
+			assert.NoError(t, err)
+			for _, expected := range tc.mustContain {
+				assert.Contains(t, cmdArgs, expected)
+			}
+		})
+	}
+}

--- a/pkg/unikontainers/hypervisors/utils.go
+++ b/pkg/unikontainers/hypervisors/utils.go
@@ -47,23 +47,19 @@ func bytesToMiB(bytes uint64) uint64 {
 	return bytes / bytesInMiB
 }
 
-func bytesToMB(bytes uint64) uint64 {
-	const bytesInMB = 1000 * 1000
-	return bytes / bytesInMB
+func BytesToBString(argMem uint64) string {
+	if argMem == 0 {
+		return strconv.FormatUint(DefaultMemory*1024*1024, 10)
+	}
+	return strconv.FormatUint(argMem, 10)
 }
 
-func BytesToStringMB(argMem uint64) string {
-	stringMem := strconv.FormatUint(DefaultMemory, 10)
-	if argMem != 0 {
-		userMem := bytesToMB(argMem)
-		// Check for too low memory
-		if userMem == 0 {
-			userMem = DefaultMemory
-		}
-		stringMem = strconv.FormatUint(userMem, 10)
+func BytesToMiBString(argMem uint64) string {
+	if argMem == 0 {
+		return strconv.FormatUint(DefaultMemory, 10)
 	}
-
-	return stringMem
+	userMem := bytesToMiB(argMem)
+	return strconv.FormatUint(userMem, 10)
 }
 
 func killProcess(pid int) error {

--- a/pkg/unikontainers/hypervisors/utils_test.go
+++ b/pkg/unikontainers/hypervisors/utils_test.go
@@ -46,28 +46,49 @@ func TestBytesToMiB(t *testing.T) {
 	}
 }
 
-func TestBytesToMB(t *testing.T) {
+func TestBytesToBString(t *testing.T) {
 	t.Parallel()
-
-	const mb uint64 = 1000 * 1000
 
 	cases := []struct {
 		name     string
 		input    uint64
-		expected uint64
+		expected string
 	}{
-		{"zero", 0, 0},
-		{"less than one MB truncates to zero", mb - 1, 0},
-		{"exactly one MB", mb, 1},
-		{"exactly two MB", 2 * mb, 2},
-		{"non-multiple truncates down", mb + (mb / 2), 1},
-		{"large value", 1024 * mb, 1024},
+		{"zero (Case A)", 0, "268435456"}, // 256 MB * 1024 * 1024
+		{"exactly 512 bytes", 512, "512"},
+		{"exactly 1024 bytes", 1024, "1024"},
+		{"large value", 1024 * 1024 * 1024, "1073741824"},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tc.expected, bytesToMB(tc.input))
+			assert.Equal(t, tc.expected, BytesToBString(tc.input))
+		})
+	}
+}
+
+func TestBytesToMiBString(t *testing.T) {
+	t.Parallel()
+
+	const mib uint64 = 1024 * 1024
+
+	cases := []struct {
+		name     string
+		input    uint64
+		expected string
+	}{
+		{"zero (Case A)", 0, "256"},
+		{"less than one MiB (Case B/C)", mib - 1, "0"},
+		{"exactly one MiB", mib, "1"},
+		{"exactly two MiB", 2 * mib, "2"},
+		{"large value", 1024 * mib, "1024"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, BytesToMiBString(tc.input))
 		})
 	}
 }

--- a/pkg/unikontainers/shared_fs.go
+++ b/pkg/unikontainers/shared_fs.go
@@ -121,7 +121,7 @@ func chooseTmpfsSize(sfsType string, mem uint64) string {
 	// However, since /tmp might be used from the monitors for other
 	// things too, we add one more MB extra.
 	tmpMountMem := mem + (1024 * 1024)
-	tmpMountMemStr := hypervisors.BytesToStringMB(tmpMountMem) + "m"
+	tmpMountMemStr := hypervisors.BytesToMiBString(tmpMountMem) + "m"
 
 	return tmpMountMemStr
 }


### PR DESCRIPTION
## Description

This PR fixes the memory handling issues reported in #818 and #819 by replacing the previous global conversion with monitor-specific handling.

Previously, OCI memory limits were converted using decimal MB for all monitors, which could cause the guest to receive more memory than requested. Additionally, requests that rounded to `0` were treated as unspecified and silently replaced with `DefaultMemory` (256MB).

This PR updates each backend to use the most accurate representation it supports:

- **QEMU:** pass exact byte values (`-m <bytes>B`).
- **Cloud Hypervisor:** pass exact byte values (`--memory size=<bytes>`).
- **Firecracker:** convert to MiB and clamp values below `1 MiB` to the minimum representable value.
- **Solo5:** convert to MiB and clamp values below `1 MiB` to satisfy its CLI validation.

An unspecified (`0`) memory request continues to fall back to `DefaultMemory`, while valid non-zero requests are preserved as accurately as each monitor allows.

### Related issues

- Fixes #818
- Fixes #819

### How was this tested?

- Verified each monitor's supported memory units from its implementation and documentation.
- Boot-tested QEMU, Cloud Hypervisor, Firecracker, and Solo5 with real guest images.
- Confirmed QEMU and Cloud Hypervisor preserve exact byte values end-to-end.
- Added unit tests for the new conversion helpers and updated QEMU tests.
- Ran `go test -v ./pkg/...`.

### LLM usage

Claude (Anthropic) Sonnet 5 was used to discuss implementation trade-offs. All implementation details and behavior were independently verified through source inspection, documentation, and runtime testing.

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).