### PR TITLE
fix(network): close tap device fd after creation

### DIFF
--- a/.github/contributors.yaml
+++ b/.github/contributors.yaml
@@ -107,6 +107,9 @@ users:
   Chennamma-Hotkar:
     name: Chennamma Hotkar
     email: channuhotkar@gmail.com
+  Anamika1608:
+    name: Anamika Aggarwal
+    email: anamikaagg18@gmail.com
   pocopepe:
     name: Viju Sanjai
     email: avijusanjai@gmail.com

--- a/.github/linters/urunc-dict.txt
+++ b/.github/linters/urunc-dict.txt
@@ -84,6 +84,7 @@ Sharedfs
 Syscalls
 TUNSETGROUP
 TUNSETOWNER
+TUNSETPERSIST
 TUNTAP
 Timestamping
 Tmpfs

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -101,15 +101,34 @@ func createTapDevice(name string, mtu int, ownerUID, ownerGID uint32) (netlink.L
 		return nil, fmt.Errorf("failed to create tap device: %w", err)
 	}
 
+	// LinkAdd opened the tap device's fd and set TUNSETPERSIST, so the
+	// interface survives independently of any open fd. Nothing after the
+	// owner/group ioctl calls uses the fd (the remaining setup goes through
+	// netlink and the monitor attaches to the device by name with its own
+	// open), so close it right away instead of relying on a later exec to
+	// close it (O_CLOEXEC). A single-queue tap device only allows one
+	// attached fd at a time, so holding it open blocks the monitor from
+	// attaching if the caller does not exec away.
 	for _, tapFd := range tapLink.Fds {
 		err = unix.IoctlSetInt(int(tapFd.Fd()), unix.TUNSETOWNER, int(ownerUID))
 		if err != nil {
+			if closeErr := tapFd.Close(); closeErr != nil {
+				netlog.Warnf("failed to close tap %s fd after owner ioctl error: %v", name, closeErr)
+			}
 			return nil, fmt.Errorf("failed to set tap %s owner to uid %d: %w", name, ownerUID, err)
 		}
 
 		err = unix.IoctlSetInt(int(tapFd.Fd()), unix.TUNSETGROUP, int(ownerGID))
 		if err != nil {
+			if closeErr := tapFd.Close(); closeErr != nil {
+				netlog.Warnf("failed to close tap %s fd after group ioctl error: %v", name, closeErr)
+			}
 			return nil, fmt.Errorf("failed to set tap %s group to gid %d: %w", name, ownerGID, err)
+		}
+
+		err = tapFd.Close()
+		if err != nil {
+			return nil, fmt.Errorf("failed to close the fd of tap %s: %w", name, err)
 		}
 	}
 


### PR DESCRIPTION
## Description

`createTapDevice` relies on a later `syscall.Exec` into the monitor to close the tap device fd that `netlink.LinkAdd` opened (`O_CLOEXEC`). In any flow where urunc keeps running instead of exec-ing away, the fd stays open for as long as urunc runs, and since the tap device is single-queue, it blocks the monitor from attaching to the device ("Resource busy").

Close the fd explicitly right after the owner/group ioctls. The device is created with `TUNSETPERSIST`, so it survives the close.

### Related issues

- Fixes #830

### How was this tested?

- `go build ./...` and `go test ./internal/... ./pkg/...` pass (Ubuntu 24.04 aarch64 VM with KVM, Firecracker v1.7.0).
- `make lint` reports no findings in the changed file.
- The failure this fixes was reproduced and verified fixed in a prototype where urunc spawns Firecracker as a child process instead of exec-ing into it (the API-based boot work from #756): with the fd left open, Firecracker's `/network-interfaces` call fails with EBUSY; with this change, the guest boots and serves traffic.
- Live end-to-end check on this branch: the chttp-firecracker image boots through real containerd + nerdctl and the guest's HTTP server answers 200. Verified identical behavior on unchanged `main`.
- `make test_nerdctl` is not runnable in my environment (aarch64 VM with only Firecracker installed; the suite needs docker, all five monitors, devmapper, and amd64 test images), so the e2e checkbox is left unticked.

### LLM usage

claude code (opus 4.8) for the understanding of codebase, approach decisions and reviews

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).