### PR TITLE
test(fuzz): add native Go fuzzing target for urunc config parsing

### DIFF
--- a/pkg/unikontainers/urunc_config.go
+++ b/pkg/unikontainers/urunc_config.go
@@ -108,6 +108,27 @@ func defaultUruncConfig() *UruncConfig {
 	}
 }
 
+// ParseUruncConfigBytes parses the urunc configuration from a byte slice (TOML format).
+// If decoding fails, it returns the default configuration alongside the error.
+func ParseUruncConfigBytes(data []byte) (*UruncConfig, error) {
+	cfg := defaultUruncConfig()
+	_, err := toml.Decode(string(data), cfg)
+	if err != nil {
+		return defaultUruncConfig(), err
+	}
+	for name, mon := range cfg.Monitors {
+		if mon.DefaultMemoryMB == 0 {
+			mon.DefaultMemoryMB = defaultMonitorMemoryMB
+		}
+		if mon.DefaultVCPUs == 0 {
+			mon.DefaultVCPUs = defaultMonitorVCPUs
+		}
+		cfg.Monitors[name] = mon
+	}
+
+	return cfg, nil
+}
+
 // LoadUruncConfig loads the urunc configuration from the specified path.
 // If the file does not exist or is malformed, it returns the default configuration.
 func LoadUruncConfig(path string) (*UruncConfig, error) {

--- a/pkg/unikontainers/urunc_config_test.go
+++ b/pkg/unikontainers/urunc_config_test.go
@@ -618,3 +618,54 @@ path = "/usr/bin/mon"
 		assert.Equal(t, defaultMonitorsConfig(), config.Monitors)
 	})
 }
+
+func TestParseUruncConfigBytes(t *testing.T) {
+	t.Run("valid toml bytes", func(t *testing.T) {
+		t.Parallel()
+		data := []byte(`
+[log]
+level = "debug"
+syslog = true
+
+[monitors.qemu]
+default_memory_mb = 512
+default_vcpus = 2
+`)
+		config, err := ParseUruncConfigBytes(data)
+		assert.NoError(t, err)
+		assert.Equal(t, "debug", config.Log.Level)
+		assert.True(t, config.Log.Syslog)
+		assert.Equal(t, uint(512), config.Monitors["qemu"].DefaultMemoryMB)
+	})
+
+	t.Run("invalid toml bytes returns default config and error", func(t *testing.T) {
+		t.Parallel()
+		data := []byte(`invalid toml [syntax`)
+		config, err := ParseUruncConfigBytes(data)
+		assert.Error(t, err)
+		assert.NotNil(t, config)
+		assert.Equal(t, defaultMonitorsConfig(), config.Monitors)
+	})
+}
+
+func FuzzLoadUruncConfig(f *testing.F) {
+	// Seed corpus with valid TOML configurations and edge cases
+	f.Add([]byte(""))
+	f.Add([]byte("[log]\nlevel = \"debug\"\nsyslog = true\n"))
+	f.Add([]byte("[monitors.qemu]\ndefault_memory_mb = 512\ndefault_vcpus = 2\npath = \"/usr/bin/qemu\"\n"))
+	f.Add([]byte("[extra_binaries.virtiofsd]\npath = \"/usr/libexec/virtiofsd\"\noptions = \"--cache always\"\n"))
+	f.Add([]byte("[monitors.custom]\ndefault_memory_mb = 0\ndefault_vcpus = 0\n"))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		cfg, err := ParseUruncConfigBytes(data)
+		if err != nil {
+			if cfg == nil {
+				t.Fatalf("ParseUruncConfigBytes returned nil config on error")
+			}
+			return
+		}
+		// Invariant: parsed config must produce valid map representation without panics
+		_ = cfg.Map()
+	})
+}
+


### PR DESCRIPTION
### Summary
This PR introduces native Go fuzzing (`go test -fuzz`) for system configuration decoding and validation in [`pkg/unikontainers/urunc_config.go`](https://github.com/urunc-dev/urunc/blob/main/pkg/unikontainers/urunc_config.go).

This directly addresses part of **#852** (*"Add fuzzing and robustness testing"*) by establishing automated fuzz targets for core parsing functions.

### Description of Changes
1. **In-Memory Helper**: Added `ParseUruncConfigBytes(data []byte) (*UruncConfig, error)` in `pkg/unikontainers/urunc_config.go` to allow direct TOML parsing from byte slices without requiring disk file reads.
2. **Unit Tests**: Added `TestParseUruncConfigBytes` in `pkg/unikontainers/urunc_config_test.go` to verify valid TOML bytes parsing and graceful error handling on malformed bytes.
3. **Go Native Fuzz Target**: Implemented `FuzzLoadUruncConfig(f *testing.F)` in `pkg/unikontainers/urunc_config_test.go` with seed corpuses for valid TOML configurations, fuzzing TOML decoding and ensuring `cfg.Map()` invariants hold without panics.

### Related Issue
Closes #919 

### Verification & Testing
- Ran cross-compilation targeting Linux (`GOOS=linux`) for `pkg/unikontainers`.
- Executed `go test -v -fuzz=FuzzLoadUruncConfig -fuzztime=30s ./pkg/unikontainers` with 0 panics.
