### PR TITLE
fix(network): remove leaked tap device on networkSetup failure

### DIFF
--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -222,6 +222,28 @@ func addRedirectFilter(source netlink.Link, target netlink.Link) error {
 	})
 }
 
+// removeTap undoes a partial or complete tap setup performed by networkSetup,
+// so a failed attempt does not leave the netns in a state that blocks the
+// next one. redirectQdiscAdded must only be true when the ingress qdisc on
+// redirectLink was actually added by this attempt: unlike the tap device,
+// redirectLink is the container's real interface and can carry TC config
+// that predates this call, so it must never be removed unless we know we
+// are the ones who put it there. Deleting the tap device removes any qdisc,
+// filter or address that was attached to the tap itself. Failures here are
+// logged rather than returned: they must not shadow the original error that
+// triggered the rollback, and a partial rollback still leaves less behind
+// than no rollback at all.
+func removeTap(tapDevice netlink.Link, redirectLink netlink.Link, redirectQdiscAdded bool) {
+	if redirectQdiscAdded {
+		if err := deleteIngressQdisc(redirectLink); err != nil {
+			netlog.Warnf("rollback: failed to remove ingress qdisc from %s: %v", redirectLink.Attrs().Name, err)
+		}
+	}
+	if err := netlink.LinkDel(tapDevice); err != nil {
+		netlog.Warnf("rollback: failed to remove tap device %s: %v", tapDevice.Attrs().Name, err)
+	}
+}
+
 func networkSetup(tapName string, ipAddress string, redirectLink netlink.Link, addTCRules bool, uid uint32, gid uint32) (netlink.Link, error) {
 	netlog.Debugf("starting for tapName=%s ipAddress=%s redirectLink=%s addTCRules=%v",
 		tapName, ipAddress, redirectLink.Attrs().Name, addTCRules)
@@ -233,14 +255,22 @@ func networkSetup(tapName string, ipAddress string, redirectLink netlink.Link, a
 	}
 	netlog.Debugf("created tap device %s (index=%d)", newTapDevice.Attrs().Name, newTapDevice.Attrs().Index)
 
+	// From this point on, any failure must delete the tap device we just
+	// created (and any TC rule we managed to add on redirectLink) before
+	// returning, otherwise it is leaked in the netns and blocks the next
+	// setup attempt (see: tap count check in getTapIndex).
+	redirectQdiscAdded := false
+
 	// Bring TAP up before qdisc
 	if err = netlink.LinkSetUp(newTapDevice); err != nil {
+		removeTap(newTapDevice, redirectLink, redirectQdiscAdded)
 		return nil, fmt.Errorf("LinkSetUp(%s) failed: %w", newTapDevice.Attrs().Name, err)
 	}
 	netlog.Debugf("TAP %s is UP", newTapDevice.Attrs().Name)
 
 	// Bring redirectLink (eth0) up before using it in filters
 	if err = netlink.LinkSetUp(redirectLink); err != nil {
+		removeTap(newTapDevice, redirectLink, redirectQdiscAdded)
 		return nil, fmt.Errorf("LinkSetUp(%s) failed: %w", redirectLink.Attrs().Name, err)
 	}
 	netlog.Debugf("redirectLink %s is UP", redirectLink.Attrs().Name)
@@ -250,18 +280,23 @@ func networkSetup(tapName string, ipAddress string, redirectLink netlink.Link, a
 		netlog.Debug("adding tc ingress qdisc + redirect filters")
 
 		if err = addIngressQdisc(newTapDevice); err != nil {
+			removeTap(newTapDevice, redirectLink, redirectQdiscAdded)
 			return nil, fmt.Errorf("addIngressQdisc(tap=%s) failed: %w",
 				newTapDevice.Attrs().Name, err)
 		}
 		if err = addIngressQdisc(redirectLink); err != nil {
+			removeTap(newTapDevice, redirectLink, redirectQdiscAdded)
 			return nil, fmt.Errorf("addIngressQdisc(redirect=%s) failed: %w",
 				redirectLink.Attrs().Name, err)
 		}
+		redirectQdiscAdded = true
 		if err = addRedirectFilter(newTapDevice, redirectLink); err != nil {
+			removeTap(newTapDevice, redirectLink, redirectQdiscAdded)
 			return nil, fmt.Errorf("addRedirectFilter(%s->%s) failed: %w",
 				newTapDevice.Attrs().Name, redirectLink.Attrs().Name, err)
 		}
 		if err = addRedirectFilter(redirectLink, newTapDevice); err != nil {
+			removeTap(newTapDevice, redirectLink, redirectQdiscAdded)
 			return nil, fmt.Errorf("addRedirectFilter(%s->%s) failed: %w",
 				redirectLink.Attrs().Name, newTapDevice.Attrs().Name, err)
 		}
@@ -272,9 +307,11 @@ func networkSetup(tapName string, ipAddress string, redirectLink netlink.Link, a
 		netlog.Debugf("assigning IP %s to %s", ipAddress, newTapDevice.Attrs().Name)
 		ipn, err := netlink.ParseAddr(ipAddress)
 		if err != nil {
+			removeTap(newTapDevice, redirectLink, redirectQdiscAdded)
 			return nil, fmt.Errorf("ParseAddr(%s) failed: %w", ipAddress, err)
 		}
 		if err = netlink.AddrReplace(newTapDevice, ipn); err != nil {
+			removeTap(newTapDevice, redirectLink, redirectQdiscAdded)
 			return nil, fmt.Errorf("AddrReplace(%s, %s) failed: %w",
 				newTapDevice.Attrs().Name, ipAddress, err)
 		}

--- a/pkg/network/network_dynamic.go
+++ b/pkg/network/network_dynamic.go
@@ -59,6 +59,11 @@ func (n DynamicNetwork) NetworkSetup(uid uint32, gid uint32) (*UnikernelNetworkI
 	netlog.Debugf("fetching info for %s", redirectLink.Attrs().Name)
 	ifInfo, err := getInterfaceInfo(redirectLink.Attrs().Name)
 	if err != nil {
+		// networkSetup succeeded above, so the tap and its TC rules exist
+		// in the netns and must be torn down before returning the error,
+		// otherwise the leftover tap blocks every future setup attempt in
+		// this netns (see getTapIndex).
+		removeTap(newTapDevice, redirectLink, true)
 		return nil, fmt.Errorf("getInterfaceInfo(%s) failed: %w", redirectLink.Attrs().Name, err)
 	}
 

--- a/pkg/network/network_static.go
+++ b/pkg/network/network_static.go
@@ -102,6 +102,11 @@ func (n StaticNetwork) NetworkSetup(uid uint32, gid uint32) (*UnikernelNetworkIn
 	}
 	err = setNATRule(redirectLink.Attrs().Name, StaticIPAddr)
 	if err != nil {
+		// networkSetup succeeded above, so the tap it created is now
+		// leftover in the netns unless we remove it here. addTCRules is
+		// false for the static manager, so no TC rule on redirectLink to
+		// undo, just the tap device itself.
+		removeTap(newTapDevice, redirectLink, addTCRules)
 		return nil, err
 	}
 	return &UnikernelNetworkInfo{


### PR DESCRIPTION
## Description

networkSetup() creates the tap device before doing anything that can
fail (bringing the tap/redirect link up, adding TC ingress qdiscs and
redirect filters, assigning an IP), but none of its error paths ever
deleted the tap it had already created. The same gap existed one level
up: DynamicNetwork.NetworkSetup() and StaticNetwork.NetworkSetup() each
call networkSetup() successfully and then do more work
(getInterfaceInfo, setNATRule) that can still fail, leaving the tap
behind again.

The only existing cleanup, CleanupAllUruncTaps(), is only reachable
from Kill(), which only runs on `urunc delete --force`. A plain
create/start failure therefore leaves a stray tapN_urunc device (and
any TC rules on it) in the netns. Since getTapIndex() treats the mere
presence of a tap as a sign that a unikernel is already running there,
every subsequent setup attempt in that same netns then fails
permanently until something explicitly force-deletes the container.

### Related issues

- Fixes #874

### Changes

- Added `removeTap()` in `pkg/network/network.go`, which deletes the
  tap device and, only if it was actually added during this attempt,
  the ingress qdisc it placed on the container's real interface. The
  container's own interface is never touched unless we know we put the
  TC state there ourselves, since it can carry configuration that
  predates this call.
- `networkSetup()` now calls `removeTap()` on every error path after
  the tap device is created.
- `DynamicNetwork.NetworkSetup()` now calls `removeTap()` if
  `getInterfaceInfo()` fails after a successful `networkSetup()`.
- `StaticNetwork.NetworkSetup()` now calls `removeTap()` if
  `setNATRule()` fails after a successful `networkSetup()`.

### How was this tested?

- `gofmt -l` clean on all changed files
- `GOOS=linux GOARCH=amd64 go build ./pkg/network/...` and `go vet`
  pass (this package uses Linux only netlink/unix constants, so it
  cannot be built or tested directly on non-Linux)
- Existing `pkg/network` unit tests don't exercise `networkSetup()`
  itself since it needs real netlink/root/netns. Verified instead by
  reviewing every error path and reasoning about which TC state
  predates vs. is created by each call. Happy to add a netns based
  integration test if there's an existing harness/CI job for that.

### LLM usage

Claude (Anthropic, model: claude-sonnet-5) was used to trace the
leaked tap device path and help put this fix together. Reviewed and
tested by me before opening this PR, per the project's LLM policy.

### Checklist

- [x] I have read the contribution guide.
- [ ] The linter passes locally (`make lint`). Not run locally, no
  golangci-lint setup available in this environment; deferring to CI.
- [ ] The e2e tests of at least one tool pass locally. Not run
  locally; deferring to CI.
- [x] If LLMs were used: I have read the llm policy.
