### PR TITLE
feat(monitors): graceful shutdown over the control socket

### DIFF
--- a/.github/linters/urunc-dict.txt
+++ b/.github/linters/urunc-dict.txt
@@ -452,3 +452,4 @@ hmpj
 ndots
 resolv
 dupword
+nowait

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -176,11 +176,21 @@ Firecracker (its API socket), Qemu (a QMP socket) and Cloud Hypervisor (its REST
 API socket). It has no effect on the other monitors. The control socket is
 opt-in: it exists only when `socket_path` is set. If it is not set, the
 monitor runs with no control socket at all; an operator can leave it unset if
-they do not need the socket, or to keep a smaller attack surface. When it is
-set, the monitor creates the socket inside its own (pivoted) rootfs; `urunc`
-creates the directory of a custom `socket_path` there for you, so the path
-can be anywhere. It fails cleanly if the location is invalid, for example
-when a file already exists at one of the directories in the path.
+they do not need the socket, or to keep a smaller attack surface.
+
+When it is set, the monitor creates the socket inside its own (pivoted) rootfs.
+`urunc` creates the directory of `socket_path` inside that rootfs after it drops
+privileges to the monitor's user, so the path is subject to two constraints:
+
+- Its parent directory must be one the monitor's user can create and write. A
+  directory that only `root` can write does not work for a non-root monitor.
+- It must not sit over an existing file or directory. `urunc` creates the
+  directory of `socket_path`; that fails cleanly if a file already exists at one
+  of the directories in the path. The monitor then binds the socket at
+  `socket_path`; that fails if a file already exists at `socket_path` itself.
+
+`urunc` removes the socket when the container is deleted, so a restart that
+reuses the same `socket_path` does not find a stale socket.
 
 **Example:**
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -189,8 +189,9 @@ privileges to the monitor's user, so the path is subject to two constraints:
   of the directories in the path. The monitor then binds the socket at
   `socket_path`; that fails if a file already exists at `socket_path` itself.
 
-`urunc` removes the socket when the container is deleted, so a restart that
-reuses the same `socket_path` does not find a stale socket.
+`urunc` removes the socket when the container is stopped (on a terminating
+signal) and when it is deleted, so a restart that reuses the same `socket_path`
+does not find a stale socket.
 
 **Example:**
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -165,10 +165,19 @@ Each monitor subsection supports the following options:
 | `path` | string | (empty) | Optional custom path to the monitor binary. If not specified, urunc will search for the binary in PATH |
 | `data_path` | string | (empty) | Optional custom path for the monitor's data file directory |
 | `vhost` | boolean | `false` | Optional: enable `vhost-net` for the monitor's network device, to improve network performance. Currently only honored by the `qemu` monitor |
+| `socket_path` | string | (empty) | Optional path for the monitor's control socket. If not specified, urunc uses a per-container default (`/tmp/<container-id>.sock`) |
 
 Since Qemu is the only currently supported monitor which requires extra data to
 boot a VM, `urunc` will first check `/usr/local/share` and then `/usr/share` for
 Qemu's data files.
+
+The `socket_path` option applies to the monitors that expose a control socket:
+Firecracker (its API socket), Qemu (a QMP socket) and Cloud Hypervisor (its REST
+API socket). It has no effect on the other monitors. The monitor creates the
+socket inside its own (pivoted) rootfs; `urunc` creates the directory of a
+custom `socket_path` there for you, so the path can be anywhere. It only fails
+if the location is invalid, for example when a file already exists at one of the
+directories in the path.
 
 **Example:**
 
@@ -184,6 +193,7 @@ vhost = false
 default_memory_mb = 512
 default_vcpus = 2
 path = "/opt/firecracker/firecracker"
+socket_path = "/run/urunc/fc.sock"
 ```
 
 ### Extra binaries Configuration

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -166,6 +166,7 @@ Each monitor subsection supports the following options:
 | `data_path` | string | (empty) | Optional custom path for the monitor's data file directory |
 | `vhost` | boolean | `false` | Optional: enable `vhost-net` for the monitor's network device, to improve network performance. Currently only honored by the `qemu` monitor |
 | `socket_path` | string | (empty) | Optional path for the monitor's control socket. If not set, the monitor runs without a control socket |
+| `graceful_shutdown` | boolean | `false` | Optional. When `true`, on SIGTERM urunc asks the monitor to shut the guest down gracefully over its control socket (QEMU and Cloud Hypervisor on all architectures, Firecracker on x86 only) instead of killing it; the container manager still escalates to SIGKILL after its grace period. Defaults to `false` |
 
 Since Qemu is the only currently supported monitor which requires extra data to
 boot a VM, `urunc` will first check `/usr/local/share` and then `/usr/share` for

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -165,7 +165,7 @@ Each monitor subsection supports the following options:
 | `path` | string | (empty) | Optional custom path to the monitor binary. If not specified, urunc will search for the binary in PATH |
 | `data_path` | string | (empty) | Optional custom path for the monitor's data file directory |
 | `vhost` | boolean | `false` | Optional: enable `vhost-net` for the monitor's network device, to improve network performance. Currently only honored by the `qemu` monitor |
-| `socket_path` | string | (empty) | Optional path for the monitor's control socket. If not specified, urunc uses a per-container default (`/tmp/<container-id>.sock`) |
+| `socket_path` | string | (empty) | Optional path for the monitor's control socket. If not set, the monitor runs without a control socket |
 
 Since Qemu is the only currently supported monitor which requires extra data to
 boot a VM, `urunc` will first check `/usr/local/share` and then `/usr/share` for
@@ -173,11 +173,14 @@ Qemu's data files.
 
 The `socket_path` option applies to the monitors that expose a control socket:
 Firecracker (its API socket), Qemu (a QMP socket) and Cloud Hypervisor (its REST
-API socket). It has no effect on the other monitors. The monitor creates the
-socket inside its own (pivoted) rootfs; `urunc` creates the directory of a
-custom `socket_path` there for you, so the path can be anywhere. It only fails
-if the location is invalid, for example when a file already exists at one of the
-directories in the path.
+API socket). It has no effect on the other monitors. The control socket is
+opt-in: it exists only when `socket_path` is set. If it is not set, the
+monitor runs with no control socket at all; an operator can leave it unset if
+they do not need the socket, or to keep a smaller attack surface. When it is
+set, the monitor creates the socket inside its own (pivoted) rootfs; `urunc`
+creates the directory of a custom `socket_path` there for you, so the path
+can be anywhere. It fails cleanly if the location is invalid, for example
+when a file already exists at one of the directories in the path.
 
 **Example:**
 

--- a/pkg/unikontainers/hypervisors/cloud_hypervisor.go
+++ b/pkg/unikontainers/hypervisors/cloud_hypervisor.go
@@ -76,9 +76,8 @@ func (ch *CloudHypervisor) BuildExecCmd(args types.ExecArgs, ukernel types.Unike
 	// Start building the command
 	exArgs := []string{ch.binaryPath}
 
-	// Expose the REST API over a control socket only when a socket_path is
-	// configured, so the runtime can talk to Cloud Hypervisor after boot (e.g.
-	// for graceful shutdown). With no configured path no control socket is set up.
+	// Expose the REST API socket only when socket_path is set, so the runtime
+	// can talk to Cloud Hypervisor after boot.
 	if args.SocketPath != "" {
 		exArgs = append(exArgs, "--api-socket", "path="+args.SocketPath)
 	}

--- a/pkg/unikontainers/hypervisors/cloud_hypervisor.go
+++ b/pkg/unikontainers/hypervisors/cloud_hypervisor.go
@@ -45,15 +45,10 @@ func (ch *CloudHypervisor) Ok() error {
 	return nil
 }
 
-// SupportsGuestShutdown reports that Cloud Hypervisor can shut the guest down
-// gracefully via its REST API power-button endpoint.
 func (ch *CloudHypervisor) SupportsGuestShutdown() bool {
 	return true
 }
 
-// RequestGuestShutdown asks Cloud Hypervisor to press the guest's power button
-// over its REST API control socket. socketPath is the already-resolved,
-// host-reachable path; it is dialed directly. A non-2xx response is an error.
 func (ch *CloudHypervisor) RequestGuestShutdown(socketPath string) error {
 	return unixSocketRequest(socketPath, http.MethodPut, "/api/v1/vm.power-button", nil)
 }

--- a/pkg/unikontainers/hypervisors/cloud_hypervisor.go
+++ b/pkg/unikontainers/hypervisors/cloud_hypervisor.go
@@ -50,9 +50,9 @@ func (ch *CloudHypervisor) UsesKVM() bool {
 }
 
 // SupportsSharedfs returns true as Cloud Hypervisor supports virtiofs
-// UsesControlSocket reports that Cloud Hypervisor exposes a control socket (its
+// SupportsControlSocket reports that Cloud Hypervisor exposes a control socket (its
 // REST API socket).
-func (ch *CloudHypervisor) UsesControlSocket() bool {
+func (ch *CloudHypervisor) SupportsControlSocket() bool {
 	return true
 }
 

--- a/pkg/unikontainers/hypervisors/cloud_hypervisor.go
+++ b/pkg/unikontainers/hypervisors/cloud_hypervisor.go
@@ -49,13 +49,13 @@ func (ch *CloudHypervisor) UsesKVM() bool {
 	return true
 }
 
-// SupportsSharedfs returns true as Cloud Hypervisor supports virtiofs
-// SupportsControlSocket reports that Cloud Hypervisor exposes a control socket (its
-// REST API socket).
+// SupportsControlSocket reports that Cloud Hypervisor exposes a control socket
+// (its REST API socket).
 func (ch *CloudHypervisor) SupportsControlSocket() bool {
 	return true
 }
 
+// SupportsSharedfs returns true as Cloud Hypervisor supports virtiofs
 func (ch *CloudHypervisor) SupportsSharedfs(fsType string) bool {
 	switch fsType {
 	case "virtio":

--- a/pkg/unikontainers/hypervisors/cloud_hypervisor.go
+++ b/pkg/unikontainers/hypervisors/cloud_hypervisor.go
@@ -70,9 +70,12 @@ func (ch *CloudHypervisor) BuildExecCmd(args types.ExecArgs, ukernel types.Unike
 	// Start building the command
 	exArgs := []string{ch.binaryPath}
 
-	// Expose the REST API over a control socket so the runtime can talk to
-	// Cloud Hypervisor after boot (e.g. for graceful shutdown).
-	exArgs = append(exArgs, "--api-socket", "path="+ResolveSocketPath(args))
+	// Expose the REST API over a control socket only when a socket_path is
+	// configured, so the runtime can talk to Cloud Hypervisor after boot (e.g.
+	// for graceful shutdown). With no configured path no control socket is set up.
+	if args.SocketPath != "" {
+		exArgs = append(exArgs, "--api-socket", "path="+args.SocketPath)
+	}
 
 	// Memory configuration
 	if args.Sharedfs.Type == "virtiofs" {

--- a/pkg/unikontainers/hypervisors/cloud_hypervisor.go
+++ b/pkg/unikontainers/hypervisors/cloud_hypervisor.go
@@ -50,6 +50,12 @@ func (ch *CloudHypervisor) UsesKVM() bool {
 }
 
 // SupportsSharedfs returns true as Cloud Hypervisor supports virtiofs
+// UsesControlSocket reports that Cloud Hypervisor exposes a control socket (its
+// REST API socket).
+func (ch *CloudHypervisor) UsesControlSocket() bool {
+	return true
+}
+
 func (ch *CloudHypervisor) SupportsSharedfs(fsType string) bool {
 	switch fsType {
 	case "virtio":

--- a/pkg/unikontainers/hypervisors/cloud_hypervisor.go
+++ b/pkg/unikontainers/hypervisors/cloud_hypervisor.go
@@ -16,6 +16,7 @@ package hypervisors
 
 import (
 	"fmt"
+	"net/http"
 	"strconv"
 
 	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
@@ -42,6 +43,19 @@ func (ch *CloudHypervisor) Stop(pid int) error {
 
 func (ch *CloudHypervisor) Ok() error {
 	return nil
+}
+
+// SupportsGuestShutdown reports that Cloud Hypervisor can shut the guest down
+// gracefully via its REST API power-button endpoint.
+func (ch *CloudHypervisor) SupportsGuestShutdown() bool {
+	return true
+}
+
+// RequestGuestShutdown asks Cloud Hypervisor to press the guest's power button
+// over its REST API control socket. socketPath is the already-resolved,
+// host-reachable path; it is dialed directly. A non-2xx response is an error.
+func (ch *CloudHypervisor) RequestGuestShutdown(socketPath string) error {
+	return unixSocketRequest(socketPath, http.MethodPut, "/api/v1/vm.power-button", nil)
 }
 
 // UsesKVM returns true as Cloud Hypervisor is a KVM-based VMM

--- a/pkg/unikontainers/hypervisors/cloud_hypervisor.go
+++ b/pkg/unikontainers/hypervisors/cloud_hypervisor.go
@@ -70,6 +70,10 @@ func (ch *CloudHypervisor) BuildExecCmd(args types.ExecArgs, ukernel types.Unike
 	// Start building the command
 	exArgs := []string{ch.binaryPath}
 
+	// Expose the REST API over a control socket so the runtime can talk to
+	// Cloud Hypervisor after boot (e.g. for graceful shutdown).
+	exArgs = append(exArgs, "--api-socket", "path="+ResolveSocketPath(args))
+
 	// Memory configuration
 	if args.Sharedfs.Type == "virtiofs" {
 		memArg := "size=" + chMem + "M,shared=on"

--- a/pkg/unikontainers/hypervisors/cloud_hypervisor_test.go
+++ b/pkg/unikontainers/hypervisors/cloud_hypervisor_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hypervisors
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
+)
+
+const testCHBinary = "/usr/bin/cloud-hypervisor"
+
+// TestCloudHypervisorBuildExecCmdSocket verifies that Cloud Hypervisor exposes
+// its REST API control socket only when a socket_path is configured. With no
+// configured path, no --api-socket flag is emitted.
+func TestCloudHypervisorBuildExecCmdSocket(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		args           types.ExecArgs
+		mustContain    []string
+		mustNotContain []string
+	}{
+		{
+			name: "configured SocketPath renders --api-socket on that path",
+			args: types.ExecArgs{
+				UnikernelPath: testKernelPath,
+				Command:       testCommand,
+				SocketPath:    "/run/urunc/ch.sock",
+			},
+			mustContain: []string{"--api-socket path=/run/urunc/ch.sock"},
+		},
+		{
+			name: "unset SocketPath omits --api-socket",
+			args: types.ExecArgs{
+				UnikernelPath: testKernelPath,
+				Command:       testCommand,
+				ContainerID:   "abc123",
+			},
+			mustNotContain: []string{"--api-socket"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ch := &CloudHypervisor{binary: CloudHypervisorBinary, binaryPath: testCHBinary}
+			out, err := ch.BuildExecCmd(tt.args, &fakeUnikernel{})
+			assert.NoError(t, err)
+			assert.NotEmpty(t, out)
+
+			assert.Equal(t, testCHBinary, out[0], "binary path must be the first element")
+			joined := strings.Join(out, " ")
+
+			for _, want := range tt.mustContain {
+				assert.Contains(t, joined, want, "expected %q to be present", want)
+			}
+			for _, notWant := range tt.mustNotContain {
+				assert.NotContains(t, joined, notWant, "expected %q to be absent", notWant)
+			}
+		})
+	}
+}

--- a/pkg/unikontainers/hypervisors/cloud_hypervisor_test.go
+++ b/pkg/unikontainers/hypervisors/cloud_hypervisor_test.go
@@ -24,9 +24,8 @@ import (
 
 const testCHBinary = "/usr/bin/cloud-hypervisor"
 
-// TestCloudHypervisorBuildExecCmdSocket verifies that Cloud Hypervisor exposes
-// its REST API control socket only when a socket_path is configured. With no
-// configured path, no --api-socket flag is emitted.
+// TestCloudHypervisorBuildExecCmdSocket verifies Cloud Hypervisor emits
+// --api-socket only when socket_path is set.
 func TestCloudHypervisorBuildExecCmdSocket(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/unikontainers/hypervisors/firecracker.go
+++ b/pkg/unikontainers/hypervisors/firecracker.go
@@ -17,8 +17,10 @@ package hypervisors
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
 	"golang.org/x/sys/unix"
@@ -85,6 +87,21 @@ func (fc *Firecracker) Stop(pid int) error {
 
 func (fc *Firecracker) Ok() error {
 	return nil
+}
+
+// SupportsGuestShutdown reports whether Firecracker can shut the guest down
+// gracefully. Firecracker's SendCtrlAltDel action only exists on x86; on
+// aarch64 the API rejects it, so guest shutdown is supported on amd64 only.
+func (fc *Firecracker) SupportsGuestShutdown() bool {
+	return runtime.GOARCH == "amd64"
+}
+
+// RequestGuestShutdown asks Firecracker to inject a Ctrl+Alt+Del into the
+// guest over its REST API control socket. socketPath is the already-resolved,
+// host-reachable path; it is dialed directly. A non-2xx response is an error.
+func (fc *Firecracker) RequestGuestShutdown(socketPath string) error {
+	body := []byte(`{"action_type":"SendCtrlAltDel"}`)
+	return unixSocketRequest(socketPath, http.MethodPut, "/actions", body)
 }
 
 func (fc *Firecracker) UsesKVM() bool {

--- a/pkg/unikontainers/hypervisors/firecracker.go
+++ b/pkg/unikontainers/hypervisors/firecracker.go
@@ -96,6 +96,12 @@ func (fc *Firecracker) SupportsSharedfs(_ string) bool {
 	return false
 }
 
+// UsesControlSocket reports that Firecracker exposes a control socket (its API
+// socket).
+func (fc *Firecracker) UsesControlSocket() bool {
+	return true
+}
+
 func (fc *Firecracker) Path() string {
 	return fc.binaryPath
 }
@@ -107,15 +113,10 @@ func (fc *Firecracker) BuildExecCmd(args types.ExecArgs, ukernel types.Unikernel
 	// options in FC, since the string return value of the Monitor related
 	// functions in the unikernel interface do not integrate well with FC's
 	// json configuration.
-	// Launch Firecracker in one of two modes, both booting the guest from the
-	// config file:
-	//   - With a socket_path configured, enable the API socket
-	//     (--api-sock <path>) so the control socket stays open for use after
-	//     the guest has started.
-	//   - With no socket_path, launch with --no-api (upstream default) so no
-	//     control socket is exposed.
 	JSONConfigFile := filepath.Join("/tmp/", FCJsonFilename)
 	exArgs := []string{fc.Path()}
+	// Enable the API socket when a socket_path is configured, otherwise keep the
+	// upstream --no-api. Either way the guest boots from the config file.
 	if args.SocketPath != "" {
 		exArgs = append(exArgs, "--api-sock", args.SocketPath)
 	} else {

--- a/pkg/unikontainers/hypervisors/firecracker.go
+++ b/pkg/unikontainers/hypervisors/firecracker.go
@@ -96,9 +96,6 @@ func (fc *Firecracker) SupportsGuestShutdown() bool {
 	return runtime.GOARCH == "amd64"
 }
 
-// RequestGuestShutdown asks Firecracker to inject a Ctrl+Alt+Del into the
-// guest over its REST API control socket. socketPath is the already-resolved,
-// host-reachable path; it is dialed directly. A non-2xx response is an error.
 func (fc *Firecracker) RequestGuestShutdown(socketPath string) error {
 	body := []byte(`{"action_type":"SendCtrlAltDel"}`)
 	return unixSocketRequest(socketPath, http.MethodPut, "/actions", body)

--- a/pkg/unikontainers/hypervisors/firecracker.go
+++ b/pkg/unikontainers/hypervisors/firecracker.go
@@ -107,8 +107,13 @@ func (fc *Firecracker) BuildExecCmd(args types.ExecArgs, ukernel types.Unikernel
 	// options in FC, since the string return value of the Monitor related
 	// functions in the unikernel interface do not integrate well with FC's
 	// json configuration.
+	// Launch Firecracker with its API socket enabled (drop --no-api) while
+	// still booting the guest from the config file. This preserves today's
+	// boot behavior and additionally leaves the control socket open for use
+	// after the guest has started.
+	apiSockPath := ResolveSocketPath(args)
 	JSONConfigFile := filepath.Join("/tmp/", FCJsonFilename)
-	exArgs := []string{fc.Path(), "--no-api", "--config-file", JSONConfigFile}
+	exArgs := []string{fc.Path(), "--api-sock", apiSockPath, "--config-file", JSONConfigFile}
 	if !args.Seccomp {
 		exArgs = append(exArgs, "--no-seccomp")
 	}

--- a/pkg/unikontainers/hypervisors/firecracker.go
+++ b/pkg/unikontainers/hypervisors/firecracker.go
@@ -96,9 +96,9 @@ func (fc *Firecracker) SupportsSharedfs(_ string) bool {
 	return false
 }
 
-// UsesControlSocket reports that Firecracker exposes a control socket (its API
+// SupportsControlSocket reports that Firecracker exposes a control socket (its API
 // socket).
-func (fc *Firecracker) UsesControlSocket() bool {
+func (fc *Firecracker) SupportsControlSocket() bool {
 	return true
 }
 

--- a/pkg/unikontainers/hypervisors/firecracker.go
+++ b/pkg/unikontainers/hypervisors/firecracker.go
@@ -107,13 +107,21 @@ func (fc *Firecracker) BuildExecCmd(args types.ExecArgs, ukernel types.Unikernel
 	// options in FC, since the string return value of the Monitor related
 	// functions in the unikernel interface do not integrate well with FC's
 	// json configuration.
-	// Launch Firecracker with its API socket enabled (drop --no-api) while
-	// still booting the guest from the config file. This preserves today's
-	// boot behavior and additionally leaves the control socket open for use
-	// after the guest has started.
-	apiSockPath := ResolveSocketPath(args)
+	// Launch Firecracker in one of two modes, both booting the guest from the
+	// config file:
+	//   - With a socket_path configured, enable the API socket
+	//     (--api-sock <path>) so the control socket stays open for use after
+	//     the guest has started.
+	//   - With no socket_path, launch with --no-api (upstream default) so no
+	//     control socket is exposed.
 	JSONConfigFile := filepath.Join("/tmp/", FCJsonFilename)
-	exArgs := []string{fc.Path(), "--api-sock", apiSockPath, "--config-file", JSONConfigFile}
+	exArgs := []string{fc.Path()}
+	if args.SocketPath != "" {
+		exArgs = append(exArgs, "--api-sock", args.SocketPath)
+	} else {
+		exArgs = append(exArgs, "--no-api")
+	}
+	exArgs = append(exArgs, "--config-file", JSONConfigFile)
 	if !args.Seccomp {
 		exArgs = append(exArgs, "--no-seccomp")
 	}

--- a/pkg/unikontainers/hypervisors/firecracker_test.go
+++ b/pkg/unikontainers/hypervisors/firecracker_test.go
@@ -24,10 +24,8 @@ import (
 
 const testFCBinary = "/usr/bin/firecracker"
 
-// TestFirecrackerBuildExecCmdSocket verifies that Firecracker enables its API
-// socket only when a socket_path is configured. With no configured path it
-// restores the upstream launch mode (--no-api --config-file), which boots the
-// guest from the config file without exposing a control socket.
+// TestFirecrackerBuildExecCmdSocket verifies Firecracker enables --api-sock
+// only when socket_path is set, and restores --no-api otherwise.
 func TestFirecrackerBuildExecCmdSocket(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/unikontainers/hypervisors/firecracker_test.go
+++ b/pkg/unikontainers/hypervisors/firecracker_test.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hypervisors
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
+)
+
+const testFCBinary = "/usr/bin/firecracker"
+
+// TestFirecrackerBuildExecCmdSocket verifies that Firecracker enables its API
+// socket only when a socket_path is configured. With no configured path it
+// restores the upstream launch mode (--no-api --config-file), which boots the
+// guest from the config file without exposing a control socket.
+func TestFirecrackerBuildExecCmdSocket(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		args           types.ExecArgs
+		mustContain    []string
+		mustNotContain []string
+	}{
+		{
+			name: "configured SocketPath renders --api-sock and keeps --config-file",
+			args: types.ExecArgs{
+				UnikernelPath: testKernelPath,
+				Command:       testCommand,
+				SocketPath:    "/run/urunc/fc.sock",
+			},
+			mustContain:    []string{"--api-sock /run/urunc/fc.sock", "--config-file"},
+			mustNotContain: []string{"--no-api"},
+		},
+		{
+			name: "unset SocketPath restores --no-api and omits --api-sock",
+			args: types.ExecArgs{
+				UnikernelPath: testKernelPath,
+				Command:       testCommand,
+				ContainerID:   "abc123",
+			},
+			mustContain:    []string{"--no-api", "--config-file"},
+			mustNotContain: []string{"--api-sock"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fc := &Firecracker{binary: FirecrackerBinary, binaryPath: testFCBinary}
+			out, err := fc.BuildExecCmd(tt.args, &fakeUnikernel{})
+			assert.NoError(t, err)
+			assert.NotEmpty(t, out)
+
+			assert.Equal(t, testFCBinary, out[0], "binary path must be the first element")
+			joined := strings.Join(out, " ")
+
+			for _, want := range tt.mustContain {
+				assert.Contains(t, joined, want, "expected %q to be present", want)
+			}
+			for _, notWant := range tt.mustNotContain {
+				assert.NotContains(t, joined, notWant, "expected %q to be absent", notWant)
+			}
+		})
+	}
+}

--- a/pkg/unikontainers/hypervisors/graceful_shutdown_test.go
+++ b/pkg/unikontainers/hypervisors/graceful_shutdown_test.go
@@ -16,6 +16,7 @@ package hypervisors
 
 import (
 	"encoding/json"
+	"errors"
 	"net"
 	"net/http"
 	"os"
@@ -48,25 +49,50 @@ func tempSocketPath(t *testing.T, name string) string {
 type qmpFakeServer struct {
 	sockPath string
 	listener net.Listener
+	cfg      qmpFakeServerConfig
 
 	mu       sync.Mutex
 	commands []string
+}
 
-	// When powerdownError is true, the server answers system_powerdown with a
-	// QMP {"error":...} object instead of a return.
-	powerdownError bool
+// qmpFakeServerConfig steers the fake server's behavior for a single
+// connection, so one server implementation can model every stage failure
+// exercised by the shutdown-stage tests below.
+type qmpFakeServerConfig struct {
+	// skipGreeting, when true, closes the connection right after accept
+	// instead of sending the QMP greeting.
+	skipGreeting bool
+
+	// errorOn, when it matches the command just received, answers with a
+	// QMP {"error":...} object instead of a return, modelling the monitor
+	// answering and rejecting the command.
+	errorOn string
+
+	// closeOn, when it matches the command just received, closes the
+	// connection without answering at all, modelling a monitor that never
+	// gets to reply for that stage.
+	closeOn string
 }
 
 func newQMPFakeServer(t *testing.T, powerdownError bool) *qmpFakeServer {
+	t.Helper()
+	cfg := qmpFakeServerConfig{}
+	if powerdownError {
+		cfg.errorOn = "system_powerdown"
+	}
+	return newQMPFakeServerWithConfig(t, cfg)
+}
+
+func newQMPFakeServerWithConfig(t *testing.T, cfg qmpFakeServerConfig) *qmpFakeServer {
 	t.Helper()
 	sockPath := tempSocketPath(t, "qmp.sock")
 	ln, err := net.Listen("unix", sockPath)
 	require.NoError(t, err)
 
 	s := &qmpFakeServer{
-		sockPath:       sockPath,
-		listener:       ln,
-		powerdownError: powerdownError,
+		sockPath: sockPath,
+		listener: ln,
+		cfg:      cfg,
 	}
 	go s.serve()
 	t.Cleanup(func() { _ = ln.Close() })
@@ -79,6 +105,10 @@ func (s *qmpFakeServer) serve() {
 		return
 	}
 	defer conn.Close()
+
+	if s.cfg.skipGreeting {
+		return
+	}
 
 	enc := json.NewEncoder(conn)
 	dec := json.NewDecoder(conn)
@@ -102,16 +132,16 @@ func (s *qmpFakeServer) serve() {
 		s.commands = append(s.commands, execute)
 		s.mu.Unlock()
 
-		switch execute {
-		case "qmp_capabilities":
-			_ = enc.Encode(map[string]any{"return": map[string]any{}})
-		case "system_powerdown":
-			if s.powerdownError {
-				_ = enc.Encode(map[string]any{
-					"error": map[string]any{"class": "GenericError", "desc": "boom"},
-				})
-				continue
-			}
+		if execute != "" && execute == s.cfg.closeOn {
+			return
+		}
+
+		switch {
+		case execute != "" && execute == s.cfg.errorOn:
+			_ = enc.Encode(map[string]any{
+				"error": map[string]any{"class": "GenericError", "desc": "boom"},
+			})
+		case execute == "system_powerdown":
 			// Async event first, command return second (fact G29). A correct
 			// client must skip the event and keep reading until the return.
 			_ = enc.Encode(map[string]any{
@@ -157,6 +187,79 @@ func TestQemuRequestGuestShutdown(t *testing.T) {
 	})
 }
 
+// TestQemuRequestGuestShutdownStages pins which sentinel each QMP failure
+// point wraps its error with, so an operator's log can say which step of the
+// shutdown request failed instead of one undifferentiated error.
+func TestQemuRequestGuestShutdownStages(t *testing.T) {
+	t.Run("unreachable socket gives ErrShutdownConnect", func(t *testing.T) {
+		t.Parallel()
+
+		q := &Qemu{}
+		err := q.RequestGuestShutdown(tempSocketPath(t, "does-not-exist.sock"))
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrShutdownConnect), "got: %v", err)
+	})
+
+	t.Run("no greeting gives ErrShutdownGreeting", func(t *testing.T) {
+		t.Parallel()
+
+		s := newQMPFakeServerWithConfig(t, qmpFakeServerConfig{skipGreeting: true})
+
+		q := &Qemu{}
+		err := q.RequestGuestShutdown(s.sockPath)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrShutdownGreeting), "got: %v", err)
+	})
+
+	t.Run("no reply to qmp_capabilities gives ErrShutdownHandshake", func(t *testing.T) {
+		t.Parallel()
+
+		s := newQMPFakeServerWithConfig(t, qmpFakeServerConfig{closeOn: "qmp_capabilities"})
+
+		q := &Qemu{}
+		err := q.RequestGuestShutdown(s.sockPath)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrShutdownHandshake), "got: %v", err)
+	})
+
+	t.Run("no reply to system_powerdown gives ErrShutdownCommand", func(t *testing.T) {
+		t.Parallel()
+
+		s := newQMPFakeServerWithConfig(t, qmpFakeServerConfig{closeOn: "system_powerdown"})
+
+		q := &Qemu{}
+		err := q.RequestGuestShutdown(s.sockPath)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrShutdownCommand), "got: %v", err)
+	})
+
+	t.Run("qmp_capabilities rejected gives ErrShutdownRefused", func(t *testing.T) {
+		t.Parallel()
+
+		s := newQMPFakeServerWithConfig(t, qmpFakeServerConfig{errorOn: "qmp_capabilities"})
+
+		q := &Qemu{}
+		err := q.RequestGuestShutdown(s.sockPath)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrShutdownRefused), "got: %v", err)
+		assert.False(t, errors.Is(err, ErrShutdownHandshake), "refusal must not also match the stage: %v", err)
+		assert.Contains(t, err.Error(), "qmp_capabilities")
+	})
+
+	t.Run("system_powerdown rejected gives ErrShutdownRefused", func(t *testing.T) {
+		t.Parallel()
+
+		s := newQMPFakeServerWithConfig(t, qmpFakeServerConfig{errorOn: "system_powerdown"})
+
+		q := &Qemu{}
+		err := q.RequestGuestShutdown(s.sockPath)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrShutdownRefused), "got: %v", err)
+		assert.False(t, errors.Is(err, ErrShutdownCommand), "refusal must not also match the stage: %v", err)
+		assert.Contains(t, err.Error(), "system_powerdown")
+	})
+}
+
 // TestQemuClientDrainsPowerdownReturn proves the QMP client reads until it sees
 // the command's own "return", consuming it off the wire, instead of stopping at
 // the async POWERDOWN event. net.Pipe is fully synchronous: every server write
@@ -178,13 +281,13 @@ func TestQemuGuestShutdownDrainsPowerdownReturn(t *testing.T) {
 		defer clientConn.Close()
 		enc := json.NewEncoder(clientConn)
 		dec := json.NewDecoder(clientConn)
-		if err := qmpCommand(enc, dec, "system_powerdown"); err != nil {
+		if err := qmpCommand(enc, dec, "system_powerdown", ErrShutdownCommand); err != nil {
 			done <- err
 			return
 		}
 		// Reachable only if the powerdown "return" was drained; otherwise it
 		// deadlocks against the server's still-pending return write.
-		done <- qmpCommand(enc, dec, "query-status")
+		done <- qmpCommand(enc, dec, "query-status", ErrShutdownCommand)
 	}()
 
 	senc := json.NewEncoder(serverConn)
@@ -279,6 +382,30 @@ func TestCloudHypervisorRequestGuestShutdown(t *testing.T) {
 			)
 		})
 	}
+}
+
+// TestUnixSocketRequestStages pins which sentinel unixSocketRequest wraps its
+// error with: an unreachable socket (client.Do never completes) is
+// ErrShutdownConnect, while a non-2xx response (the monitor answered and
+// rejected the request) is ErrShutdownRefused.
+func TestUnixSocketRequestStages(t *testing.T) {
+	t.Run("unreachable socket gives ErrShutdownConnect", func(t *testing.T) {
+		t.Parallel()
+
+		err := unixSocketRequest(tempSocketPath(t, "does-not-exist.sock"), http.MethodPut, "/actions", nil)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrShutdownConnect), "got: %v", err)
+	})
+
+	t.Run("400 response gives ErrShutdownRefused", func(t *testing.T) {
+		t.Parallel()
+
+		s := newCLHFakeServer(t, http.StatusBadRequest)
+
+		err := unixSocketRequest(s.sockPath, http.MethodPut, "/api/v1/vm.power-button", nil)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrShutdownRefused), "got: %v", err)
+	})
 }
 
 func TestSupportsGuestShutdown(t *testing.T) {

--- a/pkg/unikontainers/hypervisors/graceful_shutdown_test.go
+++ b/pkg/unikontainers/hypervisors/graceful_shutdown_test.go
@@ -157,6 +157,59 @@ func TestQemuRequestGuestShutdown(t *testing.T) {
 	})
 }
 
+// TestQemuClientDrainsPowerdownReturn proves the QMP client reads until it sees
+// the command's own "return", consuming it off the wire, instead of stopping at
+// the async POWERDOWN event. net.Pipe is fully synchronous: every server write
+// blocks until the client reads it. A single-read client (one that treated the
+// event as the reply and left the return unread) would leave the server's
+// return write pending and deadlock the follow-up command; a correct
+// read-until-return client drains it and lets the follow-up complete. The
+// deadlines turn that deadlock into a clean, prompt failure rather than a hang.
+func TestQemuGuestShutdownDrainsPowerdownReturn(t *testing.T) {
+	t.Parallel()
+
+	clientConn, serverConn := net.Pipe()
+	defer serverConn.Close()
+	require.NoError(t, clientConn.SetDeadline(time.Now().Add(3*time.Second)))
+	require.NoError(t, serverConn.SetDeadline(time.Now().Add(3*time.Second)))
+
+	done := make(chan error, 1)
+	go func() {
+		defer clientConn.Close()
+		enc := json.NewEncoder(clientConn)
+		dec := json.NewDecoder(clientConn)
+		if err := qmpCommand(enc, dec, "system_powerdown"); err != nil {
+			done <- err
+			return
+		}
+		// Reachable only if the powerdown "return" was drained; otherwise it
+		// deadlocks against the server's still-pending return write.
+		done <- qmpCommand(enc, dec, "query-status")
+	}()
+
+	senc := json.NewEncoder(serverConn)
+	sdec := json.NewDecoder(serverConn)
+
+	var cmd map[string]any
+	require.NoError(t, sdec.Decode(&cmd))
+	assert.Equal(t, "system_powerdown", cmd["execute"])
+	// Async event first, then the command's own return (fact G29).
+	require.NoError(t, senc.Encode(map[string]any{"event": "POWERDOWN"}))
+	require.NoError(t, senc.Encode(map[string]any{"return": map[string]any{}}))
+
+	require.NoError(t, sdec.Decode(&cmd),
+		"follow-up command must arrive, proving the powerdown return was drained")
+	assert.Equal(t, "query-status", cmd["execute"])
+	require.NoError(t, senc.Encode(map[string]any{"return": map[string]any{}}))
+
+	select {
+	case err := <-done:
+		assert.NoError(t, err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("qmp client did not drain the powerdown return; follow-up command deadlocked")
+	}
+}
+
 // clhFakeServer is a fake Cloud Hypervisor REST server speaking HTTP over a
 // unix socket. It records the method and path of every request and answers
 // with a configured status code.

--- a/pkg/unikontainers/hypervisors/graceful_shutdown_test.go
+++ b/pkg/unikontainers/hypervisors/graceful_shutdown_test.go
@@ -41,11 +41,9 @@ func tempSocketPath(t *testing.T, name string) string {
 	return filepath.Join(dir, name)
 }
 
-// qmpFakeServer is a minimal line-JSON QMP server over a unix socket. It sends
-// the greeting on accept, answers qmp_capabilities with {"return":{}}, and on
-// system_powerdown emits an async {"event":"POWERDOWN"} followed by the
-// command's own {"return":{}} (modelling the interleaving real QEMU does,
-// fact G29). It records the commands it receives, in order.
+// qmpFakeServer is a minimal line-JSON QMP server over a unix socket. It
+// sends the greeting on accept, answers qmp_capabilities with {"return":{}},
+// and interleaves an async POWERDOWN event before system_powerdown's return.
 type qmpFakeServer struct {
 	sockPath string
 	listener net.Listener
@@ -113,7 +111,7 @@ func (s *qmpFakeServer) serve() {
 	enc := json.NewEncoder(conn)
 	dec := json.NewDecoder(conn)
 
-	// Real QEMU sends the greeting unprompted right after accept (fact G26).
+	// Real QEMU sends the greeting unprompted right after accept.
 	_ = enc.Encode(map[string]any{
 		"QMP": map[string]any{
 			"version":      map[string]any{},
@@ -142,7 +140,7 @@ func (s *qmpFakeServer) serve() {
 				"error": map[string]any{"class": "GenericError", "desc": "boom"},
 			})
 		case execute == "system_powerdown":
-			// Async event first, command return second (fact G29). A correct
+			// Async event first, command return second. A correct
 			// client must skip the event and keep reading until the return.
 			_ = enc.Encode(map[string]any{
 				"timestamp": map[string]any{"seconds": 0, "microseconds": 0},
@@ -260,14 +258,10 @@ func TestQemuRequestGuestShutdownStages(t *testing.T) {
 	})
 }
 
-// TestQemuClientDrainsPowerdownReturn proves the QMP client reads until it sees
-// the command's own "return", consuming it off the wire, instead of stopping at
-// the async POWERDOWN event. net.Pipe is fully synchronous: every server write
-// blocks until the client reads it. A single-read client (one that treated the
-// event as the reply and left the return unread) would leave the server's
-// return write pending and deadlock the follow-up command; a correct
-// read-until-return client drains it and lets the follow-up complete. The
-// deadlines turn that deadlock into a clean, prompt failure rather than a hang.
+// TestQemuGuestShutdownDrainsPowerdownReturn proves the client reads until the
+// command's own "return", not just the async POWERDOWN event. net.Pipe is
+// synchronous, so a client that stopped at the event would leave the server's
+// return write pending and deadlock the follow-up command.
 func TestQemuGuestShutdownDrainsPowerdownReturn(t *testing.T) {
 	t.Parallel()
 
@@ -296,7 +290,7 @@ func TestQemuGuestShutdownDrainsPowerdownReturn(t *testing.T) {
 	var cmd map[string]any
 	require.NoError(t, sdec.Decode(&cmd))
 	assert.Equal(t, "system_powerdown", cmd["execute"])
-	// Async event first, then the command's own return (fact G29).
+	// Async event first, then the command's own return.
 	require.NoError(t, senc.Encode(map[string]any{"event": "POWERDOWN"}))
 	require.NoError(t, senc.Encode(map[string]any{"return": map[string]any{}}))
 

--- a/pkg/unikontainers/hypervisors/graceful_shutdown_test.go
+++ b/pkg/unikontainers/hypervisors/graceful_shutdown_test.go
@@ -1,0 +1,241 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hypervisors
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// tempSocketPath returns a short path under the system temp dir for a unix
+// socket, avoiding the ~108 byte sun_path limit that long t.TempDir()/subtest
+// names can blow past. The directory is removed when the test finishes.
+func tempSocketPath(t *testing.T, name string) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "gs")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return filepath.Join(dir, name)
+}
+
+// qmpFakeServer is a minimal line-JSON QMP server over a unix socket. It sends
+// the greeting on accept, answers qmp_capabilities with {"return":{}}, and on
+// system_powerdown emits an async {"event":"POWERDOWN"} followed by the
+// command's own {"return":{}} (modelling the interleaving real QEMU does,
+// fact G29). It records the commands it receives, in order.
+type qmpFakeServer struct {
+	sockPath string
+	listener net.Listener
+
+	mu       sync.Mutex
+	commands []string
+
+	// When powerdownError is true, the server answers system_powerdown with a
+	// QMP {"error":...} object instead of a return.
+	powerdownError bool
+}
+
+func newQMPFakeServer(t *testing.T, powerdownError bool) *qmpFakeServer {
+	t.Helper()
+	sockPath := tempSocketPath(t, "qmp.sock")
+	ln, err := net.Listen("unix", sockPath)
+	require.NoError(t, err)
+
+	s := &qmpFakeServer{
+		sockPath:       sockPath,
+		listener:       ln,
+		powerdownError: powerdownError,
+	}
+	go s.serve()
+	t.Cleanup(func() { _ = ln.Close() })
+	return s
+}
+
+func (s *qmpFakeServer) serve() {
+	conn, err := s.listener.Accept()
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+
+	enc := json.NewEncoder(conn)
+	dec := json.NewDecoder(conn)
+
+	// Real QEMU sends the greeting unprompted right after accept (fact G26).
+	_ = enc.Encode(map[string]any{
+		"QMP": map[string]any{
+			"version":      map[string]any{},
+			"capabilities": []string{},
+		},
+	})
+
+	for {
+		var cmd map[string]any
+		if err := dec.Decode(&cmd); err != nil {
+			return
+		}
+		execute, _ := cmd["execute"].(string)
+
+		s.mu.Lock()
+		s.commands = append(s.commands, execute)
+		s.mu.Unlock()
+
+		switch execute {
+		case "qmp_capabilities":
+			_ = enc.Encode(map[string]any{"return": map[string]any{}})
+		case "system_powerdown":
+			if s.powerdownError {
+				_ = enc.Encode(map[string]any{
+					"error": map[string]any{"class": "GenericError", "desc": "boom"},
+				})
+				continue
+			}
+			// Async event first, command return second (fact G29). A correct
+			// client must skip the event and keep reading until the return.
+			_ = enc.Encode(map[string]any{
+				"timestamp": map[string]any{"seconds": 0, "microseconds": 0},
+				"event":     "POWERDOWN",
+			})
+			_ = enc.Encode(map[string]any{"return": map[string]any{}})
+		default:
+			_ = enc.Encode(map[string]any{"return": map[string]any{}})
+		}
+	}
+}
+
+func (s *qmpFakeServer) recordedCommands() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, len(s.commands))
+	copy(out, s.commands)
+	return out
+}
+
+func TestQemuRequestGuestShutdown(t *testing.T) {
+	t.Run("negotiates capabilities then powers down, tolerating the event", func(t *testing.T) {
+		s := newQMPFakeServer(t, false)
+
+		q := &Qemu{}
+		err := q.RequestGuestShutdown(s.sockPath)
+		assert.NoError(t, err)
+
+		assert.Equal(t,
+			[]string{"qmp_capabilities", "system_powerdown"},
+			s.recordedCommands(),
+			"client must send qmp_capabilities before system_powerdown",
+		)
+	})
+
+	t.Run("surfaces a QMP error object as an error", func(t *testing.T) {
+		s := newQMPFakeServer(t, true)
+
+		q := &Qemu{}
+		err := q.RequestGuestShutdown(s.sockPath)
+		assert.Error(t, err)
+	})
+}
+
+// clhFakeServer is a fake Cloud Hypervisor REST server speaking HTTP over a
+// unix socket. It records the method and path of every request and answers
+// with a configured status code.
+type clhFakeServer struct {
+	sockPath string
+
+	mu       sync.Mutex
+	requests [][2]string // {method, path}
+}
+
+func newCLHFakeServer(t *testing.T, status int) *clhFakeServer {
+	t.Helper()
+	sockPath := tempSocketPath(t, "ch.sock")
+	ln, err := net.Listen("unix", sockPath)
+	require.NoError(t, err)
+
+	s := &clhFakeServer{sockPath: sockPath}
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			s.mu.Lock()
+			s.requests = append(s.requests, [2]string{r.Method, r.URL.Path})
+			s.mu.Unlock()
+			w.WriteHeader(status)
+		}),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+	return s
+}
+
+func (s *clhFakeServer) recordedRequests() [][2]string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([][2]string, len(s.requests))
+	copy(out, s.requests)
+	return out
+}
+
+func TestCloudHypervisorRequestGuestShutdown(t *testing.T) {
+	tests := []struct {
+		name    string
+		status  int
+		wantErr bool
+	}{
+		{"204 succeeds", http.StatusNoContent, false},
+		{"500 fails", http.StatusInternalServerError, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newCLHFakeServer(t, tt.status)
+
+			ch := &CloudHypervisor{}
+			err := ch.RequestGuestShutdown(s.sockPath)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t,
+				[][2]string{{http.MethodPut, "/api/v1/vm.power-button"}},
+				s.recordedRequests(),
+				"expected exactly one PUT /api/v1/vm.power-button",
+			)
+		})
+	}
+}
+
+func TestSupportsGuestShutdown(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, (&Qemu{}).SupportsGuestShutdown(), "qemu supports guest shutdown")
+	assert.True(t, (&CloudHypervisor{}).SupportsGuestShutdown(), "cloud hypervisor supports guest shutdown")
+	assert.False(t, (&HVT{}).SupportsGuestShutdown(), "hvt does not support guest shutdown")
+	assert.False(t, (&SPT{}).SupportsGuestShutdown(), "spt does not support guest shutdown")
+	assert.False(t, (&Hedge{}).SupportsGuestShutdown(), "hedge does not support guest shutdown")
+	assert.Equal(t, runtime.GOARCH == "amd64", (&Firecracker{}).SupportsGuestShutdown(),
+		"firecracker supports guest shutdown only on amd64")
+}

--- a/pkg/unikontainers/hypervisors/hedge.go
+++ b/pkg/unikontainers/hypervisors/hedge.go
@@ -51,6 +51,11 @@ func (h *Hedge) SupportsSharedfs(_ string) bool {
 	return false
 }
 
+// UsesControlSocket reports that Hedge exposes no control socket.
+func (h *Hedge) UsesControlSocket() bool {
+	return false
+}
+
 func (h *Hedge) Path() string {
 	return ""
 }

--- a/pkg/unikontainers/hypervisors/hedge.go
+++ b/pkg/unikontainers/hypervisors/hedge.go
@@ -51,8 +51,8 @@ func (h *Hedge) SupportsSharedfs(_ string) bool {
 	return false
 }
 
-// UsesControlSocket reports that Hedge exposes no control socket.
-func (h *Hedge) UsesControlSocket() bool {
+// SupportsControlSocket reports that Hedge exposes no control socket.
+func (h *Hedge) SupportsControlSocket() bool {
 	return false
 }
 

--- a/pkg/unikontainers/hypervisors/hedge.go
+++ b/pkg/unikontainers/hypervisors/hedge.go
@@ -42,6 +42,14 @@ func (h *Hedge) Stop(_ int) error {
 	return fmt.Errorf("hedge not implemented yet")
 }
 
+func (h *Hedge) SupportsGuestShutdown() bool {
+	return false
+}
+
+func (h *Hedge) RequestGuestShutdown(_ string) error {
+	return fmt.Errorf("hedge not implemented yet")
+}
+
 func (h *Hedge) UsesKVM() bool {
 	return true
 }

--- a/pkg/unikontainers/hypervisors/http_unix.go
+++ b/pkg/unikontainers/hypervisors/http_unix.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hypervisors
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// socketRequestTimeout bounds a single control-socket REST request so a stuck
+// monitor cannot block the kill path indefinitely.
+const socketRequestTimeout = 5 * time.Second
+
+// unixSocketRequest performs an HTTP request to a monitor's REST API served
+// over a unix socket. The socket path is dialed directly; the URL host is a
+// placeholder net/http requires. A non-2xx response is returned as an error.
+// body may be nil for requests without a payload.
+func unixSocketRequest(socketPath, method, urlPath string, body []byte) error {
+	client := &http.Client{
+		Timeout: socketRequestTimeout,
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				var d net.Dialer
+				return d.DialContext(ctx, "unix", socketPath)
+			},
+		},
+	}
+
+	var reqBody io.Reader
+	if body != nil {
+		reqBody = bytes.NewReader(body)
+	}
+	req, err := http.NewRequest(method, "http://unix"+urlPath, reqBody)
+	if err != nil {
+		return fmt.Errorf("failed to build %s %s request: %w", method, urlPath, err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("%s %s over %q failed: %w", method, urlPath, socketPath, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("%s %s returned status %d: %s",
+			method, urlPath, resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	return nil
+}

--- a/pkg/unikontainers/hypervisors/http_unix.go
+++ b/pkg/unikontainers/hypervisors/http_unix.go
@@ -60,17 +60,24 @@ func unixSocketRequest(socketPath, method, urlPath string, body []byte) error {
 		req.Header.Set("Content-Type", "application/json")
 	}
 
+	// A failed client.Do covers both a socket we could not reach and a
+	// monitor that never answered in time; either way, the request never
+	// completed.
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("%s %s over %q failed: %w", method, urlPath, socketPath, err)
+		return fmt.Errorf("%w (%s %s over %q): %w",
+			ErrShutdownConnect, method, urlPath, socketPath, err)
 	}
 	defer resp.Body.Close()
 
 	// The body is only used to enrich an error string, so cap the read.
 	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	// A status code proves the monitor is alive and answered, so a non-2xx
+	// here is the monitor rejecting the request, not an unreachable monitor.
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("%s %s returned status %d: %s",
-			method, urlPath, resp.StatusCode, strings.TrimSpace(string(respBody)))
+		return fmt.Errorf("%w: %s %s returned status %d: %s",
+			ErrShutdownRefused, method, urlPath, resp.StatusCode,
+			strings.TrimSpace(string(respBody)))
 	}
 	return nil
 }

--- a/pkg/unikontainers/hypervisors/http_unix.go
+++ b/pkg/unikontainers/hypervisors/http_unix.go
@@ -29,17 +29,13 @@ import (
 // monitor cannot block the kill path indefinitely.
 const socketRequestTimeout = 5 * time.Second
 
-// unixSocketRequest performs an HTTP request to a monitor's REST API served
-// over a unix socket. The socket path is dialed directly; the URL host is a
-// placeholder net/http requires. A non-2xx response is returned as an error.
-// body may be nil for requests without a payload.
+// unixSocketRequest sends an HTTP request to a monitor's REST API over a unix
+// socket. The URL host is a placeholder that net/http requires.
 func unixSocketRequest(socketPath, method, urlPath string, body []byte) error {
 	client := &http.Client{
 		Timeout: socketRequestTimeout,
 		Transport: &http.Transport{
-			// A single one-shot request; keep no idle unix connection in the
-			// pool, so nothing lingers if this helper is ever called from a
-			// long-lived process.
+			// One-shot request, so leave no idle connection behind.
 			DisableKeepAlives: true,
 			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
 				var d net.Dialer

--- a/pkg/unikontainers/hypervisors/http_unix.go
+++ b/pkg/unikontainers/hypervisors/http_unix.go
@@ -37,6 +37,10 @@ func unixSocketRequest(socketPath, method, urlPath string, body []byte) error {
 	client := &http.Client{
 		Timeout: socketRequestTimeout,
 		Transport: &http.Transport{
+			// A single one-shot request; keep no idle unix connection in the
+			// pool, so nothing lingers if this helper is ever called from a
+			// long-lived process.
+			DisableKeepAlives: true,
 			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
 				var d net.Dialer
 				return d.DialContext(ctx, "unix", socketPath)
@@ -62,7 +66,8 @@ func unixSocketRequest(socketPath, method, urlPath string, body []byte) error {
 	}
 	defer resp.Body.Close()
 
-	respBody, _ := io.ReadAll(resp.Body)
+	// The body is only used to enrich an error string, so cap the read.
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("%s %s returned status %d: %s",
 			method, urlPath, resp.StatusCode, strings.TrimSpace(string(respBody)))

--- a/pkg/unikontainers/hypervisors/hvt.go
+++ b/pkg/unikontainers/hypervisors/hvt.go
@@ -136,13 +136,10 @@ func (h *HVT) UsesKVM() bool {
 	return true
 }
 
-// SupportsGuestShutdown reports that HVT has no control socket to request a
-// graceful guest shutdown over.
 func (h *HVT) SupportsGuestShutdown() bool {
 	return false
 }
 
-// RequestGuestShutdown is unsupported for HVT; it has no control socket.
 func (h *HVT) RequestGuestShutdown(_ string) error {
 	return fmt.Errorf("guest shutdown not supported for hvt")
 }

--- a/pkg/unikontainers/hypervisors/hvt.go
+++ b/pkg/unikontainers/hypervisors/hvt.go
@@ -15,6 +15,7 @@
 package hypervisors
 
 import (
+	"fmt"
 	"os/exec"
 	"runtime"
 
@@ -133,6 +134,17 @@ func (h *HVT) Stop(pid int) error {
 // UsesKVM returns a bool value depending on if the monitor uses KVM
 func (h *HVT) UsesKVM() bool {
 	return true
+}
+
+// SupportsGuestShutdown reports that HVT has no control socket to request a
+// graceful guest shutdown over.
+func (h *HVT) SupportsGuestShutdown() bool {
+	return false
+}
+
+// RequestGuestShutdown is unsupported for HVT; it has no control socket.
+func (h *HVT) RequestGuestShutdown(_ string) error {
+	return fmt.Errorf("guest shutdown not supported for hvt")
 }
 
 // SupportsSharedfs returns a bool value depending on the monitor support for shared-fs

--- a/pkg/unikontainers/hypervisors/hvt.go
+++ b/pkg/unikontainers/hypervisors/hvt.go
@@ -140,6 +140,11 @@ func (h *HVT) SupportsSharedfs(_ string) bool {
 	return false
 }
 
+// UsesControlSocket reports that HVT exposes no control socket.
+func (h *HVT) UsesControlSocket() bool {
+	return false
+}
+
 // Path returns the path to the hvt binary.
 func (h *HVT) Path() string {
 	return h.binaryPath

--- a/pkg/unikontainers/hypervisors/hvt.go
+++ b/pkg/unikontainers/hypervisors/hvt.go
@@ -140,8 +140,8 @@ func (h *HVT) SupportsSharedfs(_ string) bool {
 	return false
 }
 
-// UsesControlSocket reports that HVT exposes no control socket.
-func (h *HVT) UsesControlSocket() bool {
+// SupportsControlSocket reports that HVT exposes no control socket.
+func (h *HVT) SupportsControlSocket() bool {
 	return false
 }
 

--- a/pkg/unikontainers/hypervisors/hyperlight.go
+++ b/pkg/unikontainers/hypervisors/hyperlight.go
@@ -46,8 +46,8 @@ func (h *Hyperlight) SupportsSharedfs(_ string) bool {
 	return false
 }
 
-// UsesControlSocket reports that Hyperlight exposes no control socket.
-func (h *Hyperlight) UsesControlSocket() bool {
+// SupportsControlSocket reports that Hyperlight exposes no control socket.
+func (h *Hyperlight) SupportsControlSocket() bool {
 	return false
 }
 

--- a/pkg/unikontainers/hypervisors/hyperlight.go
+++ b/pkg/unikontainers/hypervisors/hyperlight.go
@@ -46,6 +46,11 @@ func (h *Hyperlight) SupportsSharedfs(_ string) bool {
 	return false
 }
 
+// UsesControlSocket reports that Hyperlight exposes no control socket.
+func (h *Hyperlight) UsesControlSocket() bool {
+	return false
+}
+
 // Path returns the path to the hyperlight binary.
 func (h *Hyperlight) Path() string {
 	return h.binaryPath

--- a/pkg/unikontainers/hypervisors/hyperlight.go
+++ b/pkg/unikontainers/hypervisors/hyperlight.go
@@ -52,13 +52,10 @@ func (h *Hyperlight) SupportsControlSocket() bool {
 	return false
 }
 
-// SupportsGuestShutdown reports that Hyperlight has no control socket to
-// request a graceful guest shutdown over.
 func (h *Hyperlight) SupportsGuestShutdown() bool {
 	return false
 }
 
-// RequestGuestShutdown is unsupported for Hyperlight; it has no control socket.
 func (h *Hyperlight) RequestGuestShutdown(_ string) error {
 	return fmt.Errorf("guest shutdown not supported for hyperlight")
 }

--- a/pkg/unikontainers/hypervisors/hyperlight.go
+++ b/pkg/unikontainers/hypervisors/hyperlight.go
@@ -15,6 +15,7 @@
 package hypervisors
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
@@ -49,6 +50,17 @@ func (h *Hyperlight) SupportsSharedfs(_ string) bool {
 // SupportsControlSocket reports that Hyperlight exposes no control socket.
 func (h *Hyperlight) SupportsControlSocket() bool {
 	return false
+}
+
+// SupportsGuestShutdown reports that Hyperlight has no control socket to
+// request a graceful guest shutdown over.
+func (h *Hyperlight) SupportsGuestShutdown() bool {
+	return false
+}
+
+// RequestGuestShutdown is unsupported for Hyperlight; it has no control socket.
+func (h *Hyperlight) RequestGuestShutdown(_ string) error {
+	return fmt.Errorf("guest shutdown not supported for hyperlight")
 }
 
 // Path returns the path to the hyperlight binary.

--- a/pkg/unikontainers/hypervisors/qemu.go
+++ b/pkg/unikontainers/hypervisors/qemu.go
@@ -56,8 +56,8 @@ func (q *Qemu) SupportsSharedfs(_ string) bool {
 	return true
 }
 
-// UsesControlSocket reports that QEMU exposes a control socket (QMP).
-func (q *Qemu) UsesControlSocket() bool {
+// SupportsControlSocket reports that QEMU exposes a control socket (QMP).
+func (q *Qemu) SupportsControlSocket() bool {
 	return true
 }
 

--- a/pkg/unikontainers/hypervisors/qemu.go
+++ b/pkg/unikontainers/hypervisors/qemu.go
@@ -56,6 +56,11 @@ func (q *Qemu) SupportsSharedfs(_ string) bool {
 	return true
 }
 
+// UsesControlSocket reports that QEMU exposes a control socket (QMP).
+func (q *Qemu) UsesControlSocket() bool {
+	return true
+}
+
 func (q *Qemu) Path() string {
 	return q.binaryPath
 }

--- a/pkg/unikontainers/hypervisors/qemu.go
+++ b/pkg/unikontainers/hypervisors/qemu.go
@@ -73,6 +73,10 @@ func (q *Qemu) BuildExecCmd(args types.ExecArgs, ukernel types.Unikernel) ([]str
 		"-serial", "stdio",
 		"-monitor", "null",
 	}
+	// Expose a QMP control socket so the runtime can talk to QEMU after boot
+	// (e.g. for graceful shutdown). server,nowait lets QEMU boot without
+	// waiting for a client to connect.
+	exArgs = append(exArgs, "-qmp", "unix:"+ResolveSocketPath(args)+",server,nowait")
 
 	if args.VCPUs > 0 {
 		exArgs = append(exArgs, "-smp", strconv.FormatUint(uint64(args.VCPUs), 10))

--- a/pkg/unikontainers/hypervisors/qemu.go
+++ b/pkg/unikontainers/hypervisors/qemu.go
@@ -78,10 +78,8 @@ func (q *Qemu) BuildExecCmd(args types.ExecArgs, ukernel types.Unikernel) ([]str
 		"-serial", "stdio",
 		"-monitor", "null",
 	}
-	// Expose a QMP control socket only when a socket_path is configured, so the
-	// runtime can talk to QEMU after boot (e.g. for graceful shutdown). With no
-	// configured path QEMU boots with no control socket. server,nowait lets QEMU
-	// boot without waiting for a client to connect.
+	// Expose the QMP socket only when socket_path is set. server,nowait lets
+	// QEMU boot without waiting for a client.
 	if args.SocketPath != "" {
 		exArgs = append(exArgs, "-qmp", "unix:"+args.SocketPath+",server,nowait")
 	}

--- a/pkg/unikontainers/hypervisors/qemu.go
+++ b/pkg/unikontainers/hypervisors/qemu.go
@@ -73,10 +73,13 @@ func (q *Qemu) BuildExecCmd(args types.ExecArgs, ukernel types.Unikernel) ([]str
 		"-serial", "stdio",
 		"-monitor", "null",
 	}
-	// Expose a QMP control socket so the runtime can talk to QEMU after boot
-	// (e.g. for graceful shutdown). server,nowait lets QEMU boot without
-	// waiting for a client to connect.
-	exArgs = append(exArgs, "-qmp", "unix:"+ResolveSocketPath(args)+",server,nowait")
+	// Expose a QMP control socket only when a socket_path is configured, so the
+	// runtime can talk to QEMU after boot (e.g. for graceful shutdown). With no
+	// configured path QEMU boots with no control socket. server,nowait lets QEMU
+	// boot without waiting for a client to connect.
+	if args.SocketPath != "" {
+		exArgs = append(exArgs, "-qmp", "unix:"+args.SocketPath+",server,nowait")
+	}
 
 	if args.VCPUs > 0 {
 		exArgs = append(exArgs, "-smp", strconv.FormatUint(uint64(args.VCPUs), 10))

--- a/pkg/unikontainers/hypervisors/qemu_qmp.go
+++ b/pkg/unikontainers/hypervisors/qemu_qmp.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hypervisors
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"time"
+)
+
+// qmpDeadline bounds the whole QMP exchange so a stuck monitor cannot block
+// the kill path indefinitely.
+const qmpDeadline = 5 * time.Second
+
+// SupportsGuestShutdown reports that QEMU can shut the guest down gracefully
+// via the QMP system_powerdown command.
+func (q *Qemu) SupportsGuestShutdown() bool {
+	return true
+}
+
+// RequestGuestShutdown connects to QEMU's QMP control socket and asks the
+// guest to power down. socketPath is the already-resolved, host-reachable
+// path; it is dialed directly. QMP requires a capabilities handshake before
+// any command, and system_powerdown's reply is interleaved with an async
+// POWERDOWN event, so each response is read until its own "return" arrives.
+func (q *Qemu) RequestGuestShutdown(socketPath string) error {
+	conn, err := net.DialTimeout("unix", socketPath, qmpDeadline)
+	if err != nil {
+		return fmt.Errorf("failed to connect to QMP socket %q: %w", socketPath, err)
+	}
+	defer conn.Close()
+
+	if err := conn.SetDeadline(time.Now().Add(qmpDeadline)); err != nil {
+		return fmt.Errorf("failed to set QMP socket deadline: %w", err)
+	}
+
+	dec := json.NewDecoder(conn)
+	enc := json.NewEncoder(conn)
+
+	// QEMU sends the QMP greeting unprompted right after connect.
+	var greeting map[string]json.RawMessage
+	if err := dec.Decode(&greeting); err != nil {
+		return fmt.Errorf("failed to read QMP greeting: %w", err)
+	}
+
+	// Capabilities negotiation is mandatory before any other command.
+	if err := qmpCommand(enc, dec, "qmp_capabilities"); err != nil {
+		return err
+	}
+
+	// Ask the guest to power down (ACPI power button).
+	return qmpCommand(enc, dec, "system_powerdown")
+}
+
+// qmpCommand sends a QMP command with no arguments and waits for its return.
+func qmpCommand(enc *json.Encoder, dec *json.Decoder, command string) error {
+	if err := enc.Encode(map[string]string{"execute": command}); err != nil {
+		return fmt.Errorf("failed to send QMP command %q: %w", command, err)
+	}
+	return qmpReadReturn(dec, command)
+}
+
+// qmpReadReturn reads QMP messages until it sees the command's own reply. Any
+// async "event" message is skipped; a "return" ends the wait successfully; an
+// "error" object is surfaced as an error.
+func qmpReadReturn(dec *json.Decoder, command string) error {
+	for {
+		var msg map[string]json.RawMessage
+		if err := dec.Decode(&msg); err != nil {
+			return fmt.Errorf("failed to read QMP response for %q: %w", command, err)
+		}
+		if errObj, ok := msg["error"]; ok {
+			return fmt.Errorf("QMP command %q failed: %s", command, string(errObj))
+		}
+		if _, ok := msg["return"]; ok {
+			return nil
+		}
+		// Any other message (typically an async "event") is skipped until the
+		// command's own "return" arrives.
+	}
+}

--- a/pkg/unikontainers/hypervisors/qemu_qmp.go
+++ b/pkg/unikontainers/hypervisors/qemu_qmp.go
@@ -25,21 +25,15 @@ import (
 // the kill path indefinitely.
 const qmpDeadline = 5 * time.Second
 
-// SupportsGuestShutdown reports that QEMU can shut the guest down gracefully
-// via the QMP system_powerdown command.
 func (q *Qemu) SupportsGuestShutdown() bool {
 	return true
 }
 
-// RequestGuestShutdown connects to QEMU's QMP control socket and asks the
-// guest to power down. socketPath is the already-resolved, host-reachable
-// path; it is dialed directly. QMP requires a capabilities handshake before
-// any command, and system_powerdown's reply is interleaved with an async
-// POWERDOWN event, so each response is read until its own "return" arrives.
+// RequestGuestShutdown asks the guest to power down over QEMU's QMP socket.
+// socketPath is already resolved and host-reachable, so it is dialed directly.
 func (q *Qemu) RequestGuestShutdown(socketPath string) error {
-	// Bound the whole attempt (dial plus exchange) by a single absolute
-	// deadline, so the worst case stays within one qmpDeadline budget rather
-	// than dial timeout plus exchange timeout stacking on top of each other.
+	// One absolute deadline for dial and exchange together, so the two do not
+	// stack into twice the budget.
 	deadline := time.Now().Add(qmpDeadline)
 
 	conn, err := net.DialTimeout("unix", socketPath, time.Until(deadline))
@@ -66,14 +60,11 @@ func (q *Qemu) RequestGuestShutdown(socketPath string) error {
 		return err
 	}
 
-	// Ask the guest to power down (ACPI power button).
 	return qmpCommand(enc, dec, "system_powerdown", ErrShutdownCommand)
 }
 
-// qmpCommand sends a QMP command with no arguments and waits for its return.
-// stage names which step of the shutdown request this call serves
-// (qmp_capabilities is the handshake, system_powerdown is the command
-// itself), so a write or read failure can be wrapped with the right one.
+// qmpCommand sends an argument-less QMP command and waits for its return.
+// stage names the step, so a failure is wrapped with the right sentinel.
 func qmpCommand(enc *json.Encoder, dec *json.Decoder, command string, stage error) error {
 	if err := enc.Encode(map[string]string{"execute": command}); err != nil {
 		return fmt.Errorf("%w: failed to send QMP command %q: %w", stage, command, err)
@@ -81,11 +72,9 @@ func qmpCommand(enc *json.Encoder, dec *json.Decoder, command string, stage erro
 	return qmpReadReturn(dec, command, stage)
 }
 
-// qmpReadReturn reads QMP messages until it sees the command's own reply. Any
-// async "event" message is skipped; a "return" ends the wait successfully. A
-// read failure means the monitor never answered this stage, so it is wrapped
-// with stage; an "error" object means the monitor answered and rejected the
-// command, so that is wrapped with ErrShutdownRefused instead.
+// qmpReadReturn reads until the command's own "return", skipping async events.
+// A read failure means the monitor never answered, so it is wrapped with
+// stage; an "error" object means it answered and refused, so that is Refused.
 func qmpReadReturn(dec *json.Decoder, command string, stage error) error {
 	for {
 		var msg map[string]json.RawMessage
@@ -98,7 +87,5 @@ func qmpReadReturn(dec *json.Decoder, command string, stage error) error {
 		if _, ok := msg["return"]; ok {
 			return nil
 		}
-		// Any other message (typically an async "event") is skipped until the
-		// command's own "return" arrives.
 	}
 }

--- a/pkg/unikontainers/hypervisors/qemu_qmp.go
+++ b/pkg/unikontainers/hypervisors/qemu_qmp.go
@@ -37,13 +37,18 @@ func (q *Qemu) SupportsGuestShutdown() bool {
 // any command, and system_powerdown's reply is interleaved with an async
 // POWERDOWN event, so each response is read until its own "return" arrives.
 func (q *Qemu) RequestGuestShutdown(socketPath string) error {
-	conn, err := net.DialTimeout("unix", socketPath, qmpDeadline)
+	// Bound the whole attempt (dial plus exchange) by a single absolute
+	// deadline, so the worst case stays within one qmpDeadline budget rather
+	// than dial timeout plus exchange timeout stacking on top of each other.
+	deadline := time.Now().Add(qmpDeadline)
+
+	conn, err := net.DialTimeout("unix", socketPath, time.Until(deadline))
 	if err != nil {
 		return fmt.Errorf("failed to connect to QMP socket %q: %w", socketPath, err)
 	}
 	defer conn.Close()
 
-	if err := conn.SetDeadline(time.Now().Add(qmpDeadline)); err != nil {
+	if err := conn.SetDeadline(deadline); err != nil {
 		return fmt.Errorf("failed to set QMP socket deadline: %w", err)
 	}
 

--- a/pkg/unikontainers/hypervisors/qemu_qmp.go
+++ b/pkg/unikontainers/hypervisors/qemu_qmp.go
@@ -44,7 +44,7 @@ func (q *Qemu) RequestGuestShutdown(socketPath string) error {
 
 	conn, err := net.DialTimeout("unix", socketPath, time.Until(deadline))
 	if err != nil {
-		return fmt.Errorf("failed to connect to QMP socket %q: %w", socketPath, err)
+		return fmt.Errorf("%w %q: %w", ErrShutdownConnect, socketPath, err)
 	}
 	defer conn.Close()
 
@@ -58,37 +58,42 @@ func (q *Qemu) RequestGuestShutdown(socketPath string) error {
 	// QEMU sends the QMP greeting unprompted right after connect.
 	var greeting map[string]json.RawMessage
 	if err := dec.Decode(&greeting); err != nil {
-		return fmt.Errorf("failed to read QMP greeting: %w", err)
+		return fmt.Errorf("%w: %w", ErrShutdownGreeting, err)
 	}
 
 	// Capabilities negotiation is mandatory before any other command.
-	if err := qmpCommand(enc, dec, "qmp_capabilities"); err != nil {
+	if err := qmpCommand(enc, dec, "qmp_capabilities", ErrShutdownHandshake); err != nil {
 		return err
 	}
 
 	// Ask the guest to power down (ACPI power button).
-	return qmpCommand(enc, dec, "system_powerdown")
+	return qmpCommand(enc, dec, "system_powerdown", ErrShutdownCommand)
 }
 
 // qmpCommand sends a QMP command with no arguments and waits for its return.
-func qmpCommand(enc *json.Encoder, dec *json.Decoder, command string) error {
+// stage names which step of the shutdown request this call serves
+// (qmp_capabilities is the handshake, system_powerdown is the command
+// itself), so a write or read failure can be wrapped with the right one.
+func qmpCommand(enc *json.Encoder, dec *json.Decoder, command string, stage error) error {
 	if err := enc.Encode(map[string]string{"execute": command}); err != nil {
-		return fmt.Errorf("failed to send QMP command %q: %w", command, err)
+		return fmt.Errorf("%w: failed to send QMP command %q: %w", stage, command, err)
 	}
-	return qmpReadReturn(dec, command)
+	return qmpReadReturn(dec, command, stage)
 }
 
 // qmpReadReturn reads QMP messages until it sees the command's own reply. Any
-// async "event" message is skipped; a "return" ends the wait successfully; an
-// "error" object is surfaced as an error.
-func qmpReadReturn(dec *json.Decoder, command string) error {
+// async "event" message is skipped; a "return" ends the wait successfully. A
+// read failure means the monitor never answered this stage, so it is wrapped
+// with stage; an "error" object means the monitor answered and rejected the
+// command, so that is wrapped with ErrShutdownRefused instead.
+func qmpReadReturn(dec *json.Decoder, command string, stage error) error {
 	for {
 		var msg map[string]json.RawMessage
 		if err := dec.Decode(&msg); err != nil {
-			return fmt.Errorf("failed to read QMP response for %q: %w", command, err)
+			return fmt.Errorf("%w: failed to read QMP response for %q: %w", stage, command, err)
 		}
 		if errObj, ok := msg["error"]; ok {
-			return fmt.Errorf("QMP command %q failed: %s", command, string(errObj))
+			return fmt.Errorf("%w: QMP command %q failed: %s", ErrShutdownRefused, command, string(errObj))
 		}
 		if _, ok := msg["return"]; ok {
 			return nil

--- a/pkg/unikontainers/hypervisors/qemu_test.go
+++ b/pkg/unikontainers/hypervisors/qemu_test.go
@@ -81,7 +81,6 @@ func TestQemuBuildExecCmd(t *testing.T) {
 				"-vga none",
 				"-serial stdio",
 				"-monitor null",
-				"-qmp unix:/tmp/.sock,server,nowait",
 				"-m 256M",
 				"-kernel " + testKernelPath,
 				"-nic none",
@@ -94,6 +93,7 @@ func TestQemuBuildExecCmd(t *testing.T) {
 				"vhost-user-fs-pci",
 				"virtio-blk-pci",
 				"vhost-vsock-pci",
+				"-qmp",
 			},
 		},
 		{
@@ -107,14 +107,14 @@ func TestQemuBuildExecCmd(t *testing.T) {
 			mustContain: []string{"-qmp unix:/run/urunc/q.sock,server,nowait"},
 		},
 		{
-			name: "default SocketPath uses the container-id path",
+			name: "unset SocketPath omits -qmp",
 			args: types.ExecArgs{
 				UnikernelPath: testKernelPath,
 				Command:       testCommand,
 				ContainerID:   "abc123",
 			},
-			unikernel:   &fakeUnikernel{},
-			mustContain: []string{"-qmp unix:/tmp/abc123.sock,server,nowait"},
+			unikernel:      &fakeUnikernel{},
+			mustNotContain: []string{"-qmp"},
 		},
 		{
 			name: "custom MemSizeB renders -m in MB",

--- a/pkg/unikontainers/hypervisors/qemu_test.go
+++ b/pkg/unikontainers/hypervisors/qemu_test.go
@@ -81,6 +81,7 @@ func TestQemuBuildExecCmd(t *testing.T) {
 				"-vga none",
 				"-serial stdio",
 				"-monitor null",
+				"-qmp unix:/tmp/.sock,server,nowait",
 				"-m 256M",
 				"-kernel " + testKernelPath,
 				"-nic none",
@@ -94,6 +95,26 @@ func TestQemuBuildExecCmd(t *testing.T) {
 				"virtio-blk-pci",
 				"vhost-vsock-pci",
 			},
+		},
+		{
+			name: "configured SocketPath renders -qmp on that path",
+			args: types.ExecArgs{
+				UnikernelPath: testKernelPath,
+				Command:       testCommand,
+				SocketPath:    "/run/urunc/q.sock",
+			},
+			unikernel:   &fakeUnikernel{},
+			mustContain: []string{"-qmp unix:/run/urunc/q.sock,server,nowait"},
+		},
+		{
+			name: "default SocketPath uses the container-id path",
+			args: types.ExecArgs{
+				UnikernelPath: testKernelPath,
+				Command:       testCommand,
+				ContainerID:   "abc123",
+			},
+			unikernel:   &fakeUnikernel{},
+			mustContain: []string{"-qmp unix:/tmp/abc123.sock,server,nowait"},
 		},
 		{
 			name: "custom MemSizeB renders -m in MB",

--- a/pkg/unikontainers/hypervisors/shutdown_errors_test.go
+++ b/pkg/unikontainers/hypervisors/shutdown_errors_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hypervisors
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestShutdownStageErrors(t *testing.T) {
+	t.Parallel()
+
+	stages := []error{
+		ErrShutdownConnect,
+		ErrShutdownGreeting,
+		ErrShutdownHandshake,
+		ErrShutdownCommand,
+		ErrShutdownRefused,
+	}
+
+	seen := make(map[string]bool, len(stages))
+	for _, stage := range stages {
+		if stage == nil {
+			t.Fatal("stage error is nil")
+		}
+		if seen[stage.Error()] {
+			t.Fatalf("duplicate stage message %q", stage.Error())
+		}
+		seen[stage.Error()] = true
+	}
+
+	wrapped := fmt.Errorf("%w: dial unix: no such file", ErrShutdownConnect)
+	if !errors.Is(wrapped, ErrShutdownConnect) {
+		t.Fatal("wrapped error does not match its stage")
+	}
+	if errors.Is(wrapped, ErrShutdownCommand) {
+		t.Fatal("wrapped error matches the wrong stage")
+	}
+}

--- a/pkg/unikontainers/hypervisors/spt.go
+++ b/pkg/unikontainers/hypervisors/spt.go
@@ -46,13 +46,10 @@ func (s *SPT) UsesKVM() bool {
 	return false
 }
 
-// SupportsGuestShutdown reports that SPT has no control socket to request a
-// graceful guest shutdown over.
 func (s *SPT) SupportsGuestShutdown() bool {
 	return false
 }
 
-// RequestGuestShutdown is unsupported for SPT; it has no control socket.
 func (s *SPT) RequestGuestShutdown(_ string) error {
 	return fmt.Errorf("guest shutdown not supported for spt")
 }

--- a/pkg/unikontainers/hypervisors/spt.go
+++ b/pkg/unikontainers/hypervisors/spt.go
@@ -50,8 +50,8 @@ func (s *SPT) SupportsSharedfs(_ string) bool {
 	return false
 }
 
-// UsesControlSocket reports that SPT exposes no control socket.
-func (s *SPT) UsesControlSocket() bool {
+// SupportsControlSocket reports that SPT exposes no control socket.
+func (s *SPT) SupportsControlSocket() bool {
 	return false
 }
 

--- a/pkg/unikontainers/hypervisors/spt.go
+++ b/pkg/unikontainers/hypervisors/spt.go
@@ -15,6 +15,7 @@
 package hypervisors
 
 import (
+	"fmt"
 	"os/exec"
 
 	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
@@ -43,6 +44,17 @@ func (s *SPT) Stop(pid int) error {
 // UsesKVM returns a bool value depending on if the monitor uses KVM
 func (s *SPT) UsesKVM() bool {
 	return false
+}
+
+// SupportsGuestShutdown reports that SPT has no control socket to request a
+// graceful guest shutdown over.
+func (s *SPT) SupportsGuestShutdown() bool {
+	return false
+}
+
+// RequestGuestShutdown is unsupported for SPT; it has no control socket.
+func (s *SPT) RequestGuestShutdown(_ string) error {
+	return fmt.Errorf("guest shutdown not supported for spt")
 }
 
 // SupportsSharedfs returns a bool value depending on the monitor support for shared-fs

--- a/pkg/unikontainers/hypervisors/spt.go
+++ b/pkg/unikontainers/hypervisors/spt.go
@@ -50,6 +50,11 @@ func (s *SPT) SupportsSharedfs(_ string) bool {
 	return false
 }
 
+// UsesControlSocket reports that SPT exposes no control socket.
+func (s *SPT) UsesControlSocket() bool {
+	return false
+}
+
 // Path returns the path to the spt binary.
 func (s *SPT) Path() string {
 	return s.binaryPath

--- a/pkg/unikontainers/hypervisors/utils.go
+++ b/pkg/unikontainers/hypervisors/utils.go
@@ -17,29 +17,12 @@ package hypervisors
 import (
 	"errors"
 	"fmt"
-	"path/filepath"
 	"runtime"
 	"strconv"
 	"time"
 
-	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
 	"golang.org/x/sys/unix"
 )
-
-// DefaultSocketDir is the directory used for a monitor's control socket when
-// no socket_path is configured. It always exists inside the monitor rootfs,
-// so the default path needs no extra directory setup.
-const DefaultSocketDir = "/tmp"
-
-// ResolveSocketPath returns the path for a monitor's control socket: the
-// configured SocketPath when set, otherwise a per-container default under
-// DefaultSocketDir. Shared by every monitor that exposes a control socket.
-func ResolveSocketPath(args types.ExecArgs) string {
-	if args.SocketPath != "" {
-		return args.SocketPath
-	}
-	return filepath.Join(DefaultSocketDir, args.ContainerID+".sock")
-}
 
 func cpuArch() string {
 	switch runtime.GOARCH {

--- a/pkg/unikontainers/hypervisors/utils.go
+++ b/pkg/unikontainers/hypervisors/utils.go
@@ -17,12 +17,29 @@ package hypervisors
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"time"
 
+	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
 	"golang.org/x/sys/unix"
 )
+
+// DefaultSocketDir is the directory used for a monitor's control socket when
+// no socket_path is configured. It always exists inside the monitor rootfs,
+// so the default path needs no extra directory setup.
+const DefaultSocketDir = "/tmp"
+
+// ResolveSocketPath returns the path for a monitor's control socket: the
+// configured SocketPath when set, otherwise a per-container default under
+// DefaultSocketDir. Shared by every monitor that exposes a control socket.
+func ResolveSocketPath(args types.ExecArgs) string {
+	if args.SocketPath != "" {
+		return args.SocketPath
+	}
+	return filepath.Join(DefaultSocketDir, args.ContainerID+".sock")
+}
 
 func cpuArch() string {
 	switch runtime.GOARCH {

--- a/pkg/unikontainers/hypervisors/vmm.go
+++ b/pkg/unikontainers/hypervisors/vmm.go
@@ -30,6 +30,17 @@ type VmmType string
 var ErrVMMNotInstalled = errors.New("vmm not found")
 var vmmLog = logrus.WithField("subsystem", "monitors")
 
+// Stages of a graceful-shutdown request, so a caller can report which step
+// failed. A monitor that never answers is a monitor that never got scheduled,
+// not a guest that refused, and these let a log line say so.
+var (
+	ErrShutdownConnect   = errors.New("could not reach the monitor's control socket")
+	ErrShutdownGreeting  = errors.New("the monitor did not send its greeting")
+	ErrShutdownHandshake = errors.New("the monitor did not complete the handshake")
+	ErrShutdownCommand   = errors.New("the monitor did not answer the shutdown command")
+	ErrShutdownRefused   = errors.New("the monitor refused the shutdown request")
+)
+
 type VMMFactory struct {
 	binary     string
 	createFunc func(binary, binaryPath string, vhost bool) types.VMM

--- a/pkg/unikontainers/hypervisors/vmm.go
+++ b/pkg/unikontainers/hypervisors/vmm.go
@@ -27,6 +27,17 @@ const DefaultMemory uint64 = 256 // The default memory for every hypervisor: 256
 
 type VmmType string
 
+// UsesControlSocket reports whether a monitor exposes a control socket whose
+// path (socket_path) urunc must make reachable before the monitor launches.
+func UsesControlSocket(vmmType VmmType) bool {
+	switch vmmType {
+	case FirecrackerVmm, QemuVmm, CloudHypervisorVmm:
+		return true
+	default:
+		return false
+	}
+}
+
 var ErrVMMNotInstalled = errors.New("vmm not found")
 var vmmLog = logrus.WithField("subsystem", "monitors")
 

--- a/pkg/unikontainers/hypervisors/vmm.go
+++ b/pkg/unikontainers/hypervisors/vmm.go
@@ -30,9 +30,8 @@ type VmmType string
 var ErrVMMNotInstalled = errors.New("vmm not found")
 var vmmLog = logrus.WithField("subsystem", "monitors")
 
-// Stages of a graceful-shutdown request, so a caller can report which step
-// failed. A monitor that never answers is a monitor that never got scheduled,
-// not a guest that refused, and these let a log line say so.
+// Stages of a graceful-shutdown request. A monitor that never answers did not
+// get to the request; it does not mean the guest refused.
 var (
 	ErrShutdownConnect   = errors.New("could not reach the monitor's control socket")
 	ErrShutdownGreeting  = errors.New("the monitor did not send its greeting")

--- a/pkg/unikontainers/hypervisors/vmm.go
+++ b/pkg/unikontainers/hypervisors/vmm.go
@@ -27,17 +27,6 @@ const DefaultMemory uint64 = 256 // The default memory for every hypervisor: 256
 
 type VmmType string
 
-// UsesControlSocket reports whether a monitor exposes a control socket whose
-// path (socket_path) urunc must make reachable before the monitor launches.
-func UsesControlSocket(vmmType VmmType) bool {
-	switch vmmType {
-	case FirecrackerVmm, QemuVmm, CloudHypervisorVmm:
-		return true
-	default:
-		return false
-	}
-}
-
 var ErrVMMNotInstalled = errors.New("vmm not found")
 var vmmLog = logrus.WithField("subsystem", "monitors")
 

--- a/pkg/unikontainers/hypervisors/vmm_test.go
+++ b/pkg/unikontainers/hypervisors/vmm_test.go
@@ -21,9 +21,9 @@ import (
 	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
 )
 
-// TestUsesControlSocket verifies each monitor reports whether it exposes a
+// TestSupportsControlSocket verifies each monitor reports whether it exposes a
 // control socket (Qemu, Firecracker, Cloud Hypervisor true; the rest false).
-func TestUsesControlSocket(t *testing.T) {
+func TestSupportsControlSocket(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -43,7 +43,7 @@ func TestUsesControlSocket(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tt.want, tt.vmm.UsesControlSocket())
+			assert.Equal(t, tt.want, tt.vmm.SupportsControlSocket())
 		})
 	}
 }

--- a/pkg/unikontainers/hypervisors/vmm_test.go
+++ b/pkg/unikontainers/hypervisors/vmm_test.go
@@ -18,7 +18,37 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
 )
+
+// TestUsesControlSocket verifies every monitor reports whether it exposes a
+// control socket. The monitors that expose one (Qemu, Firecracker, Cloud
+// Hypervisor) must return true; the rest must return false. Because it is an
+// interface method, a new monitor cannot compile without declaring it.
+func TestUsesControlSocket(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		vmm  types.VMM
+		want bool
+	}{
+		{"qemu", &Qemu{}, true},
+		{"firecracker", &Firecracker{}, true},
+		{"cloud-hypervisor", &CloudHypervisor{}, true},
+		{"hvt", &HVT{}, false},
+		{"spt", &SPT{}, false},
+		{"hedge", &Hedge{}, false},
+		{"hyperlight", &Hyperlight{}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.vmm.UsesControlSocket())
+		})
+	}
+}
 
 func TestVMMFactoryQemuVhostFalse(t *testing.T) {
 	t.Parallel()

--- a/pkg/unikontainers/hypervisors/vmm_test.go
+++ b/pkg/unikontainers/hypervisors/vmm_test.go
@@ -21,10 +21,8 @@ import (
 	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
 )
 
-// TestUsesControlSocket verifies every monitor reports whether it exposes a
-// control socket. The monitors that expose one (Qemu, Firecracker, Cloud
-// Hypervisor) must return true; the rest must return false. Because it is an
-// interface method, a new monitor cannot compile without declaring it.
+// TestUsesControlSocket verifies each monitor reports whether it exposes a
+// control socket (Qemu, Firecracker, Cloud Hypervisor true; the rest false).
 func TestUsesControlSocket(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/unikontainers/types/types.go
+++ b/pkg/unikontainers/types/types.go
@@ -41,6 +41,10 @@ type VMM interface {
 	Path() string
 	UsesKVM() bool
 	SupportsSharedfs(string) bool
+	// UsesControlSocket reports whether the monitor exposes a control socket
+	// (configured through socket_path) that urunc must make reachable before
+	// the monitor launches.
+	UsesControlSocket() bool
 	Ok() error
 }
 

--- a/pkg/unikontainers/types/types.go
+++ b/pkg/unikontainers/types/types.go
@@ -41,8 +41,6 @@ type VMM interface {
 	Path() string
 	UsesKVM() bool
 	SupportsSharedfs(string) bool
-	// SupportsControlSocket reports whether the monitor exposes a control socket
-	// (set through socket_path).
 	SupportsControlSocket() bool
 	Ok() error
 }

--- a/pkg/unikontainers/types/types.go
+++ b/pkg/unikontainers/types/types.go
@@ -43,6 +43,14 @@ type VMM interface {
 	SupportsSharedfs(string) bool
 	SupportsControlSocket() bool
 	Ok() error
+	// SupportsGuestShutdown reports whether this monitor can inject a native
+	// guest-shutdown event over its control socket instead of being killed.
+	SupportsGuestShutdown() bool
+	// RequestGuestShutdown asks the monitor to inject its native guest-shutdown
+	// event over its control socket. socketPath is the already-resolved,
+	// host-reachable path (e.g. /proc/<pid>/root/...); the monitor dials it
+	// directly and must not re-resolve or re-prefix it.
+	RequestGuestShutdown(socketPath string) error
 }
 
 type NetDevParams struct {

--- a/pkg/unikontainers/types/types.go
+++ b/pkg/unikontainers/types/types.go
@@ -47,9 +47,8 @@ type VMM interface {
 	// guest-shutdown event over its control socket instead of being killed.
 	SupportsGuestShutdown() bool
 	// RequestGuestShutdown asks the monitor to inject its native guest-shutdown
-	// event over its control socket. socketPath is the already-resolved,
-	// host-reachable path (e.g. /proc/<pid>/root/...); the monitor dials it
-	// directly and must not re-resolve or re-prefix it.
+	// event. socketPath is already resolved and host-reachable, so the monitor
+	// dials it directly and must not re-resolve or re-prefix it.
 	RequestGuestShutdown(socketPath string) error
 }
 

--- a/pkg/unikontainers/types/types.go
+++ b/pkg/unikontainers/types/types.go
@@ -42,8 +42,7 @@ type VMM interface {
 	UsesKVM() bool
 	SupportsSharedfs(string) bool
 	// UsesControlSocket reports whether the monitor exposes a control socket
-	// (configured through socket_path) that urunc must make reachable before
-	// the monitor launches.
+	// (set through socket_path).
 	UsesControlSocket() bool
 	Ok() error
 }

--- a/pkg/unikontainers/types/types.go
+++ b/pkg/unikontainers/types/types.go
@@ -41,9 +41,9 @@ type VMM interface {
 	Path() string
 	UsesKVM() bool
 	SupportsSharedfs(string) bool
-	// UsesControlSocket reports whether the monitor exposes a control socket
+	// SupportsControlSocket reports whether the monitor exposes a control socket
 	// (set through socket_path).
-	UsesControlSocket() bool
+	SupportsControlSocket() bool
 	Ok() error
 }
 

--- a/pkg/unikontainers/types/types.go
+++ b/pkg/unikontainers/types/types.go
@@ -115,6 +115,7 @@ type ExecArgs struct {
 	VAccelType    string   // Specifies the vAccel acceleration type(e.g. vsock). When empty, vAccel is disabled
 	VSockDevPath  string   // The directory inside the monitor rootfs with the vAccel unix sockets
 	VSockDevID    int      // The guest-cid
+	SocketPath    string   // The path of the monitor's control socket (empty means the monitor's default)
 	Net           NetDevParams
 	Sharedfs      SharedfsParams
 }
@@ -142,7 +143,8 @@ type ExtraBinConfig struct {
 type MonitorConfig struct {
 	DefaultMemoryMB uint   `toml:"default_memory_mb"`
 	DefaultVCPUs    uint   `toml:"default_vcpus"`
-	BinaryPath      string `toml:"path,omitempty"`      // Optional path to the hypervisor binary
-	DataPath        string `toml:"data_path,omitempty"` // Optional path to the hypervisor data files (e.g. qemu bios stuff)
-	Vhost           bool   `toml:"vhost,omitempty"`     // Optional: enable vhost for network performance optimization
+	BinaryPath      string `toml:"path,omitempty"`        // Optional path to the hypervisor binary
+	DataPath        string `toml:"data_path,omitempty"`   // Optional path to the hypervisor data files (e.g. qemu bios stuff)
+	Vhost           bool   `toml:"vhost,omitempty"`       // Optional: enable vhost for network performance optimization
+	SocketPath      string `toml:"socket_path,omitempty"` // Optional path for the monitor's control socket (falls back to a per-container default)
 }

--- a/pkg/unikontainers/types/types.go
+++ b/pkg/unikontainers/types/types.go
@@ -115,7 +115,7 @@ type ExecArgs struct {
 	VAccelType    string   // Specifies the vAccel acceleration type(e.g. vsock). When empty, vAccel is disabled
 	VSockDevPath  string   // The directory inside the monitor rootfs with the vAccel unix sockets
 	VSockDevID    int      // The guest-cid
-	SocketPath    string   // The path of the monitor's control socket (empty means the monitor's default)
+	SocketPath    string   // The path of the monitor's control socket (empty means no control socket)
 	Net           NetDevParams
 	Sharedfs      SharedfsParams
 }
@@ -146,5 +146,5 @@ type MonitorConfig struct {
 	BinaryPath      string `toml:"path,omitempty"`        // Optional path to the hypervisor binary
 	DataPath        string `toml:"data_path,omitempty"`   // Optional path to the hypervisor data files (e.g. qemu bios stuff)
 	Vhost           bool   `toml:"vhost,omitempty"`       // Optional: enable vhost for network performance optimization
-	SocketPath      string `toml:"socket_path,omitempty"` // Optional path for the monitor's control socket (falls back to a per-container default)
+	SocketPath      string `toml:"socket_path,omitempty"` // Optional path for the monitor's control socket (unset means no control socket)
 }

--- a/pkg/unikontainers/types/types.go
+++ b/pkg/unikontainers/types/types.go
@@ -142,10 +142,11 @@ type ExtraBinConfig struct {
 // MonitorConfig struct is used to hold hypervisor specific configuration
 // that is parsed from the urunc config file or state.json annotations
 type MonitorConfig struct {
-	DefaultMemoryMB uint   `toml:"default_memory_mb"`
-	DefaultVCPUs    uint   `toml:"default_vcpus"`
-	BinaryPath      string `toml:"path,omitempty"`        // Optional path to the hypervisor binary
-	DataPath        string `toml:"data_path,omitempty"`   // Optional path to the hypervisor data files (e.g. qemu bios stuff)
-	Vhost           bool   `toml:"vhost,omitempty"`       // Optional: enable vhost for network performance optimization
-	SocketPath      string `toml:"socket_path,omitempty"` // Optional path for the monitor's control socket (unset means no control socket)
+	DefaultMemoryMB  uint   `toml:"default_memory_mb"`
+	DefaultVCPUs     uint   `toml:"default_vcpus"`
+	BinaryPath       string `toml:"path,omitempty"`              // Optional path to the hypervisor binary
+	DataPath         string `toml:"data_path,omitempty"`         // Optional path to the hypervisor data files (e.g. qemu bios stuff)
+	Vhost            bool   `toml:"vhost,omitempty"`             // Optional: enable vhost for network performance optimization
+	SocketPath       string `toml:"socket_path,omitempty"`       // Optional path for the monitor's control socket (unset means no control socket)
+	GracefulShutdown bool   `toml:"graceful_shutdown,omitempty"` // When true, urunc asks the monitor to shut the guest down gracefully on SIGTERM instead of killing it.
 }

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -736,7 +736,7 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 	// Create the socket directory after setupUser, so the monitor's user owns
 	// it and a non-root monitor can bind there. The monitor creates the socket;
 	// kill and Delete remove it.
-	if vmm.UsesControlSocket() && vmmArgs.SocketPath != "" {
+	if vmm.SupportsControlSocket() && vmmArgs.SocketPath != "" {
 		sockDir := filepath.Dir(vmmArgs.SocketPath)
 		if err = os.MkdirAll(sockDir, 0o700); err != nil {
 			return fmt.Errorf("failed to create control socket directory %q: %w", sockDir, err)
@@ -903,7 +903,7 @@ func (u *Unikontainer) monitorRootfs() string {
 // lethal signal) and Delete both use it.
 func (u *Unikontainer) removeControlSocket(vmm types.VMM, vmmType string) error {
 	socketPath := u.UruncCfg.Monitors[vmmType].SocketPath
-	if socketPath == "" || !vmm.UsesControlSocket() {
+	if socketPath == "" || !vmm.SupportsControlSocket() {
 		return nil
 	}
 	sockRealPath := filepath.Join(u.monitorRootfs(), socketPath)

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -890,7 +890,7 @@ func (u *Unikontainer) monitorRootfs() string {
 		rootfsDir = filepath.Join(bundleDir, rootfsDir)
 	}
 	monRootfs := filepath.Join(bundleDir, monitorRootfsDirName)
-	if _, err := os.Stat(monRootfs); !os.IsNotExist(err) {
+	if _, err := os.Stat(monRootfs); err == nil {
 		return monRootfs
 	}
 	return rootfsDir

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -510,6 +510,7 @@ func (u *Unikontainer) buildMonitorSpec(rootfsParams types.RootfsParams, monRes 
 		defaultVCPUs = 1
 	}
 	defaultMemSizeMB := u.UruncCfg.Monitors[vmmType].DefaultMemoryMB
+	socketPath := u.UruncCfg.Monitors[vmmType].SocketPath
 
 	vmmArgs := types.ExecArgs{
 		ContainerID:   u.State.ID,
@@ -518,6 +519,7 @@ func (u *Unikontainer) buildMonitorSpec(rootfsParams types.RootfsParams, monRes 
 		Seccomp:       true, // Enable Seccomp by default
 		MemSizeB:      monitorMemoryBytes(defaultMemSizeMB, u.Spec.Linux.Resources),
 		VCPUs:         uint(defaultVCPUs),
+		SocketPath:    socketPath,
 		Environment:   os.Environ(),
 	}
 
@@ -722,6 +724,19 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 	vmmArgs.Command, err = buildUnikernelCommand(unikernel, unikernelParams)
 	if err != nil {
 		return err
+	}
+
+	// Ensure the monitor's control socket directory exists inside the monitor
+	// rootfs, so the monitor can bind its socket there. changeRoot has already
+	// made this process' root the monitor rootfs, so the socket path is
+	// created relative to it. The default (/tmp) already exists; a custom
+	// socket_path may point at a directory that does not, and MkdirAll fails
+	// if that location is invalid (e.g. a file already exists there).
+	if hypervisors.UsesControlSocket(hypervisors.VmmType(ms.MonitorType)) {
+		sockDir := filepath.Dir(hypervisors.ResolveSocketPath(vmmArgs))
+		if err = os.MkdirAll(sockDir, 0o755); err != nil {
+			return fmt.Errorf("failed to create control socket directory %q: %w", sockDir, err)
+		}
 	}
 
 	// uid/gid

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -943,11 +943,8 @@ func (u *Unikontainer) Signal(signal unix.Signal) error {
 
 	socketPath := u.UruncCfg.Monitors[vmmType].SocketPath
 
-	// On SIGTERM, when graceful shutdown is enabled and the monitor exposes a
-	// control socket, ask the monitor to inject its native guest-shutdown event
-	// instead of killing it. The socket lives inside the monitor's rootfs, so
-	// it is reached through /proc/<pid>/root. Any failure falls back to
-	// forwarding the signal exactly as before.
+	// The socket lives inside the monitor's rootfs, so it is reached through
+	// /proc/<pid>/root.
 	requested := false
 	if signal == unix.SIGTERM &&
 		u.UruncCfg.Monitors[vmmType].GracefulShutdown &&
@@ -963,9 +960,6 @@ func (u *Unikontainer) Signal(signal unix.Signal) error {
 			requested = true
 		}
 	} else if signal == unix.SIGTERM && u.UruncCfg.Monitors[vmmType].GracefulShutdown {
-		// SIGTERM with graceful shutdown enabled, yet graceful is false: the
-		// only remaining reason is that this monitor does not support it. Log it
-		// so the fall-through is observable, without changing control flow.
 		uniklog.Debug("graceful shutdown enabled but not supported by this monitor, forwarding signal")
 	}
 

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -924,13 +924,35 @@ func (u *Unikontainer) Signal(signal unix.Signal) error {
 		return err
 	}
 
-	if err = vmm.Signal(u.State.Pid, signal); err != nil {
-		return err
+	socketPath := u.UruncCfg.Monitors[vmmType].SocketPath
+
+	// On SIGTERM, when graceful shutdown is enabled and the monitor exposes a
+	// control socket, ask the monitor to inject its native guest-shutdown event
+	// instead of killing it. The socket lives inside the monitor's rootfs, so
+	// it is reached through /proc/<pid>/root. Any failure falls back to
+	// forwarding the signal exactly as before.
+	requested := false
+	if signal == unix.SIGTERM &&
+		u.UruncCfg.Monitors[vmmType].GracefulShutdown &&
+		socketPath != "" &&
+		vmm.SupportsGuestShutdown() {
+		hostPath := fmt.Sprintf("/proc/%d/root%s", u.State.Pid, socketPath)
+		if shutErr := vmm.RequestGuestShutdown(hostPath); shutErr != nil {
+			uniklog.WithError(shutErr).Warn("graceful shutdown failed, forwarding signal")
+		} else {
+			uniklog.Debug("graceful shutdown requested via control socket")
+			requested = true
+		}
+	}
+
+	if !requested {
+		if err = vmm.Signal(u.State.Pid, signal); err != nil {
+			return err
+		}
 	}
 
 	// A stop calls kill with SIGTERM and never runs Delete, so the socket is
 	// removed here too. Best-effort: a failure must not fail the signal.
-	socketPath := u.UruncCfg.Monitors[vmmType].SocketPath
 	if (signal == unix.SIGKILL || signal == unix.SIGTERM) && socketPath != "" && vmm.SupportsControlSocket() {
 		if rmErr := u.removeControlSocket(socketPath); rmErr != nil {
 			uniklog.Warnf("failed to remove control socket: %v", rmErr)

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -917,6 +917,23 @@ func (u *Unikontainer) removeControlSocket(socketPath string) error {
 }
 
 // Signal sends a specified signal to container's init.
+func shutdownFailureReason(err error) string {
+	switch {
+	case errors.Is(err, hypervisors.ErrShutdownConnect):
+		return "could not reach the control socket"
+	case errors.Is(err, hypervisors.ErrShutdownGreeting):
+		return "the monitor did not greet us; it is busy or stuck"
+	case errors.Is(err, hypervisors.ErrShutdownHandshake):
+		return "the monitor did not finish the handshake; it is busy or stuck"
+	case errors.Is(err, hypervisors.ErrShutdownCommand):
+		return "the monitor did not answer the command; it is busy or stuck"
+	case errors.Is(err, hypervisors.ErrShutdownRefused):
+		return "the monitor refused the request"
+	default:
+		return "unknown failure"
+	}
+}
+
 func (u *Unikontainer) Signal(signal unix.Signal) error {
 	vmmType := u.State.Annotations[annotHypervisor]
 	vmm, err := hypervisors.NewVMM(hypervisors.VmmType(vmmType), u.UruncCfg.Monitors)
@@ -938,7 +955,9 @@ func (u *Unikontainer) Signal(signal unix.Signal) error {
 		vmm.SupportsGuestShutdown() {
 		hostPath := fmt.Sprintf("/proc/%d/root%s", u.State.Pid, socketPath)
 		if shutErr := vmm.RequestGuestShutdown(hostPath); shutErr != nil {
-			uniklog.WithError(shutErr).Warn("graceful shutdown failed, forwarding signal")
+			uniklog.WithError(shutErr).
+				WithField("reason", shutdownFailureReason(shutErr)).
+				Warn("graceful shutdown failed, forwarding signal")
 		} else {
 			uniklog.Debug("graceful shutdown requested via control socket")
 			requested = true

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -734,8 +734,7 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 	}
 
 	// Create the socket directory after setupUser, so the monitor's user owns
-	// it and a non-root monitor can bind there. The monitor creates the socket;
-	// kill and Delete remove it.
+	// it and a non-root monitor can bind there. The monitor creates the socket.
 	if vmm.SupportsControlSocket() && vmmArgs.SocketPath != "" {
 		sockDir := filepath.Dir(vmmArgs.SocketPath)
 		if err = os.MkdirAll(sockDir, 0o700); err != nil {
@@ -882,7 +881,6 @@ func setupUser(user specs.User) error {
 	return nil
 }
 
-// Signal sends a specified signal to container's init.
 // monitorRootfs returns the host path of the monitor's rootfs: the separate
 // one under the bundle if it exists, else the container's own rootfs.
 func (u *Unikontainer) monitorRootfs() string {
@@ -899,8 +897,7 @@ func (u *Unikontainer) monitorRootfs() string {
 }
 
 // removeControlSocket deletes the monitor's control socket, if one is set. It
-// skips a missing path and never deletes a non-socket file. Signal (on a
-// lethal signal) and Delete both use it.
+// skips a missing path and never deletes a non-socket file.
 func (u *Unikontainer) removeControlSocket(vmm types.VMM, vmmType string) error {
 	socketPath := u.UruncCfg.Monitors[vmmType].SocketPath
 	if socketPath == "" || !vmm.SupportsControlSocket() {
@@ -926,6 +923,7 @@ func isLethalSignal(signal unix.Signal) bool {
 	return signal == unix.SIGKILL || signal == unix.SIGTERM
 }
 
+// Signal sends a specified signal to container's init.
 func (u *Unikontainer) Signal(signal unix.Signal) error {
 	vmmType := u.State.Annotations[annotHypervisor]
 	vmm, err := hypervisors.NewVMM(hypervisors.VmmType(vmmType), u.UruncCfg.Monitors)

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -896,14 +896,13 @@ func (u *Unikontainer) monitorRootfs() string {
 	return rootfsDir
 }
 
-// removeControlSocket deletes the monitor's control socket, if one is set. It
-// skips a missing path and never deletes a non-socket file.
-func (u *Unikontainer) removeControlSocket(vmm types.VMM, vmmType string) error {
-	socketPath := u.UruncCfg.Monitors[vmmType].SocketPath
-	if socketPath == "" || !vmm.SupportsControlSocket() {
-		return nil
+// removeControlSocket deletes the monitor's control socket. It skips a missing
+// path and never deletes a non-socket file.
+func (u *Unikontainer) removeControlSocket(socketPath string) error {
+	sockRealPath, err := securejoin.SecureJoin(u.monitorRootfs(), socketPath)
+	if err != nil {
+		return err
 	}
-	sockRealPath := filepath.Join(u.monitorRootfs(), socketPath)
 	info, err := os.Lstat(sockRealPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -934,8 +933,9 @@ func (u *Unikontainer) Signal(signal unix.Signal) error {
 	// A stop calls kill with SIGTERM and never runs Delete, so remove the
 	// socket here too, while the monitor is still alive. Best-effort: never
 	// block the kill.
-	if isLethalSignal(signal) {
-		if rmErr := u.removeControlSocket(vmm, vmmType); rmErr != nil {
+	socketPath := u.UruncCfg.Monitors[vmmType].SocketPath
+	if isLethalSignal(signal) && socketPath != "" && vmm.SupportsControlSocket() {
+		if rmErr := u.removeControlSocket(socketPath); rmErr != nil {
 			uniklog.Warnf("failed to remove control socket: %v", rmErr)
 		}
 	}
@@ -1023,8 +1023,11 @@ func (u *Unikontainer) Delete() error {
 	// Remove the control socket so a restart on the same socket_path is clean.
 	// This runs before the rootfs tree is removed, so the socket is still
 	// reachable at its real path inside the monitor rootfs.
-	if err = u.removeControlSocket(vmm, vmmType); err != nil {
-		return fmt.Errorf("failed to remove control socket: %w", err)
+	socketPath := u.UruncCfg.Monitors[vmmType].SocketPath
+	if socketPath != "" && vmm.SupportsControlSocket() {
+		if err = u.removeControlSocket(socketPath); err != nil {
+			return fmt.Errorf("failed to remove control socket: %w", err)
+		}
 	}
 
 	err = os.RemoveAll(monRootfs)

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -733,7 +733,7 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 	// socket_path may point at a directory that does not, and MkdirAll fails
 	// if that location is invalid (e.g. a file already exists there).
 	if hypervisors.UsesControlSocket(hypervisors.VmmType(ms.MonitorType)) {
-		sockDir := filepath.Dir(hypervisors.ResolveSocketPath(vmmArgs))
+		sockDir := filepath.Dir(vmmArgs.SocketPath)
 		if err = os.MkdirAll(sockDir, 0o755); err != nil {
 			return fmt.Errorf("failed to create control socket directory %q: %w", sockDir, err)
 		}

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -726,24 +726,27 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 		return err
 	}
 
-	// Ensure the monitor's control socket directory exists inside the monitor
-	// rootfs, so the monitor can bind its socket there. changeRoot has already
-	// made this process' root the monitor rootfs, so the socket path is
-	// created relative to it. The default (/tmp) already exists; a custom
-	// socket_path may point at a directory that does not, and MkdirAll fails
-	// if that location is invalid (e.g. a file already exists there).
-	if hypervisors.UsesControlSocket(hypervisors.VmmType(ms.MonitorType)) {
-		sockDir := filepath.Dir(vmmArgs.SocketPath)
-		if err = os.MkdirAll(sockDir, 0o755); err != nil {
-			return fmt.Errorf("failed to create control socket directory %q: %w", sockDir, err)
-		}
-	}
-
 	// uid/gid
 	// Setup uid, gid and additional groups for the monitor process
 	err = setupUser(u.Spec.Process.User)
 	if err != nil {
 		return err
+	}
+
+	// Set up the monitor's control socket, only when one is configured.
+	// This runs after setupUser so the directory and any stale socket are
+	// handled as the monitor's user, and the monitor (which may be non-root)
+	// can bind its socket there.
+	if hypervisors.UsesControlSocket(hypervisors.VmmType(ms.MonitorType)) && vmmArgs.SocketPath != "" {
+		sockDir := filepath.Dir(vmmArgs.SocketPath)
+		if err = os.MkdirAll(sockDir, 0o755); err != nil {
+			return fmt.Errorf("failed to create control socket directory %q: %w", sockDir, err)
+		}
+		// Remove a stale socket left by a previous instance (e.g. a restart
+		// reusing the same socket_path) so the monitor can bind it again.
+		if err = os.Remove(vmmArgs.SocketPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("failed to remove stale control socket %q: %w", vmmArgs.SocketPath, err)
+		}
 	}
 
 	// execute hooks

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -943,6 +943,11 @@ func (u *Unikontainer) Signal(signal unix.Signal) error {
 			uniklog.Debug("graceful shutdown requested via control socket")
 			requested = true
 		}
+	} else if signal == unix.SIGTERM && u.UruncCfg.Monitors[vmmType].GracefulShutdown {
+		// SIGTERM with graceful shutdown enabled, yet graceful is false: the
+		// only remaining reason is that this monitor does not support it. Log it
+		// so the fall-through is observable, without changing control flow.
+		uniklog.Debug("graceful shutdown enabled but not supported by this monitor, forwarding signal")
 	}
 
 	if !requested {

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -916,12 +916,6 @@ func (u *Unikontainer) removeControlSocket(socketPath string) error {
 	return os.Remove(sockRealPath)
 }
 
-// isLethalSignal reports whether the signal stops the container. Only SIGKILL
-// and SIGTERM count (the signals a stop sends).
-func isLethalSignal(signal unix.Signal) bool {
-	return signal == unix.SIGKILL || signal == unix.SIGTERM
-}
-
 // Signal sends a specified signal to container's init.
 func (u *Unikontainer) Signal(signal unix.Signal) error {
 	vmmType := u.State.Annotations[annotHypervisor]
@@ -930,17 +924,20 @@ func (u *Unikontainer) Signal(signal unix.Signal) error {
 		return err
 	}
 
-	// A stop calls kill with SIGTERM and never runs Delete, so remove the
-	// socket here too, while the monitor is still alive. Best-effort: never
-	// block the kill.
+	if err = vmm.Signal(u.State.Pid, signal); err != nil {
+		return err
+	}
+
+	// A stop calls kill with SIGTERM and never runs Delete, so the socket is
+	// removed here too. Best-effort: a failure must not fail the signal.
 	socketPath := u.UruncCfg.Monitors[vmmType].SocketPath
-	if isLethalSignal(signal) && socketPath != "" && vmm.SupportsControlSocket() {
+	if (signal == unix.SIGKILL || signal == unix.SIGTERM) && socketPath != "" && vmm.SupportsControlSocket() {
 		if rmErr := u.removeControlSocket(socketPath); rmErr != nil {
 			uniklog.Warnf("failed to remove control socket: %v", rmErr)
 		}
 	}
 
-	return vmm.Signal(u.State.Pid, signal)
+	return nil
 }
 
 // Kill stops the VMM process, first by asking the VMM struct to stop

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -884,11 +884,63 @@ func setupUser(user specs.User) error {
 }
 
 // Signal sends a specified signal to container's init.
+// monitorRootfs returns the host path of the monitor's rootfs: the separate
+// one under the bundle if it exists, else the container's own rootfs.
+func (u *Unikontainer) monitorRootfs() string {
+	bundleDir := filepath.Clean(u.State.Bundle)
+	rootfsDir := filepath.Clean(u.Spec.Root.Path)
+	if !filepath.IsAbs(rootfsDir) {
+		rootfsDir = filepath.Join(bundleDir, rootfsDir)
+	}
+	monRootfs := filepath.Join(bundleDir, monitorRootfsDirName)
+	if _, err := os.Stat(monRootfs); !os.IsNotExist(err) {
+		return monRootfs
+	}
+	return rootfsDir
+}
+
+// removeControlSocket deletes the monitor's control socket, if one is set. It
+// skips a missing path and never deletes a non-socket file. Signal (on a
+// lethal signal) and Delete both use it.
+func (u *Unikontainer) removeControlSocket(vmm types.VMM, vmmType string) error {
+	socketPath := u.UruncCfg.Monitors[vmmType].SocketPath
+	if socketPath == "" || !vmm.UsesControlSocket() {
+		return nil
+	}
+	sockRealPath := filepath.Join(u.monitorRootfs(), socketPath)
+	info, err := os.Lstat(sockRealPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if info.Mode()&os.ModeSocket == 0 {
+		return nil
+	}
+	return os.Remove(sockRealPath)
+}
+
+// isLethalSignal reports whether the signal stops the container. Only SIGKILL
+// and SIGTERM count (the signals a stop sends).
+func isLethalSignal(signal unix.Signal) bool {
+	return signal == unix.SIGKILL || signal == unix.SIGTERM
+}
+
 func (u *Unikontainer) Signal(signal unix.Signal) error {
 	vmmType := u.State.Annotations[annotHypervisor]
 	vmm, err := hypervisors.NewVMM(hypervisors.VmmType(vmmType), u.UruncCfg.Monitors)
 	if err != nil {
 		return err
+	}
+
+	// A stop calls kill with SIGTERM and never runs Delete, so remove the
+	// socket here too, while the monitor is still alive. Best-effort: never
+	// block the kill.
+	if isLethalSignal(signal) {
+		if rmErr := u.removeControlSocket(vmm, vmmType); rmErr != nil {
+			uniklog.Warnf("failed to remove control socket: %v", rmErr)
+		}
 	}
 
 	return vmm.Signal(u.State.Pid, signal)
@@ -960,29 +1012,22 @@ func (u *Unikontainer) Delete() error {
 		uniklog.Errorf("failed to restore block volume mounts: %v", err)
 	}
 
-	// The monitor rootfs lives under the bundle. Its mounts went away with the
-	// monitor's mount namespace, so only the directory tree itself is left.
-	monRootfs := filepath.Join(filepath.Clean(u.State.Bundle), monitorRootfsDirName)
-
-	// Remove the monitor's control socket, if one was configured, so that a
-	// restart reusing the same socket_path does not find a stale socket. The
-	// socket lives inside the monitor rootfs (the monitor binds it there after
-	// the pivot in Exec); at delete time that rootfs is reachable at its real
-	// path. Only an actual socket is removed, so a misconfigured socket_path
-	// pointing at a regular file is never deleted. This runs before the rootfs
-	// tree is removed, so the socket is still reachable.
+	// get a monitor instance of the running monitor
 	vmmType := u.State.Annotations[annotHypervisor]
 	vmm, err := hypervisors.NewVMM(hypervisors.VmmType(vmmType), u.UruncCfg.Monitors)
 	if err != nil {
 		return err
 	}
-	if socketPath := u.UruncCfg.Monitors[vmmType].SocketPath; socketPath != "" && vmm.UsesControlSocket() {
-		sockRealPath := filepath.Join(monRootfs, socketPath)
-		if info, statErr := os.Lstat(sockRealPath); statErr == nil && info.Mode()&os.ModeSocket != 0 {
-			if err = os.Remove(sockRealPath); err != nil {
-				return fmt.Errorf("failed to remove control socket %q: %w", sockRealPath, err)
-			}
-		}
+
+	// The monitor rootfs lives under the bundle. Its mounts went away with the
+	// monitor's mount namespace, so only the directory tree itself is left.
+	monRootfs := filepath.Join(filepath.Clean(u.State.Bundle), monitorRootfsDirName)
+
+	// Remove the control socket so a restart on the same socket_path is clean.
+	// This runs before the rootfs tree is removed, so the socket is still
+	// reachable at its real path inside the monitor rootfs.
+	if err = u.removeControlSocket(vmm, vmmType); err != nil {
+		return fmt.Errorf("failed to remove control socket: %w", err)
 	}
 
 	err = os.RemoveAll(monRootfs)

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -733,19 +733,14 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 		return err
 	}
 
-	// Set up the monitor's control socket, only when one is configured.
-	// This runs after setupUser so the directory and any stale socket are
-	// handled as the monitor's user, and the monitor (which may be non-root)
-	// can bind its socket there.
-	if hypervisors.UsesControlSocket(hypervisors.VmmType(ms.MonitorType)) && vmmArgs.SocketPath != "" {
+	// Create the directory for the monitor's control socket, only when one is
+	// configured. This runs after setupUser so the directory is owned by the
+	// monitor's user and a non-root monitor can bind its socket there. The
+	// socket file itself is created by the monitor and removed in Delete.
+	if vmm.UsesControlSocket() && vmmArgs.SocketPath != "" {
 		sockDir := filepath.Dir(vmmArgs.SocketPath)
-		if err = os.MkdirAll(sockDir, 0o755); err != nil {
+		if err = os.MkdirAll(sockDir, 0o700); err != nil {
 			return fmt.Errorf("failed to create control socket directory %q: %w", sockDir, err)
-		}
-		// Remove a stale socket left by a previous instance (e.g. a restart
-		// reusing the same socket_path) so the monitor can bind it again.
-		if err = os.Remove(vmmArgs.SocketPath); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("failed to remove stale control socket %q: %w", vmmArgs.SocketPath, err)
 		}
 	}
 
@@ -968,6 +963,28 @@ func (u *Unikontainer) Delete() error {
 	// The monitor rootfs lives under the bundle. Its mounts went away with the
 	// monitor's mount namespace, so only the directory tree itself is left.
 	monRootfs := filepath.Join(filepath.Clean(u.State.Bundle), monitorRootfsDirName)
+
+	// Remove the monitor's control socket, if one was configured, so that a
+	// restart reusing the same socket_path does not find a stale socket. The
+	// socket lives inside the monitor rootfs (the monitor binds it there after
+	// the pivot in Exec); at delete time that rootfs is reachable at its real
+	// path. Only an actual socket is removed, so a misconfigured socket_path
+	// pointing at a regular file is never deleted. This runs before the rootfs
+	// tree is removed, so the socket is still reachable.
+	vmmType := u.State.Annotations[annotHypervisor]
+	vmm, err := hypervisors.NewVMM(hypervisors.VmmType(vmmType), u.UruncCfg.Monitors)
+	if err != nil {
+		return err
+	}
+	if socketPath := u.UruncCfg.Monitors[vmmType].SocketPath; socketPath != "" && vmm.UsesControlSocket() {
+		sockRealPath := filepath.Join(monRootfs, socketPath)
+		if info, statErr := os.Lstat(sockRealPath); statErr == nil && info.Mode()&os.ModeSocket != 0 {
+			if err = os.Remove(sockRealPath); err != nil {
+				return fmt.Errorf("failed to remove control socket %q: %w", sockRealPath, err)
+			}
+		}
+	}
+
 	err = os.RemoveAll(monRootfs)
 	if err != nil {
 		return fmt.Errorf("failed to remove the monitor rootfs %s: %w", monRootfs, err)

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -733,10 +733,9 @@ func (u *Unikontainer) Exec(metrics m.Writer) error {
 		return err
 	}
 
-	// Create the directory for the monitor's control socket, only when one is
-	// configured. This runs after setupUser so the directory is owned by the
-	// monitor's user and a non-root monitor can bind its socket there. The
-	// socket file itself is created by the monitor and removed in Delete.
+	// Create the socket directory after setupUser, so the monitor's user owns
+	// it and a non-root monitor can bind there. The monitor creates the socket;
+	// kill and Delete remove it.
 	if vmm.UsesControlSocket() && vmmArgs.SocketPath != "" {
 		sockDir := filepath.Dir(vmmArgs.SocketPath)
 		if err = os.MkdirAll(sockDir, 0o700); err != nil {

--- a/pkg/unikontainers/urunc_config.go
+++ b/pkg/unikontainers/urunc_config.go
@@ -220,6 +220,7 @@ func (p *UruncConfig) Map() map[string]string {
 		cfgMap[prefix+"binary_path"] = hvCfg.BinaryPath
 		cfgMap[prefix+"data_path"] = hvCfg.DataPath
 		cfgMap[prefix+"vhost"] = strconv.FormatBool(hvCfg.Vhost)
+		cfgMap[prefix+"graceful_shutdown"] = strconv.FormatBool(hvCfg.GracefulShutdown)
 		cfgMap[prefix+"socket_path"] = hvCfg.SocketPath
 	}
 	for eb, ebCfg := range p.ExtraBins {
@@ -276,6 +277,13 @@ func UruncConfigFromMap(cfgMap map[string]string) *UruncConfig {
 				uniklog.Warnf("Invalid vhost value '%s' for monitor '%s': %v. Using default (false).", val, hv, err)
 			} else {
 				hvCfg.Vhost = boolVal
+			}
+		case "graceful_shutdown":
+			boolVal, err := strconv.ParseBool(val)
+			if err != nil {
+				uniklog.Warnf("Invalid graceful_shutdown value '%s' for monitor '%s': %v. Using default (false).", val, hv, err)
+			} else {
+				hvCfg.GracefulShutdown = boolVal
 			}
 		}
 		cfg.Monitors[hv] = hvCfg

--- a/pkg/unikontainers/urunc_config.go
+++ b/pkg/unikontainers/urunc_config.go
@@ -220,6 +220,7 @@ func (p *UruncConfig) Map() map[string]string {
 		cfgMap[prefix+"binary_path"] = hvCfg.BinaryPath
 		cfgMap[prefix+"data_path"] = hvCfg.DataPath
 		cfgMap[prefix+"vhost"] = strconv.FormatBool(hvCfg.Vhost)
+		cfgMap[prefix+"socket_path"] = hvCfg.SocketPath
 	}
 	for eb, ebCfg := range p.ExtraBins {
 		prefix := "urunc_config.extra_binaries." + eb + "."
@@ -267,6 +268,8 @@ func UruncConfigFromMap(cfgMap map[string]string) *UruncConfig {
 			hvCfg.BinaryPath = val
 		case "data_path":
 			hvCfg.DataPath = val
+		case "socket_path":
+			hvCfg.SocketPath = val
 		case "vhost":
 			boolVal, err := strconv.ParseBool(val)
 			if err != nil {


### PR DESCRIPTION
## Description

Adds an opt-in graceful shutdown for the monitors that expose a control socket. When `graceful_shutdown` is enabled for a monitor and the container receives SIGTERM, urunc asks the monitor to inject its native guest-shutdown event over the control socket instead of killing the monitor:

- QEMU: `system_powerdown` over QMP
- Cloud Hypervisor: `vm.power-button` over the REST API
- Firecracker: `SendCtrlAltDel`, x86 only (`SupportsGuestShutdown()` gates it by
  architecture; on aarch64 Firecracker has no such mechanism)

urunc sends the request and returns without forwarding the signal. It does not wait and adds no timeout of its own: the container manager already escalates to SIGKILL after its grace period. Any error, an unsupported monitor, the feature
being disabled, or any signal other than SIGTERM falls back to the exact kill behavior of today.

This is the runtime ("host") side of graceful shutdown. Teaching the guest init (`urunit`) to react to these events is a separate follow-up; until then the events are delivered but the guest does not yet act on them.

The feature is off by default. It is wired as a per-monitor `graceful_shutdown` boolean, following the existing `vhost` option pattern.

> Note: this branch is stacked on #850 (the configurable control socket). The
> first commit here (`feat(monitors): expose a configurable control socket for
> each monitor`) belongs to #850. Once #850 merges, this branch will be rebased
> onto main so the diff shows only the graceful-shutdown commits.

### Related issues

- Part of #336

### How was this tested?

- Unit tests for the new interface methods, driving fake QMP and REST servers over Unix sockets, including a test that asserts the QMP client drains the asynchronous `POWERDOWN` event and reads the command's `return` (a single-read client fails it).
- A manual end-to-end matrix on aarch64 (QEMU and Cloud Hypervisor), covering: the happy path (the event is sent and urunc returns; the monitor keeps running until the container manager's SIGKILL, since `urunit` does not react yet); opt-out parity (feature off behaves exactly as before); a dead monitor and a
SIGSTOP'd monitor both falling back safely without hanging; a custom `socket_path`; a non-SIGTERM signal never attempting graceful shutdown; and Firecracker on aarch64 taking the unsupported path.
- The clearest signal is stop latency: with the feature on, `nerdctl stop` takes the full ~10s grace period (urunc sends the event and returns, the monitor survives until SIGKILL); with it off, the same stop is ~0.06s.

### LLM usage

claude code (opus 4.8) for the understanding of codebase, approach decisions and coding


### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [ ] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
