### PR TITLE
fix(firecracker): intercept SIGTERM and SIGINT to terminate VMM process immediately

### DIFF
--- a/.github/contributors.yaml
+++ b/.github/contributors.yaml
@@ -116,4 +116,8 @@ users:
   Anand-240:
     name: Anand Prakash Srivastava
     email: anandprakashsrivastava68@gmail.com
+  Nachiket-Roy:
+    name: Nachiket Roy
+    email: nachiket.roy.2@gmail.com
+
 

--- a/pkg/unikontainers/hypervisors/firecracker.go
+++ b/pkg/unikontainers/hypervisors/firecracker.go
@@ -77,6 +77,9 @@ type FirecrackerConfig struct {
 }
 
 func (fc *Firecracker) Signal(pid int, signal unix.Signal) error {
+	if signal == unix.SIGTERM || signal == unix.SIGINT {
+		return fc.Stop(pid)
+	}
 	return unix.Kill(pid, signal)
 }
 

--- a/pkg/unikontainers/hypervisors/firecracker.go
+++ b/pkg/unikontainers/hypervisors/firecracker.go
@@ -76,6 +76,9 @@ type FirecrackerConfig struct {
 }
 
 func (fc *Firecracker) Signal(pid int, signal unix.Signal) error {
+	if signal == unix.SIGTERM || signal == unix.SIGINT {
+		return fc.Stop(pid)
+	}
 	return unix.Kill(pid, signal)
 }
 


### PR DESCRIPTION
## Description
Intercepts `SIGTERM` and `SIGINT` signals in the Firecracker hypervisor driver's `Signal` method and redirects them to `Stop(pid)`. Since Firecracker ignores SIGTERM, this avoids waiting for the 30-second containerd grace period and makes container stops/deletions instant.
<!-- Describe the changes and why they are needed. -->

### Related issues

<!-- Include links to relevant issues or other pages. -->

- Fixes #789 

### How was this tested?
- **Unit Tests**: Ran `go test ./pkg/...` (all passed).
- **Manual Verification**: Deployed the modified binaries to a Kind/KVM Kubernetes control plane node, scaled `nginx-urunc` deployment to 5 replicas, and deleted them. All pods stopped and were destroyed instantly (in `0.816s` total) instead of blocking for 30 seconds.
<!-- Describe how you tested your changes. Include relevant details such as test configuration, commands run, or manual testing steps. -->

### LLM usage
N/A
<!-- Mention the LLm(s) that assisted with the creation of this PR. (N/A) if none was used-->

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [x] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [ ] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
