### PR TITLE
chore: Strengthen contribution rules and triage infra

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,6 @@ jobs:
             runner: ubuntu-22.04
           - arch: arm64
             runner: ubuntu-22.04-arm
-    continue-on-error: true
 
     steps:
     - name: Harden the runner (Audit all outbound calls)

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -29,4 +29,5 @@ jobs:
           days-before-pr-stale: 60
           days-before-issue-close: 15
           days-before-pr-close: 15
-          exempt-issue-labels: 'design,dev,enhancement,documentation,bug,feature'
+          exempt-issue-labels: 'design,dev,enhancement,documentation,bug,feature,mentorship'
+          exempt-pr-labels: 'ok-to-test,takeover'

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -28,7 +28,6 @@ jobs:
             runner: ubuntu-22.04-arm
 
       fail-fast: false
-    continue-on-error: true
 
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/docs/developer-guide/contribute.md
+++ b/docs/developer-guide/contribute.md
@@ -59,6 +59,18 @@ welcome to open a new issue, which is either related to a bug or a request for
 a new feature. Please make sure to read the [LLM
 policy](../developer-guide/llm-policy.md) in cases where an LLM has been used.
 
+Please keep in mind that `urunc` is a community-led open-source project, not
+backed by a specific company. Maintainers review issues on a best-effort basis.
+Therefore, please refrain from @-mentioning maintainers when opening an issue
+or shortly after opening it. The maintainers will get to the issue as soon as
+they can.
+
+When a maintainer goes through an issue, they will label it accordingly. We
+use the labels to track triage, so an issue with no labels on it has not been
+accepted yet. Issues that lack the necessary information to reproduce or
+verify the reported problem will stay unlabeled, until that information shows
+up. If it never does, we will close the issue.
+
 ### Reporting bugs
 
 In order to report a bug or misbehavior in `urunc`, a user can open a new issue explaining the problem.
@@ -76,6 +88,13 @@ In that context, when opening a new issue regarding a bug, we kindly ask you to:
     5. Any particular steps to reproduce the issue.
 - Keep an eye on the issue for possible questions from the maintainers.
 
+Bug reports must describe a problem that the reporter has actually run into
+and reproduced. In that context, the logs and the output of the failing
+commands are required, not optional -- they are the evidence that the problem
+is real. Issues that only describe code the reporter has read, without
+executing it and without the respective output, will stay unlabeled and will
+be closed if the missing information is not provided.
+
 A template for an issue could be the following one:
 ```
 ## Description
@@ -90,6 +109,10 @@ An explanation of the issue
 
 ## Steps to reproduce
 A list of steps that can reproduce the issue.
+
+## Logs / output
+The actual output of the failing commands and the relevant logs
+(eg. containerd logs, urunc debug logs).
 ```
 
 ### Requesting new features
@@ -105,8 +128,13 @@ Anyone should feel free to submit a change or an addition to the codebase of `ur
 Currently, we use GitHub's Pull Requests (PRs) to submit changes to `urunc`'s codebase.
 Before creating a new PR, please follow the rules below:
 
-- Avoid opening PRs for non-existent issues. Please create an issue first.
+- Open PRs only for issues that a maintainer has already labeled. If there is
+  no issue for the change you have in mind, please open one first and wait for
+  the maintainers to go through it.
 - Complete the PR template.
+- Add yourself in
+  [`.github/contributors.yaml`](https://github.com/urunc-dev/urunc/blob/main/.github/contributors.yaml).
+  We use that file to add the proper git trailers in the commits of a PR.
 - In case LLMs have been used, please read the [LLM
   policy](../developer-guide/llm-policy.md).
 - Avoid changes unrelated to the PR/issue.
@@ -122,7 +150,8 @@ Before creating a new PR, please follow the rules below:
 
 The maintainers and admins of the `urunc` project reserve the right to close
 PRs that do not comply with the above rules, with reference to this contribution
-guide.
+guide. In the same context, anyone who keeps ignoring this guide will be
+banned from the project.
 
 A new (draft) PR triggers the following process:
 
@@ -140,6 +169,18 @@ A new (draft) PR triggers the following process:
      main branch. If the PR is external, the maintainer should rebase & merge for
      the action to be triggered. If the PR is internal, the action will be triggered
      automatically.
+
+### A note on mentorship programs
+
+We are always happy to see new contributors, including people who get involved
+through a mentorship program (eg. LFX). If this is your case, please go through
+the [LFX Standards of
+Excellence](https://docs.linuxfoundation.org/lfx/mentorship/standards-of-excellence)
+first.
+
+In case `urunc` takes part in a mentorship term, the relevant issues will be
+explicitly marked with a `mentorship` label. Unless an issue carries that
+label, please avoid opening issues or PRs related to mentorship programs.
 
 ## Labels for the CI
 


### PR DESCRIPTION
## Description

Following an increase of drive-by issues and PRs, mostly around mentorship
program cycles, this PR makes our contribution rules more explicit and fixes
two infra quirks that make triaging harder than it should be.

In `docs/developer-guide/contribute.md`:

- Bug reports must come with the actual logs and the output of the failing
  commands. Issues that only describe code the reporter has read stay
  unlabeled and get closed if the information never shows up.
- We use labels to track triage, so an issue with no labels on it has not been
  accepted yet. In the same context, PRs are expected to reference an issue
  that a maintainer has already labeled.
- Contributors should add themselves in `.github/contributors.yaml`, which is
  what our automation uses to add the proper git trailers.
- We kindly ask people not to @-mention maintainers right after opening an
  issue.
- Mentorship applicants are pointed to the [LFX Standards of
  Excellence](https://docs.linuxfoundation.org/lfx/mentorship/standards-of-excellence),
  and the `mentorship` label stays as the only marker of such work.
- Anyone who keeps ignoring the guide will be banned from the project.

In `stale.yml`: the stale bot currently nags items that maintainers have
already triaged, while unverified reports keep sitting in the queue. Exempt
the `mentorship` label for issues, along with the PRs a maintainer has engaged
with (`ok-to-test`, `takeover`).

In `build.yml` / `unit_test.yml`: remove the job-level `continue-on-error`, so
that a PR that does not compile or fails its unit tests shows a red check
instead of a green one. `build-latest.yml` and `upload_s3.yml` are left
untouched, as they do not gate PRs.

Note: the only new label we need to create in the repo is `mentorship`. Will
do that as soon as this gets merged.

### Related issues

- Fixes #729

### How was this tested?

Docs and workflow-only changes, no code is touched. The markdown was reviewed
rendered locally, `cspell` passes on `contribute.md` with the repo config, and
the workflow changes are a label-list extension and two line deletions. CI on
this PR exercises the modified build/unit-test workflows directly.

### LLM usage

Claude (Fable 5, via Claude Code). All content reviewed and edited by me.

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
