### PR TITLE
fix(storage): unescape /proc/self/mountinfo paths in getMountInfo

### DIFF
--- a/pkg/unikontainers/block.go
+++ b/pkg/unikontainers/block.go
@@ -15,7 +15,6 @@
 package unikontainers
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
 	"os"
@@ -56,55 +55,50 @@ type blockRootfs struct {
 // There are cases (e.g. bind mounts) where mounts use the same underlying
 // source device as the original mount, so they can appear identical to
 // regular mounts when inspecting mount information.
+//
+// We rely on moby/sys/mountinfo to parse /proc/self/mountinfo instead of
+// splitting the raw lines ourselves, because the kernel octal-escapes
+// spaces, tabs, newlines and backslashes in the root and mount point
+// fields (see proc(5)), and mountinfo.GetMounts() already decodes them.
 func getMountInfo(path string) (types.BlockDevParams, error) {
-	selfProcMountInfo := "/proc/self/mountinfo"
-
-	file, err := os.Open(selfProcMountInfo)
+	mounts, err := mountinfo.GetMounts(nil)
 	if err != nil {
-		return types.BlockDevParams{}, fmt.Errorf("failed to open mountinfo: %w", err)
+		return types.BlockDevParams{}, fmt.Errorf("failed to read mountinfo: %w", err)
 	}
-	defer file.Close()
 
+	return findMountInfo(mounts, path)
+}
+
+// findMountInfo scans already-parsed mountinfo entries for the one mounted
+// at path. It is split out from getMountInfo so the matching logic can be
+// unit tested against synthetic mounts, without depending on the real
+// /proc/self/mountinfo of the process running the test.
+func findMountInfo(mounts []*mountinfo.Info, path string) (types.BlockDevParams, error) {
 	blockDev := types.BlockDevParams{}
 	nonSpecialSources := make(map[string]struct{})
-	scanner := bufio.NewScanner(file)
 
-	for scanner.Scan() {
-		line := scanner.Text()
-		parts := strings.Split(line, " - ")
-		if len(parts) != 2 {
-			return types.BlockDevParams{}, fmt.Errorf("invalid mountinfo line in /proc/self/mountinfo")
-		}
-
-		preDash := strings.Fields(parts[0])
-		if len(preDash) < 6 {
-			continue
-		}
-		postDash := strings.Fields(parts[1])
-		if len(postDash) < 2 {
-			continue
-		}
-		if preDash[4] == path {
+	for _, m := range mounts {
+		if m.Mountpoint == path {
 			uniklog.WithFields(logrus.Fields{
 				"mounted at": path,
-				"device":     postDash[1],
-				"fstype":     postDash[0],
-				"options":    preDash[5],
+				"device":     m.Source,
+				"fstype":     m.FSType,
+				"options":    m.Options,
 			}).Debug("Found block device")
 
-			blockDev.Source = postDash[1]
-			blockDev.FsType = postDash[0]
+			blockDev.Source = m.Source
+			blockDev.FsType = m.FSType
 			blockDev.MountPoint = path
-			// Keep the-mount VFS options (field 6 of mountinfo)
+			// Keep the mount VFS options (field 6 of mountinfo)
 			// to restore them later in the delete path.
-			blockDev.MountOptions = preDash[5]
+			blockDev.MountOptions = m.Options
 			blockDev.ID = ""
 			continue
 		}
 		// Store the source of all mounts with non-special fs
 		// (e.g. overlay, tmpfs) in a map
-		if postDash[0] != postDash[1] {
-			nonSpecialSources[postDash[1]] = struct{}{}
+		if m.FSType != m.Source {
+			nonSpecialSources[m.Source] = struct{}{}
 		}
 	}
 

--- a/pkg/unikontainers/block_test.go
+++ b/pkg/unikontainers/block_test.go
@@ -15,8 +15,10 @@
 package unikontainers
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/moby/sys/mountinfo"
 	"github.com/stretchr/testify/assert"
 	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
 )
@@ -36,4 +38,35 @@ func TestGetBlockDevice(t *testing.T) {
 	assert.Equal(t, tmpMnt.MountPoint, rootFs.MountPoint, "Incorrect mountpoint")
 	assert.Equal(t, tmpMnt.FsType, rootFs.FsType, "Expected filesystem type to be proc")
 	assert.Equal(t, tmpMnt.ID, rootFs.ID, "Expected ID to be empty")
+}
+
+// TestFindMountInfoEscapedPath reproduces a bind mount whose source path
+// contains a space, tab, newline or backslash. The kernel octal-escapes
+// these characters in /proc/self/mountinfo (e.g. a space becomes \040), so
+// this exercises that findMountInfo still matches the real, unescaped path
+// against the mountinfo entry once it has been parsed by mountinfo.GetMountsFromReader.
+func TestFindMountInfoEscapedPath(t *testing.T) {
+	tests := []struct {
+		name       string
+		path       string
+		escapedRaw string
+	}{
+		{name: "space", path: "/mnt/my volume", escapedRaw: `/mnt/my\040volume`},
+		{name: "tab", path: "/mnt/my\tvolume", escapedRaw: `/mnt/my\011volume`},
+		{name: "backslash", path: `/mnt/my\volume`, escapedRaw: `/mnt/my\134volume`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			line := "36 35 8:1 / " + tt.escapedRaw + " rw,relatime shared:1 - ext4 /dev/sdb1 rw"
+			mounts, err := mountinfo.GetMountsFromReader(strings.NewReader(line), nil)
+			assert.NoError(t, err, "expected the synthetic mountinfo line to parse")
+
+			blockDev, err := findMountInfo(mounts, tt.path)
+			assert.NoError(t, err, "expected the escaped mount point to match the real path")
+			assert.Equal(t, "/dev/sdb1", blockDev.Source)
+			assert.Equal(t, "ext4", blockDev.FsType)
+			assert.Equal(t, tt.path, blockDev.MountPoint)
+		})
+	}
 }


### PR DESCRIPTION
## Description

`getMountInfo()` in `pkg/unikontainers/block.go` figures out whether a bind-mount source is itself a mount point by scanning `/proc/self/mountinfo` and comparing the mount point field against the given path with a plain string comparison (`preDash[4] == path`).

The kernel octal-escapes spaces, tabs, newlines and backslashes in the root and mount point fields of that file (e.g. a space becomes `\040`). The old code read those fields straight off the file and never unescaped them, so a mount whose path contained any of those characters could never match, `getMountInfo` returned `ErrMountpoint`, and `getBlockVolumes()` silently skipped attaching it as a block device with no error surfaced anywhere.

This switches `getMountInfo` to use `moby/sys/mountinfo.GetMounts`, which is already a dependency and already used elsewhere in this file (`mountinfo.Mounted` in `restoreBlockVolumes`). That library decodes the escaping while parsing, so the comparison works correctly. The actual matching logic is pulled out into `findMountInfo(mounts []*mountinfo.Info, path string)` so it can be tested against synthetic mount entries instead of depending on the real `/proc/self/mountinfo` of whatever process runs the tests.

### Related issues

- Fixes #867

### How was this tested?

- `go build ./...` and `go vet ./...` on Linux (cross-compiled from macOS, then verified inside a `golang` container since the affected code and `unix`/loop-device syscalls it depends on are Linux-only).
- `go test ./pkg/unikontainers/...` in a Linux container: existing `TestGetBlockDevice` still passes (it exercises `getMountInfo("/proc")` against the real mountinfo of the test process).
- Added `TestFindMountInfoEscapedPath`, which builds a synthetic mountinfo line with a mount point escaped the way the kernel would escape it (space, tab, backslash), parses it with `mountinfo.GetMountsFromReader`, and checks `findMountInfo` matches it against the real, unescaped path. This reproduces the bug and fails on the old code path, passes with the fix.
- Confirmed two other test failures in the same package (`TestCopyFile`, `TestMoveFile`) are pre-existing and unrelated. They fail identically on unmodified `main` when run as root inside the container (permission-denied checks don't trigger for root).
- I did not have a working `golangci-lint`/hypervisor e2e setup available in this environment, so `make lint` and the e2e suites were not run locally; flagging that here rather than checking those boxes.

### LLM usage

Claude (Anthropic, model: claude-sonnet-5) was used to investigate the bug, write the fix, and write this description. All changes were reviewed and tested by me before opening this PR, per the project's LLM policy.

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [ ] The linter passes locally (`make lint`). Not run locally, see note above.
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`). Not run locally, see note above.
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).

