### PR TITLE
fix(storage): roll back unmounted volumes on getBlockVolumes error

### DIFF
--- a/pkg/unikontainers/block.go
+++ b/pkg/unikontainers/block.go
@@ -209,7 +209,7 @@ func getBlockVolumes(mounts []specs.Mount, ukernel types.Unikernel) ([]types.Blo
 			continue
 		}
 		if err != nil {
-			return nil, err
+			return nil, rollbackBlockVolumes(blkImgs, err)
 		}
 		if ukernel.SupportsFS(mInfo.FsType) {
 			// So, there was an issue which was manifested from the testing.
@@ -228,12 +228,21 @@ func getBlockVolumes(mounts []specs.Mount, ukernel types.Unikernel) ([]types.Blo
 			// handling
 			cleared, err := setLoopAutoclear(mInfo.Source, false)
 			if err != nil {
-				return nil, err
+				return nil, rollbackBlockVolumes(blkImgs, err)
 			}
 			mInfo.LoopAutoclear = cleared
 			err = mount.Unmount(mInfo.MountPoint)
 			if err != nil {
-				return nil, err
+				// The autoclear flag was already cleared on the device,
+				// even though the mount itself is still in place. Restore
+				// it directly, since this entry never made it into blkImgs
+				// for rollbackBlockVolumes to pick up.
+				if cleared {
+					if _, rErr := setLoopAutoclear(mInfo.Source, true); rErr != nil {
+						err = fmt.Errorf("%w (failed to restore autoclear flag on %s: %v)", err, mInfo.Source, rErr)
+					}
+				}
+				return nil, rollbackBlockVolumes(blkImgs, err)
 			}
 			mInfo.ID = fmt.Sprintf("vol%d", i)
 			mInfo.HostMountPoint = mInfo.MountPoint
@@ -243,6 +252,17 @@ func getBlockVolumes(mounts []specs.Mount, ukernel types.Unikernel) ([]types.Blo
 	}
 
 	return blkImgs, nil
+}
+
+// rollbackBlockVolumes restores any volumes getBlockVolumes already
+// unmounted before hitting err, so a failed create never leaves
+// pre-existing host mounts detached. It always returns the original error,
+// annotated when the rollback itself also fails.
+func rollbackBlockVolumes(blkImgs []types.BlockDevParams, err error) error {
+	if rErr := restoreBlockVolumes(blkImgs); rErr != nil {
+		return fmt.Errorf("%w (rollback of already unmounted volumes also failed: %v)", err, rErr)
+	}
+	return err
 }
 
 // restoreBlockVolumes mounts the block volume sources that were unmounted

--- a/pkg/unikontainers/block_test.go
+++ b/pkg/unikontainers/block_test.go
@@ -15,11 +15,38 @@
 package unikontainers
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
 )
+
+func TestRollbackBlockVolumesNoVolumes(t *testing.T) {
+	// With no already-unmounted volumes to restore, rollbackBlockVolumes
+	// must return the original error unchanged.
+	origErr := errors.New("original failure")
+
+	err := rollbackBlockVolumes(nil, origErr)
+	assert.ErrorIs(t, err, origErr, "Expected the original error to be returned unchanged")
+
+	err = rollbackBlockVolumes([]types.BlockDevParams{}, origErr)
+	assert.ErrorIs(t, err, origErr, "Expected the original error to be returned unchanged")
+}
+
+func TestRollbackBlockVolumesSkipsNonHostMounts(t *testing.T) {
+	// Volumes without a HostMountPoint were never unmounted by
+	// getBlockVolumes (e.g. an explicit block image), so
+	// restoreBlockVolumes must skip them and rollback must still
+	// surface the original error.
+	origErr := errors.New("original failure")
+	blkImgs := []types.BlockDevParams{
+		{Source: "/dev/loop0", MountPoint: "/mnt/vol0"},
+	}
+
+	err := rollbackBlockVolumes(blkImgs, origErr)
+	assert.ErrorIs(t, err, origErr, "Expected the original error to be returned unchanged")
+}
 
 func TestGetBlockDevice(t *testing.T) {
 	// Create a mock partition


### PR DESCRIPTION
## Description

`getBlockVolumes` unmounts host bind mounts one at a time so they can be handed to the guest as block devices. The problem is that if any mount after the first one fails during that process (bad mountinfo, autoclear flag change fails, or the unmount itself fails), the function bails out immediately and throws away the list of volumes it had already unmounted. Those earlier mounts just stay detached on the host, and since `create` fails before `state.json` gets written, `delete` doesn't even know they exist to restore them.

This PR adds `rollbackBlockVolumes`, which restores whatever was already unmounted (reusing the existing `restoreBlockVolumes` logic) before the error is returned. It also covers the case where the autoclear flag got cleared on a device but the unmount call itself failed, by restoring that flag directly.

### Related issues

- Fixes #859

### How was this tested?

- `gofmt -l` clean
- Built and vetted with `GOOS=linux GOARCH=amd64` (no build/vet issues)
- Added two unit tests for `rollbackBlockVolumes` covering the no-op case and volumes without a host mountpoint
- Didn't have a Linux box handy to run the full `make test_unikontainers` / e2e suite, so leaving that to CI

### LLM usage

Used Claude to help track down the bug and put this fix together, reviewed and tested everything myself before opening this.

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [ ] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
