### PR TITLE
fix(network): distinguish missing container iface from setup failures

### DIFF
--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -33,6 +33,11 @@ const (
 
 var netlog = logrus.WithField("subsystem", "network")
 
+// ErrNoContainerNetwork is returned when the current network namespace has no
+// suitable container interface (e.g. ctr without networking, or --network none).
+// Callers may treat this as a non-fatal condition and continue without guest networking.
+var ErrNoContainerNetwork = errors.New("no suitable network interface found in namespace")
+
 type UnikernelNetworkInfo struct {
 	TapDevice string
 	EthDevice Interface
@@ -403,7 +408,7 @@ func discoverContainerIface() (netlink.Link, error) {
 		}
 		netlog.Debugf("skipping interface %s: no default route found", attrs.Name)
 	}
-	return nil, errors.New("no suitable network interface found in namespace")
+	return nil, ErrNoContainerNetwork
 }
 
 func deleteAllQDiscs(device netlink.Link) error {

--- a/pkg/network/network_static.go
+++ b/pkg/network/network_static.go
@@ -93,8 +93,7 @@ func (n StaticNetwork) NetworkSetup(uid uint32, gid uint32) (*UnikernelNetworkIn
 	addTCRules := false
 	redirectLink, err := discoverContainerIface()
 	if err != nil {
-		netlog.Errorf("failed to find container interface, (unikernel may have been spawned using ctr): %v", err)
-		return nil, err
+		return nil, fmt.Errorf("failed to find container interface, (unikernel may have been spawned using ctr): %w", err)
 	}
 	newTapDevice, err := networkSetup(newTapName, StaticIPAddr, redirectLink, addTCRules, uid, gid)
 	if err != nil {

--- a/pkg/network/network_test.go
+++ b/pkg/network/network_test.go
@@ -15,6 +15,8 @@
 package network
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -55,4 +57,14 @@ func TestNewNetworkManager(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestErrNoContainerNetworkIsDetectableWhenWrapped(t *testing.T) {
+	t.Parallel()
+
+	wrapped := fmt.Errorf("failed to find container interface, (unikernel may have been spawned using ctr): %w", ErrNoContainerNetwork)
+	assert.True(t, errors.Is(wrapped, ErrNoContainerNetwork))
+
+	other := fmt.Errorf("createTapDevice(tap0_urunc) failed: %w", errors.New("permission denied"))
+	assert.False(t, errors.Is(other, ErrNoContainerNetwork))
 }

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -266,23 +266,23 @@ func (u *Unikontainer) SetupNet() (types.NetDevParams, error) {
 
 	networkInfo, err := netManager.NetworkSetup(u.Spec.Process.User.UID, u.Spec.Process.User.GID)
 	if err != nil {
-		// TODO: Handle this case better. We do not need to show an error
-		// since there was no network in the container. Therefore, we
-		// need better error handling and specifically check if the container
-		// di not have any network.
-		uniklog.Errorf("Failed to setup network :%v. Possibly due to ctr", err)
+		// No container interface means there is no network to set up (e.g. ctr
+		// without CNI, or --network none). Continue without guest networking.
+		// Any other failure (TAP creation, TC rules, etc.) is fatal.
+		if errors.Is(err, network.ErrNoContainerNetwork) {
+			uniklog.Debugf("no container network interface found, continuing without network: %v", err)
+			return netArgs, nil
+		}
+		return netArgs, fmt.Errorf("failed to setup network: %w", err)
 	}
-	// if network info is nil, we didn't find eth0, so we are running with ctr
-	if networkInfo != nil {
-		netArgs.TapDev = networkInfo.TapDevice
-		netArgs.IP = networkInfo.EthDevice.IP
-		netArgs.Mask = networkInfo.EthDevice.Mask
-		netArgs.Gateway = networkInfo.EthDevice.DefaultGateway
-		// The MAC address for the guest network device is the same as the
-		// virtual ethernet interface inside the namespace
-		netArgs.MAC = networkInfo.EthDevice.MAC
-		netArgs.MTU = networkInfo.EthDevice.MTU
-	}
+	netArgs.TapDev = networkInfo.TapDevice
+	netArgs.IP = networkInfo.EthDevice.IP
+	netArgs.Mask = networkInfo.EthDevice.Mask
+	netArgs.Gateway = networkInfo.EthDevice.DefaultGateway
+	// The MAC address for the guest network device is the same as the
+	// virtual ethernet interface inside the namespace
+	netArgs.MAC = networkInfo.EthDevice.MAC
+	netArgs.MTU = networkInfo.EthDevice.MTU
 
 	return netArgs, nil
 }


### PR DESCRIPTION
## Description
`SetupNet` previously logged and ignored all `NetworkSetup` errors, so real failures (TAP creation, TC rules, permissions) could leave a container running without networking.
This change follows the guidance on #417:
- Add `network.ErrNoContainerNetwork` for the "no suitable interface in the netns" case (ctr / `--network none`).
- `discoverContainerIface` returns that sentinel.
- `SetupNet` continues only when `errors.Is(err, ErrNoContainerNetwork)`; all other errors are returned to the caller.
- Align static network discovery wrapping with the dynamic path so the sentinel stays detectable via `%w`.


### Related issues

- Fixes #417

### How was this tested?


- `make test_network` (includes `TestErrNoContainerNetworkIsDetectableWhenWrapped`)
  - `sudo nerdctl run --rm --network none --runtime io.containerd.urunc.v2 harbor.nbfc.io/nubificus/urunc/hello-qemu-unikraft:latest` → Hello world
  - `sudo nerdctl run -d --name urunc-nginx --runtime io.containerd.urunc.v2 harbor.nbfc.io/nubificus/urunc/nginx-qemu-unikraft-initrd:latest` → curl to container IP succeeded

### LLM usage

Claude assisted with drafting the PR creation; I reviewed and verified the logic against the discussion on #417 and tested locally as above.

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [x] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
