### PR TITLE
ci: modified codeql-action steps to have the same version

### DIFF
--- a/.github/contributors.yaml
+++ b/.github/contributors.yaml
@@ -125,3 +125,6 @@ users:
   danbugs:
     name: Dan Chiarlone
     email: danilochiarlone@gmail.com
+  OdysseasKalaitsidis:
+    name: Odysseas Kalaitsidis
+    email: odysseaskalaitsides@gmail.com

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action/*"

--- a/.github/linters/urunc-dict.txt
+++ b/.github/linters/urunc-dict.txt
@@ -427,3 +427,5 @@ cyphar
 blkdev
 hyperlight
 Hyperlight
+Odysseas
+Kalaitsidis

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,7 +50,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v3.29.5
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -60,7 +60,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3.29.5
+        uses: github/codeql-action/autobuild@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -73,6 +73,6 @@ jobs:
       #   ./location_of_script_within_repo/buildscript.sh
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3.29.5
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## Description

After investigating the CodeQL workflow, I found that commit 9d371bc changed only the init step to v4.37.4 but left the autobuild and analyze steps on the older version of v4.36.2. Since all steps come from the same codeql-action and need to stay on the same version, the version drift caused the init to write a config file newer than the analyze could read and the run failed with 
"Loaded a configuration file for version '4.37.4', but running
version '4.36.2'"

The PR modifies the codeql.yml to point to the same new version v4.37.4

### Related issues

Fixes #915 

### How was this tested?

I pulled the actual failed run 31158525443 to confirm the error and checked via GitHub API the version tag and the commit SHA it points to. It confirmed that the init step new SHA is the v4.37.4 so the comment # v3.29.5 next to it in the file was wrong and that the old SHA is still used by the autobuild and analze which was the  v4.36.2

### LLM usage

Claude Sonnet 5  assisted me in investigating the failing run.  I reviewed the diagnosis and the fix myself before submitting this PR.

### Checklist

- [X] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [ ] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [X] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
