### PR TITLE
feat(cloud-hypervisor): add an api boot mode over the REST API socket

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -166,6 +166,7 @@ Each monitor subsection supports the following options:
 | `data_path` | string | (empty) | Optional custom path for the monitor's data file directory |
 | `vhost` | boolean | `false` | Optional: enable `vhost-net` for the monitor's network device, to improve network performance. Currently only honored by the `qemu` monitor |
 | `socket_path` | string | (empty) | Optional path for the monitor's control socket. If not specified, urunc uses a per-container default under `/tmp`. When a custom path is set, urunc creates its parent directory; setting it to an invalid location (a file already exists on the path) makes the monitor fail to start. Currently used by Cloud Hypervisor. |
+| `boot_mode` | string | (empty) | Optional boot mode. When set to `api`, urunc starts the monitor as a supervised child and triggers the guest's start through the monitor's control socket; when unset, the monitor boots from its command line as before. Currently only used by Cloud Hypervisor. |
 
 Since Qemu is the only currently supported monitor which requires extra data to
 boot a VM, `urunc` will first check `/usr/local/share` and then `/usr/share` for
@@ -185,6 +186,11 @@ vhost = false
 default_memory_mb = 512
 default_vcpus = 2
 path = "/opt/firecracker/firecracker"
+
+[monitors.cloud-hypervisor]
+default_memory_mb = 256
+default_vcpus = 1
+boot_mode = "api"
 ```
 
 ### Extra binaries Configuration

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -165,6 +165,7 @@ Each monitor subsection supports the following options:
 | `path` | string | (empty) | Optional custom path to the monitor binary. If not specified, urunc will search for the binary in PATH |
 | `data_path` | string | (empty) | Optional custom path for the monitor's data file directory |
 | `vhost` | boolean | `false` | Optional: enable `vhost-net` for the monitor's network device, to improve network performance. Currently only honored by the `qemu` monitor |
+| `socket_path` | string | (empty) | Optional path for the monitor's control socket. If not specified, urunc uses a per-container default under `/tmp`. When a custom path is set, urunc creates its parent directory; setting it to an invalid location (a file already exists on the path) makes the monitor fail to start. Currently used by Cloud Hypervisor. |
 
 Since Qemu is the only currently supported monitor which requires extra data to
 boot a VM, `urunc` will first check `/usr/local/share` and then `/usr/share` for

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -151,6 +151,7 @@ values.
 
 - [QEMU/KVM](./hypervisor-support#qemu) - `qemu`
 - [Firecracker](./hypervisor-support#firecracker) - `firecracker`
+- [Cloud Hypervisor](./hypervisor-support#cloud-hypervisor) - `cloud-hypervisor`
 - [Solo5-hvt](./hypervisor-support#solo5-hvt) - `hvt` - Solo5 hvt (KVM-based tender)
 - [Solo5-spt](./hypervisor-support#solo5-spt) - `spt` - Solo5 spt (Seccomp-based tender)
 

--- a/pkg/unikontainers/hypervisors/cloud_hypervisor.go
+++ b/pkg/unikontainers/hypervisors/cloud_hypervisor.go
@@ -15,8 +15,16 @@
 package hypervisors
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
 	"strconv"
+	"strings"
+	"syscall"
+	"time"
 
 	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
 	"golang.org/x/sys/unix"
@@ -166,4 +174,231 @@ func (ch *CloudHypervisor) BuildExecCmd(args types.ExecArgs, ukernel types.Unike
 // PreExec performs pre-execution setup. Cloud Hypervisor has no special pre-exec requirements.
 func (ch *CloudHypervisor) PreExec(_ types.ExecArgs) error {
 	return nil
+}
+
+// The following types mirror the subset of Cloud Hypervisor's REST VmConfig
+// that urunc's command-line boot already uses (verified against the installed
+// cloud-hypervisor v53 API).
+
+type CHPayload struct {
+	Kernel    string `json:"kernel,omitempty"`
+	Cmdline   string `json:"cmdline,omitempty"`
+	Initramfs string `json:"initramfs,omitempty"`
+}
+
+type CHMemory struct {
+	Size   uint64 `json:"size"`
+	Shared bool   `json:"shared,omitempty"`
+}
+
+type CHCpus struct {
+	BootVcpus uint `json:"boot_vcpus"`
+	MaxVcpus  uint `json:"max_vcpus"`
+}
+
+type CHNet struct {
+	Tap string `json:"tap,omitempty"`
+	Mac string `json:"mac,omitempty"`
+	Mtu int    `json:"mtu,omitempty"`
+}
+
+type CHDisk struct {
+	Path string `json:"path"`
+	ID   string `json:"id,omitempty"`
+}
+
+type CHFs struct {
+	Tag    string `json:"tag"`
+	Socket string `json:"socket"`
+}
+
+type CHVsock struct {
+	Cid    int    `json:"cid"`
+	Socket string `json:"socket"`
+}
+
+type CHConsole struct {
+	Mode string `json:"mode"`
+}
+
+type CHVMConfig struct {
+	Payload CHPayload  `json:"payload"`
+	Memory  *CHMemory  `json:"memory,omitempty"`
+	Cpus    *CHCpus    `json:"cpus,omitempty"`
+	Net     []CHNet    `json:"net,omitempty"`
+	Disks   []CHDisk   `json:"disks,omitempty"`
+	Fs      []CHFs     `json:"fs,omitempty"`
+	Vsock   *CHVsock   `json:"vsock,omitempty"`
+	Serial  *CHConsole `json:"serial,omitempty"`
+	Console *CHConsole `json:"console,omitempty"`
+}
+
+// buildCHVMConfig maps the same data BuildExecCmd puts on the command line
+// into the REST VmConfig. Unikernel-specific raw CLI argument strings cannot
+// be mapped to JSON, so they yield an error instead of being dropped.
+func buildCHVMConfig(args types.ExecArgs, ukernel types.Unikernel) (*CHVMConfig, error) {
+	mem := args.MemSizeB
+	if mem < 1<<20 {
+		mem = DefaultMemory << 20
+	}
+	cfg := &CHVMConfig{
+		Payload: CHPayload{Kernel: args.UnikernelPath, Cmdline: args.Command},
+		Memory:  &CHMemory{Size: mem, Shared: args.Sharedfs.Type == "virtiofs"},
+		Serial:  &CHConsole{Mode: "Tty"},
+		Console: &CHConsole{Mode: "Off"},
+	}
+	if args.VCPUs > 0 {
+		cfg.Cpus = &CHCpus{BootVcpus: args.VCPUs, MaxVcpus: args.VCPUs}
+	}
+
+	extraMonArgs := ukernel.MonitorCli()
+	if len(extraMonArgs.OtherArgs) > 0 {
+		return nil, fmt.Errorf("boot_mode=api does not support unikernel-specific monitor arguments (%q)", strings.Join(extraMonArgs.OtherArgs, " "))
+	}
+	initrdPath := args.InitrdPath
+	if initrdPath == "" {
+		initrdPath = extraMonArgs.ExtraInitrd
+	}
+	cfg.Payload.Initramfs = initrdPath
+
+	if args.Net.TapDev != "" {
+		if netCli := ukernel.MonitorNetCli(args.Net.TapDev, args.Net.MAC); len(netCli) > 0 {
+			return nil, fmt.Errorf("boot_mode=api does not support unikernel-specific network arguments (%q)", strings.Join(netCli, " "))
+		}
+		cfg.Net = append(cfg.Net, CHNet{Tap: args.Net.TapDev, Mac: args.Net.MAC, Mtu: args.Net.MTU})
+	}
+
+	for _, blockArg := range ukernel.MonitorBlockCli() {
+		if len(blockArg.ExactArgs) > 0 {
+			return nil, fmt.Errorf("boot_mode=api does not support unikernel-specific block arguments (%q)", strings.Join(blockArg.ExactArgs, " "))
+		}
+		if blockArg.Path != "" {
+			cfg.Disks = append(cfg.Disks, CHDisk{Path: blockArg.Path, ID: blockArg.ID})
+		}
+	}
+
+	if args.Sharedfs.Type == "virtiofs" {
+		cfg.Fs = append(cfg.Fs, CHFs{Tag: "fs0", Socket: "/tmp/vhostqemu"})
+	}
+	if args.VAccelType == "vsock" {
+		cfg.Vsock = &CHVsock{Cid: args.VSockDevID, Socket: args.VSockDevPath + "/vaccel.sock"}
+	}
+	return cfg, nil
+}
+
+// CHSession is a Cloud Hypervisor child process driven over its REST API
+// socket. Create it with SpawnSocketVMM, send the full configuration with
+// ConfigureVM, boot the guest with BootVM once the caller's start handshake
+// allows it, then hand the calling process over with Supervise.
+type CHSession struct {
+	cmd    *exec.Cmd
+	client *chAPIClient
+}
+
+// SpawnSocketVMM starts Cloud Hypervisor as a supervised child with only its
+// API socket enabled. It is called after changeRoot, so the child inherits
+// the pivoted root and its socket lives inside the monitor rootfs. The
+// caller is still privileged here and only drops its own privileges
+// afterwards, so when uid/gid are non-zero the child is started directly
+// under that credential.
+func (ch *CloudHypervisor) SpawnSocketVMM(args types.ExecArgs, uid, gid uint32) (*CHSession, error) {
+	socketPath := ResolveSocketPath(args)
+	// Cloud Hypervisor binds this path itself; remove any stale leftover.
+	if err := os.Remove(socketPath); err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("failed to remove stale socket %q: %w", socketPath, err)
+	}
+	execCmd := []string{ch.binaryPath, "--api-socket", "path=" + socketPath}
+	if args.Seccomp {
+		execCmd = append(execCmd, "--seccomp", "true")
+	} else {
+		execCmd = append(execCmd, "--seccomp", "false")
+	}
+
+	cmd := exec.Command(execCmd[0], execCmd[1:]...) //nolint: gosec
+	cmd.Env = args.Environment
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if uid != 0 || gid != 0 {
+		cmd.SysProcAttr = &syscall.SysProcAttr{
+			Credential: &syscall.Credential{Uid: uid, Gid: gid},
+		}
+	}
+	vmmLog.WithField("command", execCmd).Debug("starting cloud-hypervisor as a supervised child")
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("failed to start cloud-hypervisor: %w", err)
+	}
+
+	client := newCHAPIClient(socketPath)
+	if err := client.connect(5 * time.Second); err != nil {
+		s := &CHSession{cmd: cmd, client: client}
+		s.Kill()
+		return nil, fmt.Errorf("cloud-hypervisor API socket never became ready: %w", err)
+	}
+	return &CHSession{cmd: cmd, client: client}, nil
+}
+
+// ConfigureVM sends the complete VM configuration in one request.
+func (s *CHSession) ConfigureVM(ctx context.Context, args types.ExecArgs, ukernel types.Unikernel) error {
+	cfg, err := buildCHVMConfig(args, ukernel)
+	if err != nil {
+		return err
+	}
+	vmmLog.Debug("api boot: sending vm.create")
+	return s.client.createVM(ctx, cfg)
+}
+
+// BootVM boots the configured VM.
+func (s *CHSession) BootVM(ctx context.Context) error {
+	vmmLog.Debug("api boot: sending vm.boot")
+	return s.client.bootVM(ctx)
+}
+
+// Kill terminates the child and reaps it. For error paths before Supervise.
+func (s *CHSession) Kill() {
+	_ = s.cmd.Process.Kill()
+	_, _ = s.cmd.Process.Wait()
+}
+
+// Supervise hands the calling process over to the child for the rest of its
+// life: it forwards SIGTERM/SIGINT and, once the child exits, exits this
+// process with the child's exit code, mirroring the semantics syscall.Exec
+// would have had. The caller must not exit before the child, since it is
+// the container's init process.
+//
+// On success this function does not return: it calls os.Exit with the
+// child's exit status once the child exits.
+func (s *CHSession) Supervise() error {
+	// Forward the signals containerd would send to stop the container.
+	// SIGKILL cannot be caught, so it is not listed here: if it arrives,
+	// this process dies immediately and the child is left running, a known
+	// gap for this bounded experiment, not yet handled.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+	go func() {
+		sig, ok := <-sigCh
+		if !ok {
+			return
+		}
+		if sg, ok := sig.(syscall.Signal); ok {
+			_ = s.cmd.Process.Signal(sg)
+		}
+	}()
+
+	waitErr := s.cmd.Wait()
+	signal.Stop(sigCh)
+	close(sigCh)
+
+	exitCode := 0
+	if waitErr != nil {
+		var exitErr *exec.ExitError
+		if errors.As(waitErr, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else {
+			vmmLog.WithError(waitErr).Error("cloud-hypervisor exited with an unexpected error")
+			exitCode = 1
+		}
+	}
+	os.Exit(exitCode)
+	return nil // unreachable
 }

--- a/pkg/unikontainers/hypervisors/cloud_hypervisor.go
+++ b/pkg/unikontainers/hypervisors/cloud_hypervisor.go
@@ -78,8 +78,6 @@ func (ch *CloudHypervisor) BuildExecCmd(args types.ExecArgs, ukernel types.Unike
 	// Start building the command
 	exArgs := []string{ch.binaryPath}
 
-	// Expose the REST API over a control socket so the runtime can talk to
-	// Cloud Hypervisor after boot (e.g. for graceful shutdown).
 	exArgs = append(exArgs, "--api-socket", "path="+ResolveSocketPath(args))
 
 	// Memory configuration
@@ -176,9 +174,8 @@ func (ch *CloudHypervisor) PreExec(_ types.ExecArgs) error {
 	return nil
 }
 
-// The following types mirror the subset of Cloud Hypervisor's REST VmConfig
-// that urunc's command-line boot already uses (verified against the installed
-// cloud-hypervisor v53 API).
+// These types mirror the part of Cloud Hypervisor's REST VmConfig that the
+// command-line boot already uses. Checked against cloud-hypervisor v53.
 
 type CHPayload struct {
 	Kernel    string `json:"kernel,omitempty"`
@@ -233,9 +230,8 @@ type CHVMConfig struct {
 	Console *CHConsole `json:"console,omitempty"`
 }
 
-// buildCHVMConfig maps the same data BuildExecCmd puts on the command line
-// into the REST VmConfig. Unikernel-specific raw CLI argument strings cannot
-// be mapped to JSON, so they yield an error instead of being dropped.
+// buildCHVMConfig maps the command-line data into the REST VmConfig. Raw CLI
+// argument strings have no JSON form, so they return an error.
 func buildCHVMConfig(args types.ExecArgs, ukernel types.Unikernel) (*CHVMConfig, error) {
 	mem := args.MemSizeB
 	if mem < 1<<20 {
@@ -286,24 +282,18 @@ func buildCHVMConfig(args types.ExecArgs, ukernel types.Unikernel) (*CHVMConfig,
 	return cfg, nil
 }
 
-// CHSession is a Cloud Hypervisor child process driven over its REST API
-// socket. Create it with SpawnSocketVMM, send the full configuration with
-// ConfigureVM, boot the guest with BootVM once the caller's start handshake
-// allows it, then hand the calling process over with Supervise.
+// CHSession is a Cloud Hypervisor child process that urunc drives over its
+// REST API socket.
 type CHSession struct {
 	cmd    *exec.Cmd
 	client *chAPIClient
 }
 
-// SpawnSocketVMM starts Cloud Hypervisor as a supervised child with only its
-// API socket enabled. It is called after changeRoot, so the child inherits
-// the pivoted root and its socket lives inside the monitor rootfs. The
-// caller is still privileged here and only drops its own privileges
-// afterwards, so when uid/gid are non-zero the child is started directly
-// under that credential.
+// SpawnSocketVMM starts Cloud Hypervisor with only its API socket. It must
+// run after changeRoot, so the socket stays inside the monitor rootfs.
 func (ch *CloudHypervisor) SpawnSocketVMM(args types.ExecArgs, uid, gid uint32) (*CHSession, error) {
 	socketPath := ResolveSocketPath(args)
-	// Cloud Hypervisor binds this path itself; remove any stale leftover.
+	// Cloud Hypervisor binds this path, and a leftover file makes the bind fail.
 	if err := os.Remove(socketPath); err != nil && !os.IsNotExist(err) {
 		return nil, fmt.Errorf("failed to remove stale socket %q: %w", socketPath, err)
 	}
@@ -348,31 +338,22 @@ func (s *CHSession) ConfigureVM(ctx context.Context, args types.ExecArgs, ukerne
 	return s.client.createVM(ctx, cfg)
 }
 
-// BootVM boots the configured VM.
 func (s *CHSession) BootVM(ctx context.Context) error {
 	vmmLog.Debug("api boot: sending vm.boot")
 	return s.client.bootVM(ctx)
 }
 
-// Kill terminates the child and reaps it. For error paths before Supervise.
+// Kill terminates the child process and reaps it.
 func (s *CHSession) Kill() {
 	_ = s.cmd.Process.Kill()
 	_, _ = s.cmd.Process.Wait()
 }
 
-// Supervise hands the calling process over to the child for the rest of its
-// life: it forwards SIGTERM/SIGINT and, once the child exits, exits this
-// process with the child's exit code, mirroring the semantics syscall.Exec
-// would have had. The caller must not exit before the child, since it is
-// the container's init process.
-//
-// On success this function does not return: it calls os.Exit with the
-// child's exit status once the child exits.
+// Supervise forwards signals to Cloud Hypervisor and exits with its exit code
+// once it exits. It does not return on success.
 func (s *CHSession) Supervise() error {
-	// Forward the signals containerd would send to stop the container.
-	// SIGKILL cannot be caught, so it is not listed here: if it arrives,
-	// this process dies immediately and the child is left running, a known
-	// gap for this bounded experiment, not yet handled.
+	// Forward the signals that stop a container. SIGKILL cannot be caught, so
+	// this process dies at once and leaves Cloud Hypervisor running.
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
 	go func() {

--- a/pkg/unikontainers/hypervisors/cloud_hypervisor.go
+++ b/pkg/unikontainers/hypervisors/cloud_hypervisor.go
@@ -70,6 +70,10 @@ func (ch *CloudHypervisor) BuildExecCmd(args types.ExecArgs, ukernel types.Unike
 	// Start building the command
 	exArgs := []string{ch.binaryPath}
 
+	// Expose the REST API over a control socket so the runtime can talk to
+	// Cloud Hypervisor after boot (e.g. for graceful shutdown).
+	exArgs = append(exArgs, "--api-socket", "path="+ResolveSocketPath(args))
+
 	// Memory configuration
 	if args.Sharedfs.Type == "virtiofs" {
 		memArg := "size=" + chMem + "M,shared=on"

--- a/pkg/unikontainers/hypervisors/cloud_hypervisor_client.go
+++ b/pkg/unikontainers/hypervisors/cloud_hypervisor_client.go
@@ -26,13 +26,8 @@ import (
 	"time"
 )
 
-// chAPIClient drives a running Cloud Hypervisor process over its HTTP-over-Unix
-// REST API socket. urunc uses it to create the whole VM configuration in one
-// request and boot the guest when the start handshake allows it.
-//
-// The client establishes a single connection in connect() and keeps it alive
-// for all requests, so every request reuses the connection whose readiness
-// connect() already waited for, instead of re-dialing.
+// chAPIClient drives a running Cloud Hypervisor process over its HTTP API on a
+// unix socket. connect() opens one connection, and every request reuses it.
 type chAPIClient struct {
 	socketPath string
 	httpClient *http.Client
@@ -53,9 +48,8 @@ func newCHAPIClient(socketPath string) *chAPIClient {
 	return c
 }
 
-// dialContext hands the transport the connection pre-established by connect(),
-// and falls back to dialing the socket path directly if that connection was
-// already consumed.
+// dialContext hands over the connection connect() made, or dials again if it
+// was already used.
 func (c *chAPIClient) dialContext(ctx context.Context, _, _ string) (net.Conn, error) {
 	c.dialMu.Lock()
 	defer c.dialMu.Unlock()
@@ -68,9 +62,8 @@ func (c *chAPIClient) dialContext(ctx context.Context, _, _ string) (net.Conn, e
 	return d.DialContext(ctx, "unix", c.socketPath)
 }
 
-// connect blocks until the API socket exists and accepts connections, or the
-// timeout elapses. Cloud Hypervisor creates the socket shortly after it
-// starts, so the dial is retried tightly.
+// connect blocks until the API socket accepts connections, or the timeout
+// elapses. It keeps the connection for the requests that follow.
 func (c *chAPIClient) connect(timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	var lastErr error
@@ -91,19 +84,16 @@ func (c *chAPIClient) connect(timeout time.Duration) error {
 	return fmt.Errorf("cloud-hypervisor API socket %q not ready within %s: %w", c.socketPath, timeout, lastErr)
 }
 
-// createVM sends the full VM configuration.
 func (c *chAPIClient) createVM(ctx context.Context, cfg *CHVMConfig) error {
 	return c.put(ctx, "/api/v1/vm.create", cfg)
 }
 
-// bootVM boots the created VM.
 func (c *chAPIClient) bootVM(ctx context.Context) error {
 	return c.put(ctx, "/api/v1/vm.boot", nil)
 }
 
-// put sends body as an HTTP PUT to the given API path over the Unix socket,
-// returning an error for any non-2xx response. A nil body sends an empty
-// request.
+// put sends body as an HTTP PUT over the Unix socket and returns an error
+// for any non-2xx response. A nil body sends an empty request.
 func (c *chAPIClient) put(ctx context.Context, path string, body any) error {
 	var payload []byte
 	if body != nil {

--- a/pkg/unikontainers/hypervisors/cloud_hypervisor_client.go
+++ b/pkg/unikontainers/hypervisors/cloud_hypervisor_client.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hypervisors
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// chAPIClient drives a running Cloud Hypervisor process over its HTTP-over-Unix
+// REST API socket. urunc uses it to create the whole VM configuration in one
+// request and boot the guest when the start handshake allows it.
+//
+// The client establishes a single connection in connect() and keeps it alive
+// for all requests, so every request reuses the connection whose readiness
+// connect() already waited for, instead of re-dialing.
+type chAPIClient struct {
+	socketPath string
+	httpClient *http.Client
+
+	dialMu   sync.Mutex
+	heldConn net.Conn
+}
+
+func newCHAPIClient(socketPath string) *chAPIClient {
+	c := &chAPIClient{socketPath: socketPath}
+	transport := &http.Transport{
+		DialContext:         c.dialContext,
+		IdleConnTimeout:     0,
+		MaxIdleConns:        1,
+		MaxIdleConnsPerHost: 1,
+	}
+	c.httpClient = &http.Client{Transport: transport}
+	return c
+}
+
+// dialContext hands the transport the connection pre-established by connect(),
+// and falls back to dialing the socket path directly if that connection was
+// already consumed.
+func (c *chAPIClient) dialContext(ctx context.Context, _, _ string) (net.Conn, error) {
+	c.dialMu.Lock()
+	defer c.dialMu.Unlock()
+	if c.heldConn != nil {
+		conn := c.heldConn
+		c.heldConn = nil
+		return conn, nil
+	}
+	var d net.Dialer
+	return d.DialContext(ctx, "unix", c.socketPath)
+}
+
+// connect blocks until the API socket exists and accepts connections, or the
+// timeout elapses. Cloud Hypervisor creates the socket shortly after it
+// starts, so the dial is retried tightly.
+func (c *chAPIClient) connect(timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("unix", c.socketPath, 50*time.Millisecond)
+		if err == nil {
+			c.dialMu.Lock()
+			c.heldConn = conn
+			c.dialMu.Unlock()
+			return nil
+		}
+		lastErr = err
+		time.Sleep(1 * time.Millisecond)
+	}
+	if lastErr == nil {
+		lastErr = context.DeadlineExceeded
+	}
+	return fmt.Errorf("cloud-hypervisor API socket %q not ready within %s: %w", c.socketPath, timeout, lastErr)
+}
+
+// createVM sends the full VM configuration.
+func (c *chAPIClient) createVM(ctx context.Context, cfg *CHVMConfig) error {
+	return c.put(ctx, "/api/v1/vm.create", cfg)
+}
+
+// bootVM boots the created VM.
+func (c *chAPIClient) bootVM(ctx context.Context) error {
+	return c.put(ctx, "/api/v1/vm.boot", nil)
+}
+
+// put sends body as an HTTP PUT to the given API path over the Unix socket,
+// returning an error for any non-2xx response. A nil body sends an empty
+// request.
+func (c *chAPIClient) put(ctx context.Context, path string, body any) error {
+	var payload []byte
+	if body != nil {
+		var err error
+		payload, err = json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("marshal %s request: %w", path, err)
+		}
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, "http://localhost"+path, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("build %s request: %w", path, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("send %s request: %w", path, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("%s returned HTTP %d: %s", path, resp.StatusCode, string(respBody))
+	}
+	return nil
+}

--- a/pkg/unikontainers/hypervisors/cloud_hypervisor_session_test.go
+++ b/pkg/unikontainers/hypervisors/cloud_hypervisor_session_test.go
@@ -1,0 +1,188 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hypervisors
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
+)
+
+type chRecordedRequest struct {
+	path string
+	body map[string]any
+}
+
+type fakeCHAPI struct {
+	mu       sync.Mutex
+	requests []chRecordedRequest
+}
+
+func (f *fakeCHAPI) recorded() []chRecordedRequest {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]chRecordedRequest, len(f.requests))
+	copy(out, f.requests)
+	return out
+}
+
+func startFakeCHAPI(t *testing.T) (*fakeCHAPI, string) {
+	t.Helper()
+	sockPath := filepath.Join(t.TempDir(), "ch.sock")
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("failed to listen on %s: %v", sockPath, err)
+	}
+	api := &fakeCHAPI{}
+	srv := &http.Server{
+		ReadHeaderTimeout: time.Second,
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			api.mu.Lock()
+			api.requests = append(api.requests, chRecordedRequest{path: r.URL.Path, body: body})
+			api.mu.Unlock()
+			w.WriteHeader(http.StatusNoContent)
+		}),
+	}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+	return api, sockPath
+}
+
+func newTestCHSession(t *testing.T, sockPath string) *CHSession {
+	t.Helper()
+	client := newCHAPIClient(sockPath)
+	if err := client.connect(2 * time.Second); err != nil {
+		t.Fatalf("connect failed: %v", err)
+	}
+	return &CHSession{client: client}
+}
+
+// TestCHConfigureVMSendsFullConfig verifies vm.create carries the complete
+// machine configuration mapped from ExecArgs: payload paths verbatim (no
+// rootfs prefixing), memory in bytes, both vcpu fields, net, disks, and the
+// fixed console/serial modes.
+func TestCHConfigureVMSendsFullConfig(t *testing.T) {
+	api, sockPath := startFakeCHAPI(t)
+	session := newTestCHSession(t, sockPath)
+
+	args := types.ExecArgs{
+		ContainerID:   "test-container",
+		Command:       "app -arg",
+		UnikernelPath: "/unikernel/app.bin",
+		InitrdPath:    "/unikernel/initrd",
+		MemSizeB:      256 * 1024 * 1024,
+		VCPUs:         2,
+	}
+	args.Net.TapDev = "tap0"
+	args.Net.MAC = "aa:bb:cc:dd:ee:ff"
+	args.Net.MTU = 1500
+	ukernel := &fakeUnikernel{
+		blockCli: []types.MonitorBlockArgs{{ID: "rootfs", Path: "/dev/mapper/test-snap-1"}},
+	}
+
+	if err := session.ConfigureVM(context.Background(), args, ukernel); err != nil {
+		t.Fatalf("ConfigureVM failed: %v", err)
+	}
+
+	reqs := api.recorded()
+	if len(reqs) != 1 || reqs[0].path != "/api/v1/vm.create" {
+		t.Fatalf("expected one PUT to /api/v1/vm.create, got %+v", reqs)
+	}
+	body := reqs[0].body
+
+	payload, _ := body["payload"].(map[string]any)
+	if payload["kernel"] != "/unikernel/app.bin" || payload["cmdline"] != "app -arg" || payload["initramfs"] != "/unikernel/initrd" {
+		t.Errorf("unexpected payload: %v", payload)
+	}
+	memory, _ := body["memory"].(map[string]any)
+	if memory["size"] != float64(256*1024*1024) {
+		t.Errorf("memory.size = %v, want bytes not MB", memory["size"])
+	}
+	cpus, _ := body["cpus"].(map[string]any)
+	if cpus["boot_vcpus"] != float64(2) || cpus["max_vcpus"] != float64(2) {
+		t.Errorf("unexpected cpus: %v", cpus)
+	}
+	nets, _ := body["net"].([]any)
+	if len(nets) != 1 {
+		t.Fatalf("expected one net device, got %v", body["net"])
+	}
+	net0, _ := nets[0].(map[string]any)
+	if net0["tap"] != "tap0" || net0["mac"] != "aa:bb:cc:dd:ee:ff" || net0["mtu"] != float64(1500) {
+		t.Errorf("unexpected net[0]: %v", net0)
+	}
+	disks, _ := body["disks"].([]any)
+	if len(disks) != 1 {
+		t.Fatalf("expected one disk, got %v", body["disks"])
+	}
+	disk0, _ := disks[0].(map[string]any)
+	if disk0["path"] != "/dev/mapper/test-snap-1" {
+		t.Errorf("disk path = %v, want unprefixed", disk0["path"])
+	}
+	serial, _ := body["serial"].(map[string]any)
+	console, _ := body["console"].(map[string]any)
+	if serial["mode"] != "Tty" || console["mode"] != "Off" {
+		t.Errorf("serial=%v console=%v", serial, console)
+	}
+}
+
+// TestCHBootAfterCreate verifies the request ordering create then boot.
+func TestCHBootAfterCreate(t *testing.T) {
+	api, sockPath := startFakeCHAPI(t)
+	session := newTestCHSession(t, sockPath)
+	ctx := context.Background()
+
+	args := types.ExecArgs{ContainerID: "test-container", Command: "app", UnikernelPath: "/unikernel/app.bin", MemSizeB: 256 * 1024 * 1024, VCPUs: 1}
+	if err := session.ConfigureVM(ctx, args, &fakeUnikernel{}); err != nil {
+		t.Fatalf("ConfigureVM failed: %v", err)
+	}
+	if err := session.BootVM(ctx); err != nil {
+		t.Fatalf("BootVM failed: %v", err)
+	}
+	want := []string{"/api/v1/vm.create", "/api/v1/vm.boot"}
+	reqs := api.recorded()
+	if len(reqs) != len(want) {
+		t.Fatalf("expected %v, got %+v", want, reqs)
+	}
+	for i := range want {
+		if reqs[i].path != want[i] {
+			t.Errorf("request %d: got %s, want %s", i, reqs[i].path, want[i])
+		}
+	}
+}
+
+// TestCHConfigureVMRejectsRawCliOverrides verifies the documented limitation:
+// unikernel-provided raw CLI argument strings cannot be mapped to the REST
+// config and must fail loudly rather than be silently dropped.
+func TestCHConfigureVMRejectsRawCliOverrides(t *testing.T) {
+	_, sockPath := startFakeCHAPI(t)
+	session := newTestCHSession(t, sockPath)
+
+	args := types.ExecArgs{ContainerID: "test-container", Command: "app", UnikernelPath: "/unikernel/app.bin", MemSizeB: 256 * 1024 * 1024, VCPUs: 1}
+	ukernel := &fakeUnikernel{
+		blockCli: []types.MonitorBlockArgs{{ID: "vol0", ExactArgs: []string{"--disk", "path=/x"}}},
+	}
+	if err := session.ConfigureVM(context.Background(), args, ukernel); err == nil {
+		t.Fatal("ConfigureVM accepted a raw CLI override it cannot map")
+	}
+}

--- a/pkg/unikontainers/hypervisors/utils.go
+++ b/pkg/unikontainers/hypervisors/utils.go
@@ -17,10 +17,12 @@ package hypervisors
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"time"
 
+	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
 	"golang.org/x/sys/unix"
 )
 
@@ -85,4 +87,18 @@ func killProcess(pid int) error {
 	}
 
 	return nil
+}
+
+// DefaultSocketDir is the directory used for a monitor's control socket when
+// no socket_path is configured. It always exists inside the monitor rootfs.
+const DefaultSocketDir = "/tmp"
+
+// ResolveSocketPath returns the path for a monitor's control socket: the
+// configured SocketPath when set, otherwise a per-container default under
+// DefaultSocketDir.
+func ResolveSocketPath(args types.ExecArgs) string {
+	if args.SocketPath != "" {
+		return args.SocketPath
+	}
+	return filepath.Join(DefaultSocketDir, args.ContainerID+".sock")
 }

--- a/pkg/unikontainers/hypervisors/utils_test.go
+++ b/pkg/unikontainers/hypervisors/utils_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
 )
 
 func TestBytesToMiB(t *testing.T) {
@@ -69,5 +70,25 @@ func TestBytesToMB(t *testing.T) {
 			t.Parallel()
 			assert.Equal(t, tc.expected, bytesToMB(tc.input))
 		})
+	}
+}
+
+func TestResolveSocketPath(t *testing.T) {
+	t.Parallel()
+	if got := ResolveSocketPath(types.ExecArgs{SocketPath: "/run/urunc/x.sock"}); got != "/run/urunc/x.sock" {
+		t.Fatalf("configured: got %q", got)
+	}
+	if got := ResolveSocketPath(types.ExecArgs{ContainerID: "abc"}); got != "/tmp/abc.sock" {
+		t.Fatalf("default: got %q", got)
+	}
+}
+
+func TestUsesControlSocket(t *testing.T) {
+	t.Parallel()
+	if !UsesControlSocket(CloudHypervisorVmm) {
+		t.Fatal("cloud-hypervisor should use a control socket")
+	}
+	if UsesControlSocket(HvtVmm) {
+		t.Fatal("hvt should not")
 	}
 }

--- a/pkg/unikontainers/hypervisors/vmm.go
+++ b/pkg/unikontainers/hypervisors/vmm.go
@@ -27,6 +27,17 @@ const DefaultMemory uint64 = 256 // The default memory for every hypervisor: 256
 
 type VmmType string
 
+// UsesControlSocket reports whether a monitor exposes a control socket whose
+// path (socket_path) urunc must make reachable before the monitor launches.
+func UsesControlSocket(vmmType VmmType) bool {
+	switch vmmType {
+	case CloudHypervisorVmm:
+		return true
+	default:
+		return false
+	}
+}
+
 var ErrVMMNotInstalled = errors.New("vmm not found")
 var vmmLog = logrus.WithField("subsystem", "monitors")
 

--- a/pkg/unikontainers/types/types.go
+++ b/pkg/unikontainers/types/types.go
@@ -148,5 +148,5 @@ type MonitorConfig struct {
 	DataPath        string `toml:"data_path,omitempty"`   // Optional path to the hypervisor data files (e.g. qemu bios stuff)
 	Vhost           bool   `toml:"vhost,omitempty"`       // Optional: enable vhost for network performance optimization
 	SocketPath      string `toml:"socket_path,omitempty"` // Optional path for the monitor's control socket (falls back to a per-container default)
-	BootMode        string `toml:"boot_mode,omitempty"`
+	BootMode        string `toml:"boot_mode,omitempty"`   // Optional boot mode for the monitor. "api" drives the guest's start over the monitor's control socket; any other value boots the monitor from its command line as before.
 }

--- a/pkg/unikontainers/types/types.go
+++ b/pkg/unikontainers/types/types.go
@@ -116,6 +116,7 @@ type ExecArgs struct {
 	VSockDevPath  string   // The directory inside the monitor rootfs with the vAccel unix sockets
 	VSockDevID    int      // The guest-cid
 	SocketPath    string   // The path of the monitor's control socket (empty means the monitor's default)
+	BootMode      string   // Optional boot mode for the monitor. "api" drives the guest's start over the monitor's control socket; any other value boots the monitor from its command line as before.
 	Net           NetDevParams
 	Sharedfs      SharedfsParams
 }
@@ -147,4 +148,5 @@ type MonitorConfig struct {
 	DataPath        string `toml:"data_path,omitempty"`   // Optional path to the hypervisor data files (e.g. qemu bios stuff)
 	Vhost           bool   `toml:"vhost,omitempty"`       // Optional: enable vhost for network performance optimization
 	SocketPath      string `toml:"socket_path,omitempty"` // Optional path for the monitor's control socket (falls back to a per-container default)
+	BootMode        string `toml:"boot_mode,omitempty"`
 }

--- a/pkg/unikontainers/types/types.go
+++ b/pkg/unikontainers/types/types.go
@@ -115,6 +115,7 @@ type ExecArgs struct {
 	VAccelType    string   // Specifies the vAccel acceleration type(e.g. vsock). When empty, vAccel is disabled
 	VSockDevPath  string   // The directory inside the monitor rootfs with the vAccel unix sockets
 	VSockDevID    int      // The guest-cid
+	SocketPath    string   // The path of the monitor's control socket (empty means the monitor's default)
 	Net           NetDevParams
 	Sharedfs      SharedfsParams
 }
@@ -142,7 +143,8 @@ type ExtraBinConfig struct {
 type MonitorConfig struct {
 	DefaultMemoryMB uint   `toml:"default_memory_mb"`
 	DefaultVCPUs    uint   `toml:"default_vcpus"`
-	BinaryPath      string `toml:"path,omitempty"`      // Optional path to the hypervisor binary
-	DataPath        string `toml:"data_path,omitempty"` // Optional path to the hypervisor data files (e.g. qemu bios stuff)
-	Vhost           bool   `toml:"vhost,omitempty"`     // Optional: enable vhost for network performance optimization
+	BinaryPath      string `toml:"path,omitempty"`        // Optional path to the hypervisor binary
+	DataPath        string `toml:"data_path,omitempty"`   // Optional path to the hypervisor data files (e.g. qemu bios stuff)
+	Vhost           bool   `toml:"vhost,omitempty"`       // Optional: enable vhost for network performance optimization
+	SocketPath      string `toml:"socket_path,omitempty"` // Optional path for the monitor's control socket (falls back to a per-container default)
 }

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -16,6 +16,7 @@ package unikontainers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -688,6 +689,27 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 		vmmArgs.VSockDevID = idToGuestCID(u.State.ID)
 	}
 
+	// api boot mode: Cloud Hypervisor is spawned bare right after changeRoot
+	// below, so the monitor and its API socket are confined inside the
+	// monitor rootfs. The whole VM configuration is sent over the socket,
+	// and the guest only boots when vm.boot is sent after the start-success
+	// handshake, preserving OCI start ordering.
+	isAPIBoot := vmmArgs.BootMode == "api" && ms.MonitorType == string(hypervisors.CloudHypervisorVmm)
+	if isAPIBoot && vmmArgs.Sharedfs.Type == "virtiofs" {
+		return fmt.Errorf("boot_mode=api does not support the virtiofs shared filesystem yet")
+	}
+	var chSession *hypervisors.CHSession
+	chHandedOff := false
+	defer func() {
+		// Any error return after the spawn must not leave the VMM child
+		// behind. Supervise never returns (os.Exit), so this only fires on
+		// error paths.
+		if chSession != nil && !chHandedOff {
+			chSession.Kill()
+		}
+	}()
+	ctx := context.Background()
+
 	// pivot
 	_, err = findNS(u.Spec.Linux.Namespaces, specs.MountNamespace)
 	// Only pivot if a mount namespace entry is actually present in the
@@ -735,6 +757,25 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 		}
 	}
 
+	// urunc is still privileged at this point; the child is started directly
+	// under the container user's credentials, and urunc drops its own
+	// privileges right after (setupUser below).
+	if isAPIBoot {
+		ch, ok := vmm.(*hypervisors.CloudHypervisor)
+		if !ok {
+			return fmt.Errorf("boot_mode=api is only supported for the cloud-hypervisor monitor")
+		}
+		chSession, err = ch.SpawnSocketVMM(vmmArgs, u.Spec.Process.User.UID, u.Spec.Process.User.GID)
+		if err != nil {
+			uniklog.Errorf("failed to spawn cloud-hypervisor: %v", err)
+			return err
+		}
+		if err = chSession.ConfigureVM(ctx, vmmArgs, unikernel); err != nil {
+			uniklog.Errorf("failed to configure the vm over the socket: %v", err)
+			return err
+		}
+	}
+
 	// uid/gid
 	// Setup uid, gid and additional groups for the monitor process
 	err = setupUser(u.Spec.Process.User)
@@ -760,10 +801,15 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 
 	// Build the VMM command once and verify it can be constructed successfully, so
 	// we do not report the container as started if command building fails.
-	execCmd, err := vmm.BuildExecCmd(vmmArgs, unikernel)
-	if err != nil {
-		uniklog.WithError(err).Error("failed to build VMM command")
-		return err
+	// For the api boot mode the VMM is already running and fully configured
+	// (the equivalent validation), so there is no command to build.
+	var execCmd []string
+	if !isAPIBoot {
+		execCmd, err = vmm.BuildExecCmd(vmmArgs, unikernel)
+		if err != nil {
+			uniklog.WithError(err).Error("failed to build VMM command")
+			return err
+		}
 	}
 
 	// Notify urunc start that the monitor is ready to execute, only after the
@@ -771,6 +817,19 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 	err = u.SendMessage(StartSuccess)
 	if err != nil {
 		return err
+	}
+
+	if isAPIBoot {
+		// The VMM is up and configured; boot the guest and hand this process
+		// over to supervising the child. This process must not exit before
+		// the child, since it is the container's init process.
+		metrics.Capture(m.TS18)
+		if err = chSession.BootVM(ctx); err != nil {
+			uniklog.Errorf("failed to boot the guest: %v", err)
+			return err
+		}
+		chHandedOff = true
+		return chSession.Supervise()
 	}
 
 	return execMonitor(metrics, vmm, vmmArgs, execCmd)

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -511,6 +511,7 @@ func (u *Unikontainer) buildMonitorSpec(rootfsParams types.RootfsParams, monRes 
 	}
 	defaultMemSizeMB := u.UruncCfg.Monitors[vmmType].DefaultMemoryMB
 	socketPath := u.UruncCfg.Monitors[vmmType].SocketPath
+	bootMode := u.UruncCfg.Monitors[vmmType].BootMode
 
 	vmmArgs := types.ExecArgs{
 		ContainerID:   u.State.ID,
@@ -521,6 +522,7 @@ func (u *Unikontainer) buildMonitorSpec(rootfsParams types.RootfsParams, monRes 
 		VCPUs:         uint(defaultVCPUs),
 		Environment:   os.Environ(),
 		SocketPath:    socketPath,
+		BootMode:      bootMode,
 	}
 
 	// Check if container is set to unconfined -- disable seccomp

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -510,6 +510,7 @@ func (u *Unikontainer) buildMonitorSpec(rootfsParams types.RootfsParams, monRes 
 		defaultVCPUs = 1
 	}
 	defaultMemSizeMB := u.UruncCfg.Monitors[vmmType].DefaultMemoryMB
+	socketPath := u.UruncCfg.Monitors[vmmType].SocketPath
 
 	vmmArgs := types.ExecArgs{
 		ContainerID:   u.State.ID,
@@ -519,6 +520,7 @@ func (u *Unikontainer) buildMonitorSpec(rootfsParams types.RootfsParams, monRes 
 		MemSizeB:      monitorMemoryBytes(defaultMemSizeMB, u.Spec.Linux.Resources),
 		VCPUs:         uint(defaultVCPUs),
 		Environment:   os.Environ(),
+		SocketPath:    socketPath,
 	}
 
 	// Check if container is set to unconfined -- disable seccomp
@@ -722,6 +724,13 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 	vmmArgs.Command, err = buildUnikernelCommand(unikernel, unikernelParams)
 	if err != nil {
 		return err
+	}
+
+	if hypervisors.UsesControlSocket(hypervisors.VmmType(ms.MonitorType)) {
+		sockDir := filepath.Dir(hypervisors.ResolveSocketPath(vmmArgs))
+		if err = os.MkdirAll(sockDir, 0o755); err != nil {
+			return fmt.Errorf("failed to create control socket directory %q: %w", sockDir, err)
+		}
 	}
 
 	// uid/gid

--- a/pkg/unikontainers/urunc_config.go
+++ b/pkg/unikontainers/urunc_config.go
@@ -220,6 +220,7 @@ func (p *UruncConfig) Map() map[string]string {
 		cfgMap[prefix+"binary_path"] = hvCfg.BinaryPath
 		cfgMap[prefix+"data_path"] = hvCfg.DataPath
 		cfgMap[prefix+"vhost"] = strconv.FormatBool(hvCfg.Vhost)
+		cfgMap[prefix+"socket_path"] = hvCfg.SocketPath
 	}
 	for eb, ebCfg := range p.ExtraBins {
 		prefix := "urunc_config.extra_binaries." + eb + "."
@@ -274,6 +275,8 @@ func UruncConfigFromMap(cfgMap map[string]string) *UruncConfig {
 			} else {
 				hvCfg.Vhost = boolVal
 			}
+		case "socket_path":
+			hvCfg.SocketPath = val
 		}
 		cfg.Monitors[hv] = hvCfg
 	}

--- a/pkg/unikontainers/urunc_config.go
+++ b/pkg/unikontainers/urunc_config.go
@@ -221,6 +221,7 @@ func (p *UruncConfig) Map() map[string]string {
 		cfgMap[prefix+"data_path"] = hvCfg.DataPath
 		cfgMap[prefix+"vhost"] = strconv.FormatBool(hvCfg.Vhost)
 		cfgMap[prefix+"socket_path"] = hvCfg.SocketPath
+		cfgMap[prefix+"boot_mode"] = hvCfg.BootMode
 	}
 	for eb, ebCfg := range p.ExtraBins {
 		prefix := "urunc_config.extra_binaries." + eb + "."
@@ -277,6 +278,8 @@ func UruncConfigFromMap(cfgMap map[string]string) *UruncConfig {
 			}
 		case "socket_path":
 			hvCfg.SocketPath = val
+		case "boot_mode":
+			hvCfg.BootMode = val
 		}
 		cfg.Monitors[hv] = hvCfg
 	}


### PR DESCRIPTION
## Description

Expose Cloud Hypervisor's REST API socket, and add a `boot_mode` option that can drive the whole boot over it.

- `cloud_hypervisor.go` launches with `--api-socket path=<socket_path>`.
- The socket path is configurable via a `socket_path` monitor field; when a custom path is set, urunc creates its parent directory inside the monitor rootfs. Default is a per-container path under `/tmp`.
- `boot_mode = "api"` starts Cloud Hypervisor as a supervised child with only `--api-socket`, sends the whole VM configuration in one `vm.create`, and sends `vm.boot` only after the start handshake. urunc then supervises the child. The monitor is spawned after `changeRoot`, so its socket stays inside the monitor rootfs. Without `boot_mode = "api"` the exec-based boot is unchanged.

This PR is self-contained against `main`: it carries a small copy of the shared socket infrastructure (`socket_path` field, `ResolveSocketPath`, `DefaultSocketDir`, `UsesControlSocket`, the socket-directory creation). The same infra also appears in the Firecracker (#809) and QEMU (#841) PRs; whichever merges first lands it, and this PR then rebases to drop the duplicate. This PR does not touch `firecracker.go` or `qemu.go`.

### Related issues

- Related to #756

### How was this tested?

- `go build ./...`, `go test ./pkg/... ./internal/...`, `gofmt`, and cspell pass (Ubuntu 24.04 aarch64 VM, KVM, Cloud Hypervisor v53).
- Full guest-boot verification on aarch64 is currently blocked: no aarch64 Cloud Hypervisor image is published in the registry (the `ubuntu-cloud-hypervisor-linux-raw` and `chttp-cloud-hypervisor-*` variants return 404), and Cloud Hypervisor v53 has a known raw-disk/console issue on aarch64, both unrelated to this change. The `--api-socket` wiring itself is covered by the unit tests and the shared `ResolveSocketPath` tests. Once an aarch64 image is available, the socket can be verified answering `/api/v1/vm.info`, the same way Firecracker (#809) and QEMU (#841) were verified.

### LLM usage
claude code (opus 4.8) for the understanding of codebase, approach decisions and coding

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
