### PR TITLE
fix(unikernels): reject single quotes in Linux init args

### DIFF
--- a/pkg/unikontainers/unikernels/linux.go
+++ b/pkg/unikontainers/unikernels/linux.go
@@ -250,10 +250,16 @@ func (l *Linux) parseCmdLine(cmdLine []string) error {
 		return fmt.Errorf("no init was specified")
 	}
 
-	// Wrap multi-word arguments in quotes for urunit
+	// Wrap multi-word arguments in quotes for urunit. Arguments that already
+	// contain a single quote cannot be safely wrapped this way, since naively
+	// concatenating quotes produces an unbalanced quote sequence that
+	// corrupts urunit's token-boundary parsing of the boot cmdline.
 	normalizedArgs := make([]string, len(cmdLine))
 	for i, arg := range cmdLine {
 		arg = strings.TrimSpace(arg)
+		if strings.Contains(arg, "'") {
+			return fmt.Errorf("argument %q contains an unsupported single quote character", arg)
+		}
 		if strings.Contains(arg, " ") {
 			normalizedArgs[i] = "'" + arg + "'"
 		} else {

--- a/pkg/unikontainers/unikernels/linux_test.go
+++ b/pkg/unikontainers/unikernels/linux_test.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unikernels
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLinuxParseCmdLine(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		cmdLine     []string
+		expectedApp string
+		expectedCmd string
+		expectErr   bool
+	}{
+		{
+			name:      "empty cmdline",
+			cmdLine:   []string{},
+			expectErr: true,
+		},
+		{
+			name:        "single word app only",
+			cmdLine:     []string{"/urunit"},
+			expectedApp: "/urunit",
+			expectedCmd: "",
+		},
+		{
+			name:        "multi-word argument gets quoted",
+			cmdLine:     []string{"/urunit", "sh -c ls"},
+			expectedApp: "/urunit",
+			expectedCmd: "'sh -c ls'",
+		},
+		{
+			name:      "argument with space and single quote is rejected",
+			cmdLine:   []string{"/urunit", "sh -c \"echo it's broken\""},
+			expectErr: true,
+		},
+		{
+			name:      "argument with single quote and no space is rejected",
+			cmdLine:   []string{"/urunit", "it's"},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			l := &Linux{}
+			err := l.parseCmdLine(tc.cmdLine)
+
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedApp, l.App)
+			assert.Equal(t, tc.expectedCmd, l.Command)
+		})
+	}
+}


### PR DESCRIPTION
## Description

parseCmdLine() in pkg/unikontainers/unikernels/linux.go wraps
multi-word arguments in single quotes so urunit can recover argument
boundaries from the guest's boot cmdline. It does this with plain
string concatenation and does not escape quote characters already
present in the argument.

If an argument contains both a space and a single quote, for example
sh -c "echo it's broken", the wrap produces an unbalanced quote
sequence such as 'sh' 'echo it's broken', which corrupts the token
boundaries that urunit parses out of /proc/cmdline. The guest init
process can then receive the wrong arguments with no error surfaced to
the user.

Since urunit's own cmdline parser lives outside this repo and its
escaping rules are not known here, this change rejects arguments
containing a single quote with a clear error instead of guessing an
escaping scheme that might not match what urunit actually supports.

### Related issues

- Fixes #897

### Changes

- pkg/unikontainers/unikernels/linux.go: parseCmdLine now returns an
  error when an argument contains a single quote, before attempting to
  wrap it.
- pkg/unikontainers/unikernels/linux_test.go: new table driven tests
  covering the empty cmdline case, single word app, multi word
  argument quoting, and the new rejection behavior for quoted
  arguments.

### How was this tested?

- `go test ./pkg/unikontainers/unikernels/... -run TestLinux -v` passes (5/5 subtests)
- `go build ./pkg/unikontainers/unikernels/...` succeeds

### LLM usage

Claude (Anthropic, model: claude-sonnet-5) was used to trace the
quoting bug and help put this fix together. Reviewed and tested by me
before opening this PR, per the project's LLM policy.

### Checklist

- [x] I have read the contribution guide.
- [ ] The linter passes locally (`make lint`). Not run locally, no
  golangci-lint setup available in this environment; deferring to CI.
- [ ] The e2e tests of at least one tool pass locally. Not run
  locally; deferring to CI.
- [x] If LLMs were used: I have read the llm policy.
