### PR TITLE
test(cmd/urunc): add unit tests for parseSignal and validate positive signal range

### DIFF
--- a/cmd/urunc/kill.go
+++ b/cmd/urunc/kill.go
@@ -83,6 +83,9 @@ signal to the init process of the "ubuntu01" container:
 func parseSignal(rawSignal string) (unix.Signal, error) {
 	s, err := strconv.Atoi(rawSignal)
 	if err == nil {
+		if s <= 0 {
+			return -1, fmt.Errorf("invalid signal number %d: must be positive", s)
+		}
 		return unix.Signal(s), nil
 	}
 	sig := strings.ToUpper(rawSignal)

--- a/cmd/urunc/kill_test.go
+++ b/cmd/urunc/kill_test.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestParseSignal(t *testing.T) {
+	tests := []struct {
+		name       string
+		rawSignal  string
+		expected   unix.Signal
+		shouldErr  bool
+	}{
+		{
+			name:      "Valid named signal SIGKILL",
+			rawSignal: "SIGKILL",
+			expected:  unix.SIGKILL,
+			shouldErr: false,
+		},
+		{
+			name:      "Valid short named signal KILL",
+			rawSignal: "KILL",
+			expected:  unix.SIGKILL,
+			shouldErr: false,
+		},
+		{
+			name:      "Valid lowercase named signal kill",
+			rawSignal: "kill",
+			expected:  unix.SIGKILL,
+			shouldErr: false,
+		},
+		{
+			name:      "Valid named signal SIGTERM",
+			rawSignal: "SIGTERM",
+			expected:  unix.SIGTERM,
+			shouldErr: false,
+		},
+		{
+			name:      "Valid numeric signal 9",
+			rawSignal: "9",
+			expected:  unix.SIGKILL,
+			shouldErr: false,
+		},
+		{
+			name:      "Valid numeric signal 15",
+			rawSignal: "15",
+			expected:  unix.SIGTERM,
+			shouldErr: false,
+		},
+		{
+			name:      "Invalid numeric signal 0",
+			rawSignal: "0",
+			expected:  -1,
+			shouldErr: true,
+		},
+		{
+			name:      "Invalid negative numeric signal -1",
+			rawSignal: "-1",
+			expected:  -1,
+			shouldErr: true,
+		},
+		{
+			name:      "Invalid unknown signal string",
+			rawSignal: "SIGUNKNOWN",
+			expected:  -1,
+			shouldErr: true,
+		},
+		{
+			name:      "Invalid non-signal text",
+			rawSignal: "FOOBAR",
+			expected:  -1,
+			shouldErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseSignal(tt.rawSignal)
+			if (err != nil) != tt.shouldErr {
+				t.Fatalf("parseSignal(%q) error = %v, expected error = %v", tt.rawSignal, err, tt.shouldErr)
+			}
+			if !tt.shouldErr && got != tt.expected {
+				t.Errorf("parseSignal(%q) = %v, expected %v", tt.rawSignal, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Summary
This PR improves signal parsing validation in `cmd/urunc/kill.go` and introduces unit test coverage for `cmd/urunc`.

### Description of Changes
1. **Validation Fix**: Updated `parseSignal()` in `cmd/urunc/kill.go` to reject non-positive numeric signal inputs (`<= 0`) with a descriptive error message (`invalid signal number %d: must be positive`).
2. **Unit Tests**: Added `cmd/urunc/kill_test.go` with table-driven tests covering:
   - Valid named signals (`SIGKILL`, `KILL`, `kill`, `SIGTERM`)
   - Valid numeric signals (`9`, `15`)
   - Invalid numeric signals (`0`, `-1`)
   - Invalid named signal strings (`SIGUNKNOWN`, `FOOBAR`)

### Related Issue
Closes #917 

### Verification & Testing
- Added unit test suite in `cmd/urunc/kill_test.go` verifying signal parsing edge cases.
