### PR TITLE
refactor: replace string concatenation in monitor CLI option construc…

### DIFF
--- a/.github/contributors.yaml
+++ b/.github/contributors.yaml
@@ -140,3 +140,6 @@ users:
   singhshresth26:
     name: Shresth Singh
     email: shresthengineer@gmail.com
+  r0binak:
+    name: Sergey Kanibor
+    email: r081n4k@gmail.com

--- a/.github/contributors.yaml
+++ b/.github/contributors.yaml
@@ -137,3 +137,6 @@ users:
   aman21-droid:
     name: aman21-droid
     email: amanarora.smn@gmail.com
+  singhshresth26:
+    name: Shresth Singh
+    email: shresthengineer@gmail.com

--- a/.github/linters/urunc-dict.txt
+++ b/.github/linters/urunc-dict.txt
@@ -441,3 +441,4 @@ werr
 cerr
 inodes
 newc
+Shresth

--- a/pkg/unikontainers/hypervisors/cloud_hypervisor.go
+++ b/pkg/unikontainers/hypervisors/cloud_hypervisor.go
@@ -16,7 +16,7 @@ package hypervisors
 
 import (
 	"fmt"
-	"strings"
+	"strconv"
 
 	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
 	"golang.org/x/sys/unix"
@@ -72,14 +72,17 @@ func (ch *CloudHypervisor) BuildExecCmd(args types.ExecArgs, ukernel types.Unike
 
 	// Memory configuration
 	if args.Sharedfs.Type == "virtiofs" {
-		exArgs = append(exArgs, "--memory", fmt.Sprintf("size=%sM,shared=on", chMem))
+		memArg := "size=" + chMem + "M,shared=on"
+		exArgs = append(exArgs, "--memory", memArg)
 	} else {
-		exArgs = append(exArgs, "--memory", fmt.Sprintf("size=%sM", chMem))
+		memArg := "size=" + chMem + "M"
+		exArgs = append(exArgs, "--memory", memArg)
 	}
 
 	// CPU configuration
 	if args.VCPUs > 0 {
-		exArgs = append(exArgs, "--cpus", fmt.Sprintf("boot=%d", args.VCPUs))
+		cpuArg := "boot=" + strconv.FormatUint(uint64(args.VCPUs), 10)
+		exArgs = append(exArgs, "--cpus", cpuArg)
 	}
 
 	// Kernel path
@@ -98,23 +101,24 @@ func (ch *CloudHypervisor) BuildExecCmd(args types.ExecArgs, ukernel types.Unike
 	// Network configuration
 	if args.Net.TapDev != "" {
 		netCli := ukernel.MonitorNetCli(args.Net.TapDev, args.Net.MAC)
-		if netCli == "" {
+		if len(netCli) == 0 {
 			// Default network configuration for Cloud Hypervisor
-			exArgs = append(exArgs, "--net", fmt.Sprintf("tap=%s,mac=%s,mtu=%d", args.Net.TapDev, args.Net.MAC, args.Net.MTU))
+			netArg := fmt.Sprintf("tap=%s,mac=%s,mtu=%d", args.Net.TapDev, args.Net.MAC, args.Net.MTU)
+			exArgs = append(exArgs, "--net", netArg)
 		} else {
-			exArgs = append(exArgs, strings.Split(strings.TrimSpace(netCli), " ")...)
+			exArgs = append(exArgs, netCli...)
 		}
 	}
 
 	// Block device configuration
 	blockArgs := ukernel.MonitorBlockCli()
 	for _, blockArg := range blockArgs {
-		if blockArg.ExactArgs != "" {
-			exArgs = append(exArgs, strings.Split(strings.TrimSpace(blockArg.ExactArgs), " ")...)
+		if len(blockArg.ExactArgs) > 0 {
+			exArgs = append(exArgs, blockArg.ExactArgs...)
 		} else if blockArg.Path != "" {
-			diskArg := fmt.Sprintf("path=%s", blockArg.Path)
+			diskArg := "path=" + blockArg.Path
 			if blockArg.ID != "" {
-				diskArg += fmt.Sprintf(",id=%s", blockArg.ID)
+				diskArg += ",id=" + blockArg.ID
 			}
 			exArgs = append(exArgs, "--disk", diskArg)
 		}
@@ -139,12 +143,12 @@ func (ch *CloudHypervisor) BuildExecCmd(args types.ExecArgs, ukernel types.Unike
 	}
 
 	if args.VAccelType == "vsock" {
-		exArgs = append(exArgs, "--vsock", fmt.Sprintf("cid=%d,socket=%s/vaccel.sock",
-			args.VSockDevID, args.VSockDevPath))
+		vsockArg := fmt.Sprintf("cid=%d,socket=%s/vaccel.sock", args.VSockDevID, args.VSockDevPath)
+		exArgs = append(exArgs, "--vsock", vsockArg)
 	}
 
-	if extraMonArgs.OtherArgs != "" {
-		exArgs = append(exArgs, strings.Split(strings.TrimSpace(extraMonArgs.OtherArgs), " ")...)
+	if len(extraMonArgs.OtherArgs) > 0 {
+		exArgs = append(exArgs, extraMonArgs.OtherArgs...)
 	}
 
 	// Add the command line arguments for the kernel

--- a/pkg/unikontainers/hypervisors/firecracker.go
+++ b/pkg/unikontainers/hypervisors/firecracker.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
 	"golang.org/x/sys/unix"
@@ -108,11 +107,10 @@ func (fc *Firecracker) BuildExecCmd(args types.ExecArgs, ukernel types.Unikernel
 	// options in FC, since the string return value of the Monitor related
 	// functions in the unikernel interface do not integrate well with FC's
 	// json configuration.
-	cmdString := fc.Path() + " --no-api --config-file "
 	JSONConfigFile := filepath.Join("/tmp/", FCJsonFilename)
-	cmdString += JSONConfigFile
+	exArgs := []string{fc.Path(), "--no-api", "--config-file", JSONConfigFile}
 	if !args.Seccomp {
-		cmdString += " --no-seccomp"
+		exArgs = append(exArgs, "--no-seccomp")
 	}
 
 	// VM config for Firecracker
@@ -200,7 +198,6 @@ func (fc *Firecracker) BuildExecCmd(args types.ExecArgs, ukernel types.Unikernel
 	}
 	vmmLog.WithField("Json", string(FCConfigJSON)).Debug("Firecracker json config")
 
-	exArgs := strings.Split(cmdString, " ")
 	return exArgs, nil
 }
 

--- a/pkg/unikontainers/hypervisors/hvt.go
+++ b/pkg/unikontainers/hypervisors/hvt.go
@@ -17,7 +17,6 @@ package hypervisors
 import (
 	"os/exec"
 	"runtime"
-	"strings"
 
 	seccomp "github.com/elastic/go-seccomp-bpf"
 	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
@@ -27,6 +26,8 @@ import (
 const (
 	HvtVmm    VmmType = "hvt"
 	HvtBinary string  = "solo5-hvt"
+	// solo5ArgsSeparator terminates the tender options in a solo5 cli
+	solo5ArgsSeparator = "--"
 )
 
 type HVT struct {
@@ -154,21 +155,24 @@ func (h *HVT) Ok() error {
 
 func (h *HVT) BuildExecCmd(args types.ExecArgs, ukernel types.Unikernel) ([]string, error) {
 	hvtMem := BytesToStringMB(args.MemSizeB)
-	cmdString := h.binaryPath + " --mem=" + hvtMem
+	exArgs := []string{h.binaryPath, "--mem=" + hvtMem}
 	if args.Net.TapDev != "" {
-		cmdString += " "
-		cmdString += ukernel.MonitorNetCli(args.Net.TapDev, args.Net.MAC)
+		netCli := ukernel.MonitorNetCli(args.Net.TapDev, args.Net.MAC)
+		exArgs = append(exArgs, netCli...)
 	}
-	extraMonArgs := ukernel.MonitorCli()
 	bArgs := ukernel.MonitorBlockCli()
 	for _, blockArg := range bArgs {
-		cmdString = appendNonEmpty(cmdString, " --block:"+blockArg.ID+"=",
-			blockArg.Path)
+		if blockArg.Path != "" {
+			exArgs = append(exArgs, "--block:"+blockArg.ID+"="+blockArg.Path)
+		}
 	}
-	cmdString = appendNonEmpty(cmdString, " ", extraMonArgs.OtherArgs)
-	cmdString += " " + args.UnikernelPath + " " + args.Command
-	cmdArgs := strings.Split(cmdString, " ")
-	return cmdArgs, nil
+	extraMonArgs := ukernel.MonitorCli()
+	exArgs = append(exArgs, extraMonArgs.OtherArgs...)
+	exArgs = append(exArgs, solo5ArgsSeparator, args.UnikernelPath)
+	if args.Command != "" {
+		exArgs = append(exArgs, args.Command)
+	}
+	return exArgs, nil
 }
 
 // PreExec performs pre-execution setup for HVT.

--- a/pkg/unikontainers/hypervisors/hvt_test.go
+++ b/pkg/unikontainers/hypervisors/hvt_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hypervisors
+
+import "testing"
+
+func newTestHVT() *HVT {
+	return &HVT{binary: HvtBinary, binaryPath: testHvtBinary}
+}
+
+func TestHvtBuildExecCmd(t *testing.T) {
+	t.Parallel()
+	runSolo5BuildExecCmd(t, newTestHVT())
+}
+
+func TestHvtUnikernelPathIsAlwaysOneArgvElement(t *testing.T) {
+	t.Parallel()
+	runSolo5UnikernelPathOneElement(t, newTestHVT())
+}
+
+func TestHvtGuestCommandIsASingleElement(t *testing.T) {
+	t.Parallel()
+	runSolo5GuestCommandOneElement(t, newTestHVT())
+}

--- a/pkg/unikontainers/hypervisors/hyperlight.go
+++ b/pkg/unikontainers/hypervisors/hyperlight.go
@@ -15,7 +15,7 @@
 package hypervisors
 
 import (
-	"fmt"
+	"strconv"
 
 	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
 	"golang.org/x/sys/unix"
@@ -68,7 +68,8 @@ func (h *Hyperlight) BuildExecCmd(args types.ExecArgs, _ types.Unikernel) ([]str
 		cmdArgs = append(cmdArgs, "--initrd", args.InitrdPath)
 	}
 	if args.MemSizeB > 0 {
-		cmdArgs = append(cmdArgs, "--memory", fmt.Sprintf("%d", args.MemSizeB))
+		memArg := strconv.FormatUint(args.MemSizeB, 10)
+		cmdArgs = append(cmdArgs, "--memory", memArg)
 	}
 	return cmdArgs, nil
 }

--- a/pkg/unikontainers/hypervisors/qemu.go
+++ b/pkg/unikontainers/hypervisors/qemu.go
@@ -17,7 +17,7 @@ package hypervisors
 import (
 	"fmt"
 	"runtime"
-	"strings"
+	"strconv"
 
 	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
 	"golang.org/x/sys/unix"
@@ -62,87 +62,103 @@ func (q *Qemu) Path() string {
 
 func (q *Qemu) BuildExecCmd(args types.ExecArgs, ukernel types.Unikernel) ([]string, error) {
 	qemuMem := BytesToStringMB(args.MemSizeB)
-	cmdString := q.binaryPath + " -m " + qemuMem + "M"
-	cmdString += " -L /usr/share/qemu"                                  // Set the path for qemu bios/data
-	cmdString += " -cpu host"                                           // Choose CPU
-	cmdString += " -enable-kvm"                                         // Enable KVM to use CPU virt extensions
-	cmdString += " -display none -vga none -serial stdio -monitor null" // Disable graphic output
+	exArgs := []string{
+		q.binaryPath,
+		"-m", qemuMem + "M",
+		"-L", "/usr/share/qemu", // Set the path for qemu bios/data
+		"-cpu", "host", // Choose CPU
+		"-enable-kvm",      // Enable KVM to use CPU virt extensions
+		"-display", "none", // Disable graphic output
+		"-vga", "none",
+		"-serial", "stdio",
+		"-monitor", "null",
+	}
 
 	if args.VCPUs > 0 {
-		cmdString += fmt.Sprintf(" -smp %d", args.VCPUs)
+		exArgs = append(exArgs, "-smp", strconv.FormatUint(uint64(args.VCPUs), 10))
 	}
 
 	if args.Seccomp {
-		// Enable Seccomp in QEMU
-		cmdString += " --sandbox on"
-		// Allow or Deny Obsolete system calls
-		cmdString += ",obsolete=deny"
-		// Allow or Deny set*uid|gid system calls
-		cmdString += ",elevateprivileges=deny"
-		// Allow or Deny *fork and execve
-		cmdString += ",spawn=deny"
-		// Allow or Deny process affinity and schedular priority
-		cmdString += ",resourcecontrol=deny"
+		// Enable Seccomp in QEMU. The sandbox options below:
+		//   obsolete=deny          - Deny Obsolete system calls
+		//   elevateprivileges=deny - Deny set*uid|gid system calls
+		//   spawn=deny             - Deny *fork and execve
+		//   resourcecontrol=deny   - Deny process affinity and scheduler priority
+		exArgs = append(exArgs,
+			"--sandbox", "on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny",
+		)
 	}
 
-	// TODO: Check if this check causes any performance drop
-	// or explore alternative implementations
+	// TODO: explore alternative implementations
 	if runtime.GOARCH == "arm64" {
-		machineType := " -M virt"
-		cmdString += machineType
+		exArgs = append(exArgs, "-M", "virt")
 	}
 
-	cmdString += " -kernel " + args.UnikernelPath
+	exArgs = append(exArgs, "-kernel", args.UnikernelPath)
 	if args.Net.TapDev != "" {
 		netcli := ukernel.MonitorNetCli(args.Net.TapDev, args.Net.MAC)
-		if netcli == "" {
-			netcli += " -netdev tap,id=net0,script=no,downscript=no,ifname="
-			netcli += args.Net.TapDev
+		if len(netcli) == 0 {
+			netdevArg := fmt.Sprintf("tap,id=net0,script=no,downscript=no,ifname=%s", args.Net.TapDev)
 			if q.vhost {
-				netcli += ",vhost=on"
+				netdevArg += ",vhost=on"
 			}
-			netcli += fmt.Sprintf(" %s,host_mtu=%d,mac=%s", getVirtioNetArg(), args.Net.MTU, args.Net.MAC)
+			exArgs = append(exArgs, "-netdev", netdevArg)
+
+			devType := "virtio-net-pci"
+			if runtime.GOARCH == "arm64" {
+				devType = "virtio-net-device"
+			}
+			netCliDev := fmt.Sprintf("%s,netdev=net0,host_mtu=%d,mac=%s", devType, args.Net.MTU, args.Net.MAC)
+			exArgs = append(exArgs, "-device", netCliDev)
+		} else {
+			exArgs = append(exArgs, netcli...)
 		}
-		cmdString += netcli
 	} else {
-		cmdString += " -nic none"
+		exArgs = append(exArgs, "-nic", "none")
 	}
+
 	blockArgs := ukernel.MonitorBlockCli()
 	for _, blockArg := range blockArgs {
-		blockCli := blockArg.ExactArgs
-		if blockCli == "" && blockArg.ID != "" && blockArg.Path != "" {
-			blockCli1 := fmt.Sprintf(" -device virtio-blk-pci,serial=%s,drive=%s,scsi=off", blockArg.ID, blockArg.ID)
-			blockCli2 := fmt.Sprintf(" -drive format=raw,if=none,id=%s,file=%s", blockArg.ID, blockArg.Path)
-			blockCli = blockCli1 + blockCli2
+		if blockArg.ID != "" && blockArg.Path != "" {
+			devArg := fmt.Sprintf("virtio-blk-pci,serial=%s,drive=%s,scsi=off", blockArg.ID, blockArg.ID)
+			drvArg := fmt.Sprintf("format=raw,if=none,id=%s,file=%s", blockArg.ID, blockArg.Path)
+			exArgs = append(exArgs, "-device", devArg, "-drive", drvArg)
+		} else if len(blockArg.ExactArgs) > 0 {
+			exArgs = append(exArgs, blockArg.ExactArgs...)
 		}
-		cmdString += blockCli
 	}
+
 	if args.InitrdPath != "" {
-		cmdString += " -initrd " + args.InitrdPath
+		exArgs = append(exArgs, "-initrd", args.InitrdPath)
 	}
+
 	switch args.Sharedfs.Type {
 	case "9pfs":
-		cmdString += " -fsdev local,id=rootfs9p,security_model=none,path=" + args.Sharedfs.Path
-		cmdString += " -device virtio-9p-pci,fsdev=rootfs9p,mount_tag=fs0"
+		fsdevArg := fmt.Sprintf("local,id=rootfs9p,security_model=none,path=%s", args.Sharedfs.Path)
+		exArgs = append(exArgs, "-fsdev", fsdevArg, "-device", "virtio-9p-pci,fsdev=rootfs9p,mount_tag=fs0")
 	case "virtiofs":
-		cmdString += " -object memory-backend-file,id=mem,size=" + qemuMem + "M,mem-path=/tmp,share=on"
-		cmdString += " -numa node,memdev=mem"
-		cmdString += " -chardev socket,id=char0,path=/tmp/vhostqemu"
-		cmdString += " -device vhost-user-fs-pci,queue-size=1024,chardev=char0,tag=fs0"
+		objArg := fmt.Sprintf("memory-backend-file,id=mem,size=%sM,mem-path=/tmp,share=on", qemuMem)
+		exArgs = append(exArgs,
+			"-object", objArg,
+			"-numa", "node,memdev=mem",
+			"-chardev", "socket,id=char0,path=/tmp/vhostqemu",
+			"-device", "vhost-user-fs-pci,queue-size=1024,chardev=char0,tag=fs0",
+		)
 	default:
 		// Nothing to add
 	}
+
 	extraMonArgs := ukernel.MonitorCli()
 	if extraMonArgs.ExtraInitrd != "" {
-		cmdString += " -initrd " + extraMonArgs.ExtraInitrd
+		exArgs = append(exArgs, "-initrd", extraMonArgs.ExtraInitrd)
 	}
-	cmdString += extraMonArgs.OtherArgs
+	exArgs = append(exArgs, extraMonArgs.OtherArgs...)
 
 	if args.VAccelType == "vsock" {
-		cmdString += " -device vhost-vsock-pci,id=vhost-vsock-pci0,guest-cid=" + fmt.Sprintf("%d", args.VSockDevID)
+		vsockArg := fmt.Sprintf("vhost-vsock-pci,id=vhost-vsock-pci0,guest-cid=%d", args.VSockDevID)
+		exArgs = append(exArgs, "-device", vsockArg)
 	}
 
-	exArgs := strings.Split(cmdString, " ")
 	exArgs = append(exArgs, "-append", args.Command)
 	return exArgs, nil
 }
@@ -150,12 +166,4 @@ func (q *Qemu) BuildExecCmd(args types.ExecArgs, ukernel types.Unikernel) ([]str
 // PreExec performs pre-execution setup. QEMU has no special pre-exec requirements.
 func (q *Qemu) PreExec(_ types.ExecArgs) error {
 	return nil
-}
-
-func getVirtioNetArg() string {
-	devType := "virtio-net-pci"
-	if runtime.GOARCH == "arm64" {
-		devType = "virtio-net-device"
-	}
-	return "-device " + devType + ",netdev=net0"
 }

--- a/pkg/unikontainers/hypervisors/qemu_test.go
+++ b/pkg/unikontainers/hypervisors/qemu_test.go
@@ -27,7 +27,7 @@ import (
 // Qemu.BuildExecCmd. The three Monitor* methods are the ones the function
 // consults; the rest return zero values.
 type fakeUnikernel struct {
-	netCli     string
+	netCli     []string
 	blockCli   []types.MonitorBlockArgs
 	monitorCli types.MonitorCliArgs
 }
@@ -36,7 +36,7 @@ func (f *fakeUnikernel) Init(types.UnikernelParams) error          { return nil 
 func (f *fakeUnikernel) CommandString() (string, error)            { return "", nil }
 func (f *fakeUnikernel) SupportsBlock() bool                       { return true }
 func (f *fakeUnikernel) SupportsFS(string) bool                    { return true }
-func (f *fakeUnikernel) MonitorNetCli(string, string) string       { return f.netCli }
+func (f *fakeUnikernel) MonitorNetCli(string, string) []string     { return f.netCli }
 func (f *fakeUnikernel) MonitorBlockCli() []types.MonitorBlockArgs { return f.blockCli }
 func (f *fakeUnikernel) MonitorCli() types.MonitorCliArgs          { return f.monitorCli }
 
@@ -164,7 +164,7 @@ func TestQemuBuildExecCmd(t *testing.T) {
 				Command:       testCommand,
 				Net:           types.NetDevParams{TapDev: "tap0"},
 			},
-			unikernel:      &fakeUnikernel{netCli: " -netdev user,id=net0 -device e1000,netdev=net0"},
+			unikernel:      &fakeUnikernel{netCli: []string{"-netdev", "user,id=net0", "-device", "e1000,netdev=net0"}},
 			mustContain:    []string{"-netdev user,id=net0", "-device e1000,netdev=net0"},
 			mustNotContain: []string{"-netdev tap"},
 		},
@@ -219,7 +219,7 @@ func TestQemuBuildExecCmd(t *testing.T) {
 				UnikernelPath: testKernelPath,
 				Command:       testCommand,
 			},
-			unikernel:      &fakeUnikernel{blockCli: []types.MonitorBlockArgs{{ExactArgs: " -hda /custom/disk.img"}}},
+			unikernel:      &fakeUnikernel{blockCli: []types.MonitorBlockArgs{{ExactArgs: []string{"-hda", "/custom/disk.img"}}}},
 			mustContain:    []string{"-hda /custom/disk.img"},
 			mustNotContain: []string{"virtio-blk-pci"},
 		},
@@ -238,7 +238,7 @@ func TestQemuBuildExecCmd(t *testing.T) {
 				UnikernelPath: testKernelPath,
 				Command:       testCommand,
 			},
-			unikernel:   &fakeUnikernel{monitorCli: types.MonitorCliArgs{OtherArgs: " -nographic -no-reboot"}},
+			unikernel:   &fakeUnikernel{monitorCli: types.MonitorCliArgs{OtherArgs: []string{"-nographic", "-no-reboot"}}},
 			mustContain: []string{"-nographic", "-no-reboot"},
 		},
 		{

--- a/pkg/unikontainers/hypervisors/qemu_test.go
+++ b/pkg/unikontainers/hypervisors/qemu_test.go
@@ -16,6 +16,7 @@ package hypervisors
 
 import (
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 
@@ -292,4 +293,46 @@ func TestQemuBuildExecCmd(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestQemuUnikernelPathIsAlwaysOneArgvElement(t *testing.T) {
+	t.Parallel()
+
+	annotationValue := "/unikernel/app.bin -fsdev local,id=extra,path=/data " +
+		"-device virtio-9p-pci,fsdev=extra,mount_tag=data"
+
+	q := &Qemu{binary: QemuBinary, binaryPath: testQemuBinary}
+	got, err := q.BuildExecCmd(types.ExecArgs{
+		UnikernelPath: annotationValue,
+		MemSizeB:      256 * 1024 * 1024,
+	}, &fakeUnikernel{})
+	assert.NoError(t, err)
+
+	kernelIdx := slices.Index(got, "-kernel")
+	if kernelIdx == -1 || kernelIdx+1 >= len(got) {
+		t.Fatalf("-kernel must be present and followed by the kernel path, got %v", got)
+	}
+	assert.Equal(t, annotationValue, got[kernelIdx+1], "the annotation value must stay one argv element")
+	for _, flag := range []string{"-fsdev", "-device"} {
+		assert.NotContains(t, got, flag, "the annotation value must not become a separate flag")
+	}
+}
+
+func TestQemuGuestCommandIsASingleAppendValue(t *testing.T) {
+	t.Parallel()
+
+	q := &Qemu{binary: QemuBinary, binaryPath: testQemuBinary}
+	got, err := q.BuildExecCmd(types.ExecArgs{
+		UnikernelPath: testKernelPath,
+		MemSizeB:      256 * 1024 * 1024,
+		Command:       "console=ttyS0 root=/dev/vda",
+	}, &fakeUnikernel{})
+	assert.NoError(t, err)
+
+	if len(got) < 2 {
+		t.Fatalf("expected at least -append and its value, got %v", got)
+	}
+	assert.Equal(t, "-append", got[len(got)-2])
+	assert.Equal(t, "console=ttyS0 root=/dev/vda", got[len(got)-1],
+		"qemu must receive the guest cmdline as a single element")
 }

--- a/pkg/unikontainers/hypervisors/solo5_test.go
+++ b/pkg/unikontainers/hypervisors/solo5_test.go
@@ -1,0 +1,145 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hypervisors
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
+)
+
+// The two solo5 tenders (hvt and spt) share the same cli grammar:
+// "[ OPTIONS ] [ -- ] KERNEL [ ARGS ]". The runners below exercise that shared
+// behaviour and are called with the concrete tender from hvt_test.go and
+// spt_test.go.
+const (
+	testHvtBinary = "/usr/bin/solo5-hvt"
+	testSptBinary = "/usr/bin/solo5-spt"
+)
+
+type solo5Case struct {
+	name           string
+	args           types.ExecArgs
+	unikernel      types.Unikernel
+	mustContain    []string
+	mustNotContain []string
+}
+
+func runSolo5BuildExecCmd(t *testing.T, vmm types.VMM) {
+	t.Helper()
+
+	tests := []solo5Case{
+		{
+			name:           "defaults render the baseline solo5 command",
+			args:           types.ExecArgs{UnikernelPath: testKernelPath},
+			unikernel:      &fakeUnikernel{},
+			mustContain:    []string{"--mem=256", testKernelPath},
+			mustNotContain: []string{"--net:", "--block:"},
+		},
+		{
+			name:        "custom MemSizeB renders --mem in MB",
+			args:        types.ExecArgs{UnikernelPath: testKernelPath, MemSizeB: 512 * 1000 * 1000},
+			unikernel:   &fakeUnikernel{},
+			mustContain: []string{"--mem=512"},
+		},
+		{
+			name:        "MonitorNetCli is used verbatim when a tap device is set",
+			args:        types.ExecArgs{UnikernelPath: testKernelPath, Net: types.NetDevParams{TapDev: "tap0"}},
+			unikernel:   &fakeUnikernel{netCli: []string{"--net:service=tap0"}},
+			mustContain: []string{"--net:service=tap0"},
+		},
+		{
+			name: "block devices render --block:ID=PATH and skip empty paths",
+			args: types.ExecArgs{UnikernelPath: testKernelPath},
+			unikernel: &fakeUnikernel{blockCli: []types.MonitorBlockArgs{
+				{ID: "data0", Path: "/disks/data0.img"},
+				{ID: "empty", Path: ""},
+			}},
+			mustContain:    []string{"--block:data0=/disks/data0.img"},
+			mustNotContain: []string{"--block:empty="},
+		},
+		{
+			name:        "MonitorCli OtherArgs are appended verbatim",
+			args:        types.ExecArgs{UnikernelPath: testKernelPath},
+			unikernel:   &fakeUnikernel{monitorCli: types.MonitorCliArgs{OtherArgs: []string{"--block-sector-size:data0=512"}}},
+			mustContain: []string{"--block-sector-size:data0=512"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := vmm.BuildExecCmd(tt.args, tt.unikernel)
+			assert.NoError(t, err)
+			assert.NotEmpty(t, got)
+
+			// Invariants that hold for every solo5 command.
+			assert.Equal(t, vmm.Path(), got[0], "binary path must be the first element")
+			sepIdx := slices.Index(got, solo5ArgsSeparator)
+			if sepIdx == -1 || sepIdx+1 >= len(got) {
+				t.Fatalf("%q must be present and followed by the kernel path, got %v", solo5ArgsSeparator, got)
+			}
+			assert.Equal(t, tt.args.UnikernelPath, got[sepIdx+1],
+				"the kernel path must directly follow %q", solo5ArgsSeparator)
+
+			joined := strings.Join(got, " ")
+			for _, want := range tt.mustContain {
+				assert.Contains(t, joined, want, "expected %q to be present", want)
+			}
+			for _, notWant := range tt.mustNotContain {
+				assert.NotContains(t, joined, notWant, "expected %q to be absent", notWant)
+			}
+		})
+	}
+}
+
+func runSolo5UnikernelPathOneElement(t *testing.T, vmm types.VMM) {
+	t.Helper()
+
+	annotationValue := "/unikernel/app.bin --block:extra=/a/b --mem=1 --net:service=tap0"
+	got, err := vmm.BuildExecCmd(types.ExecArgs{
+		UnikernelPath: annotationValue,
+		MemSizeB:      256 * 1024 * 1024,
+	}, &fakeUnikernel{})
+	assert.NoError(t, err)
+
+	assert.Contains(t, got, annotationValue, "the annotation value must stay one argv element")
+	assert.Greater(t, slices.Index(got, annotationValue), slices.Index(got, solo5ArgsSeparator),
+		"the kernel path must come after %q", solo5ArgsSeparator)
+}
+
+func runSolo5GuestCommandOneElement(t *testing.T, vmm types.VMM) {
+	t.Helper()
+
+	command := `{"cmdline":"nginx -c /etc/nginx.conf"}`
+	got, err := vmm.BuildExecCmd(types.ExecArgs{
+		UnikernelPath: testKernelPath,
+		MemSizeB:      256 * 1024 * 1024,
+		Command:       command,
+	}, &fakeUnikernel{})
+	assert.NoError(t, err)
+
+	if len(got) < 2 {
+		t.Fatalf("expected at least the kernel path and its command, got %v", got)
+	}
+	assert.Equal(t, command, got[len(got)-1],
+		"the guest command must be forwarded as a single argv element")
+	assert.Equal(t, testKernelPath, got[len(got)-2],
+		"the kernel path must directly precede the guest command")
+}

--- a/pkg/unikontainers/hypervisors/spt.go
+++ b/pkg/unikontainers/hypervisors/spt.go
@@ -16,7 +16,6 @@ package hypervisors
 
 import (
 	"os/exec"
-	"strings"
 
 	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
 	"golang.org/x/sys/unix"
@@ -66,21 +65,24 @@ func (s *SPT) Ok() error {
 
 func (s *SPT) BuildExecCmd(args types.ExecArgs, ukernel types.Unikernel) ([]string, error) {
 	sptMem := BytesToStringMB(args.MemSizeB)
-	cmdString := s.binaryPath + " --mem=" + sptMem
+	exArgs := []string{s.binaryPath, "--mem=" + sptMem}
 	if args.Net.TapDev != "" {
-		cmdString += " "
-		cmdString += ukernel.MonitorNetCli(args.Net.TapDev, args.Net.MAC)
+		netCli := ukernel.MonitorNetCli(args.Net.TapDev, args.Net.MAC)
+		exArgs = append(exArgs, netCli...)
 	}
 	bArgs := ukernel.MonitorBlockCli()
 	for _, blockArg := range bArgs {
-		cmdString = appendNonEmpty(cmdString, " --block:"+blockArg.ID+"=",
-			blockArg.Path)
+		if blockArg.Path != "" {
+			exArgs = append(exArgs, "--block:"+blockArg.ID+"="+blockArg.Path)
+		}
 	}
 	extraMonArgs := ukernel.MonitorCli()
-	cmdString = appendNonEmpty(cmdString, " ", extraMonArgs.OtherArgs)
-	cmdString += " " + args.UnikernelPath + " " + args.Command
-	cmdArgs := strings.Split(cmdString, " ")
-	return cmdArgs, nil
+	exArgs = append(exArgs, extraMonArgs.OtherArgs...)
+	exArgs = append(exArgs, solo5ArgsSeparator, args.UnikernelPath)
+	if args.Command != "" {
+		exArgs = append(exArgs, args.Command)
+	}
+	return exArgs, nil
 }
 
 // PreExec performs pre-execution setup. SPT has no special pre-exec requirements.

--- a/pkg/unikontainers/hypervisors/spt_test.go
+++ b/pkg/unikontainers/hypervisors/spt_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hypervisors
+
+import "testing"
+
+func newTestSPT() *SPT {
+	return &SPT{binary: SptBinary, binaryPath: testSptBinary}
+}
+
+func TestSptBuildExecCmd(t *testing.T) {
+	t.Parallel()
+	runSolo5BuildExecCmd(t, newTestSPT())
+}
+
+func TestSptUnikernelPathIsAlwaysOneArgvElement(t *testing.T) {
+	t.Parallel()
+	runSolo5UnikernelPathOneElement(t, newTestSPT())
+}
+
+func TestSptGuestCommandIsASingleElement(t *testing.T) {
+	t.Parallel()
+	runSolo5GuestCommandOneElement(t, newTestSPT())
+}

--- a/pkg/unikontainers/hypervisors/utils.go
+++ b/pkg/unikontainers/hypervisors/utils.go
@@ -35,13 +35,6 @@ func cpuArch() string {
 	}
 }
 
-func appendNonEmpty(body, prefix, value string) string {
-	if value != "" {
-		return body + prefix + value
-	}
-	return body
-}
-
 func bytesToMiB(bytes uint64) uint64 {
 	const bytesInMiB = 1024 * 1024
 	return bytes / bytesInMiB

--- a/pkg/unikontainers/types/types.go
+++ b/pkg/unikontainers/types/types.go
@@ -22,7 +22,7 @@ type Unikernel interface {
 	CommandString() (string, error)
 	SupportsBlock() bool
 	SupportsFS(string) bool
-	MonitorNetCli(string, string) string
+	MonitorNetCli(string, string) []string
 	MonitorBlockCli() []MonitorBlockArgs
 	MonitorCli() MonitorCliArgs
 }
@@ -82,7 +82,7 @@ type ProcessConfig struct {
 	WorkDir string // The workdir of the process inside the guest
 }
 
-// UnikernelParams holds the data required to build the unikernels commandline
+// UnikernelParams holds the data required by the unikernels commandline
 type UnikernelParams struct {
 	CmdLine    []string // The cmdline provided by the image
 	EnvVars    []string // The environment variables provided by the image
@@ -117,13 +117,13 @@ type ExecArgs struct {
 
 type MonitorCliArgs struct {
 	ExtraInitrd string
-	OtherArgs   string
+	OtherArgs   []string
 }
 
 type MonitorBlockArgs struct {
 	ID        string
 	Path      string
-	ExactArgs string
+	ExactArgs []string
 }
 
 // ExtraBinConfig struct is used to hold specific configuration for extra binaries

--- a/pkg/unikontainers/unikernels/hermit_rs.go
+++ b/pkg/unikontainers/unikernels/hermit_rs.go
@@ -67,28 +67,29 @@ func (h *Hermit) SupportsFS(fsType string) bool {
 	return fsType == "initrd"
 }
 
-func (h *Hermit) MonitorNetCli(ifName string, mac string) string {
+func (h *Hermit) MonitorNetCli(ifName string, mac string) []string {
 	switch h.Monitor {
 	case "qemu":
-		netdev := fmt.Sprintf(" -netdev tap,id=net0,ifname=%s,script=no,downscript=no", ifName)
-
 		var deviceArgs string
 
 		// QEMU on x86_64 typically uses virtio-net-pci.
 		// On arm64 virtio-net-device is the safer default.
 		if runtime.GOARCH == "arm64" {
-			deviceArgs = " -device " + "virtio-net-device" + ",netdev=net0"
+			deviceArgs = "virtio-net-device,netdev=net0"
 		} else {
-			deviceArgs = " -device " + "virtio-net-pci" + ",netdev=net0,disable-legacy=on"
+			deviceArgs = "virtio-net-pci,netdev=net0,disable-legacy=on"
 		}
 
 		if mac != "" {
 			deviceArgs += ",mac=" + mac
 		}
 
-		return netdev + deviceArgs
+		return []string{
+			"-netdev", fmt.Sprintf("tap,id=net0,ifname=%s,script=no,downscript=no", ifName),
+			"-device", deviceArgs,
+		}
 	default:
-		return ""
+		return nil
 	}
 }
 
@@ -98,7 +99,7 @@ func (h *Hermit) MonitorBlockCli() []types.MonitorBlockArgs {
 
 func (h *Hermit) MonitorCli() types.MonitorCliArgs {
 	return types.MonitorCliArgs{
-		OtherArgs: " -no-reboot",
+		OtherArgs: []string{"-no-reboot"},
 	}
 }
 

--- a/pkg/unikontainers/unikernels/linux.go
+++ b/pkg/unikontainers/unikernels/linux.go
@@ -150,8 +150,8 @@ func (l *Linux) SupportsFS(fsType string) bool {
 	}
 }
 
-func (l *Linux) MonitorNetCli(_ string, _ string) string {
-	return ""
+func (l *Linux) MonitorNetCli(_ string, _ string) []string {
+	return nil
 }
 
 func (l *Linux) MonitorBlockCli() []types.MonitorBlockArgs {
@@ -162,10 +162,11 @@ func (l *Linux) MonitorBlockCli() []types.MonitorBlockArgs {
 	switch l.Monitor {
 	case "qemu":
 		for _, aBlock := range l.Blk {
-			bcli1 := fmt.Sprintf(" -device virtio-blk-pci,serial=%s,drive=%s", aBlock.ID, aBlock.ID)
-			bcli2 := fmt.Sprintf(" -drive format=raw,if=none,id=%s,file=%s", aBlock.ID, aBlock.Source)
 			blkArgs = append(blkArgs, types.MonitorBlockArgs{
-				ExactArgs: bcli1 + bcli2,
+				ExactArgs: []string{
+					"-device", fmt.Sprintf("virtio-blk-pci,serial=%s,drive=%s", aBlock.ID, aBlock.ID),
+					"-drive", fmt.Sprintf("format=raw,if=none,id=%s,file=%s", aBlock.ID, aBlock.Source),
+				},
 			})
 		}
 	case "firecracker":
@@ -197,7 +198,7 @@ func (l *Linux) MonitorCli() types.MonitorCliArgs {
 	switch l.Monitor {
 	case "qemu":
 		extraCliArgs := types.MonitorCliArgs{
-			OtherArgs: " -no-reboot -nodefaults",
+			OtherArgs: []string{"-no-reboot", "-nodefaults"},
 		}
 		if l.InitrdConf && l.RootFsType != "initrd" {
 			extraCliArgs.ExtraInitrd = urunitConfPath

--- a/pkg/unikontainers/unikernels/mewz.go
+++ b/pkg/unikontainers/unikernels/mewz.go
@@ -50,14 +50,15 @@ func (m *Mewz) SupportsFS(_ string) bool {
 	return false
 }
 
-func (m *Mewz) MonitorNetCli(ifName string, mac string) string {
+func (m *Mewz) MonitorNetCli(ifName string, mac string) []string {
 	switch m.Monitor {
 	case "qemu":
-		ncli := " -device virtio-net-pci,netdev=net0,disable-legacy=on,disable-modern=off,mac=" + mac
-		ncli += " -netdev tap,script=no,downscript=no,id=net0,ifname=" + ifName
-		return ncli
+		return []string{
+			"-device", "virtio-net-pci,netdev=net0,disable-legacy=on,disable-modern=off,mac=" + mac,
+			"-netdev", "tap,script=no,downscript=no,id=net0,ifname=" + ifName,
+		}
 	default:
-		return ""
+		return nil
 	}
 }
 
@@ -71,7 +72,7 @@ func (m *Mewz) MonitorCli() types.MonitorCliArgs {
 	switch m.Monitor {
 	case "qemu":
 		return types.MonitorCliArgs{
-			OtherArgs: " -no-reboot -device isa-debug-exit,iobase=0x501,iosize=2",
+			OtherArgs: []string{"-no-reboot", "-device", "isa-debug-exit,iobase=0x501,iosize=2"},
 		}
 	default:
 		return types.MonitorCliArgs{}

--- a/pkg/unikontainers/unikernels/mirage.go
+++ b/pkg/unikontainers/unikernels/mirage.go
@@ -56,14 +56,15 @@ func (m *Mirage) SupportsFS(_ string) bool {
 	return false
 }
 
-func (m *Mirage) MonitorNetCli(ifName string, mac string) string {
+func (m *Mirage) MonitorNetCli(ifName string, mac string) []string {
 	switch m.Monitor {
 	case "hvt", "spt":
-		netOption := "--net:" + m.netDevName + "=" + ifName
-		netOption += " --net-mac:" + m.netDevName + "=" + mac
-		return netOption
+		return []string{
+			"--net:" + m.netDevName + "=" + ifName,
+			"--net-mac:" + m.netDevName + "=" + mac,
+		}
 	default:
-		return ""
+		return nil
 	}
 }
 

--- a/pkg/unikontainers/unikernels/rumprun.go
+++ b/pkg/unikontainers/unikernels/rumprun.go
@@ -137,14 +137,15 @@ func (r *Rumprun) SupportsFS(fsType string) bool {
 	}
 }
 
-func (r *Rumprun) MonitorNetCli(ifName string, mac string) string {
+func (r *Rumprun) MonitorNetCli(ifName string, mac string) []string {
 	switch r.Monitor {
 	case "hvt", "spt":
-		netOption := "--net:tap=" + ifName
-		netOption += " --net-mac:tap=" + mac
-		return netOption
+		return []string{
+			"--net:tap=" + ifName,
+			"--net-mac:tap=" + mac,
+		}
 	default:
-		return ""
+		return nil
 	}
 }
 

--- a/pkg/unikontainers/unikernels/unikraft.go
+++ b/pkg/unikontainers/unikernels/unikraft.go
@@ -86,8 +86,8 @@ func (u *Unikraft) SupportsFS(fsType string) bool {
 }
 
 // There is no need for any changes here yet.
-func (u *Unikraft) MonitorNetCli(_ string, _ string) string {
-	return ""
+func (u *Unikraft) MonitorNetCli(_ string, _ string) []string {
+	return nil
 }
 
 // We have not managed to make Unikraft run with block yet.


### PR DESCRIPTION
## Description

This PR refactors the monitor/hypervisor command line arguments construction to use string slices directly instead of inefficient string concatenation.

Previously, monitors (such as HVT, SPT, QEMU, Firecracker, and Cloud Hypervisor) built their CLI options as a single space-separated string using `cli += " option"` and split it into a string slice at the end using `strings.Split`. This is inefficient because strings are immutable in Go, leading to unnecessary memory allocations, and the split operation adds overhead.

This PR:
- Updates the `Unikernel` interface method `MonitorNetCli` to return `[]string` instead of `string`.
- Updates `MonitorBlockArgs.ExactArgs` and `MonitorCliArgs.OtherArgs` to use `[]string` instead of `string`.
- Updates all hypervisors to construct their arguments directly as slices of strings, avoiding all string concatenations and subsequent splits.

### Related issues

- Fixes #844

### How was this tested?

Compiled the packages and verified that unit tests build successfully targeting Linux:
- `go build ./pkg/unikontainers/...` - Passed successfully.
- `go test -c ./pkg/unikontainers/...` - Passed successfully.

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [ ] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
