### PR TITLE
fix(unikontainers): propagate actual errors instead of masking behind ErrNotUnikernel

### DIFF
--- a/.github/workflows/vm_test.yml
+++ b/.github/workflows/vm_test.yml
@@ -197,6 +197,37 @@ jobs:
         sudo mkdir -p /opt/cni/bin
         sudo tar Cxzvf /opt/cni/bin "cni-plugins-linux-$(dpkg --print-architecture)-v${SAFE_CNI}.tgz"
         rm -f "cni-plugins-linux-$(dpkg --print-architecture)-v${SAFE_CNI}.tgz"
+        sudo mkdir -p /etc/cni/net.d
+        sudo tee /etc/cni/net.d/10-containerd-net.conflist > /dev/null <<'EOF'
+{
+  "cniVersion": "1.0.0",
+  "name": "containerd-net",
+  "plugins": [
+    {
+      "type": "bridge",
+      "bridge": "cni0",
+      "isGateway": true,
+      "ipMasq": true,
+      "promiscMode": true,
+      "ipam": {
+        "type": "host-local",
+        "ranges": [
+          [{
+            "subnet": "10.88.0.0/16"
+          }]
+        ],
+        "routes": [
+          { "dst": "0.0.0.0/0" }
+        ]
+      }
+    },
+    {
+      "type": "portmap",
+      "capabilities": {"portMappings": true}
+    }
+  ]
+}
+EOF
 
     - name: Install nerdctl
       env:

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -87,7 +87,10 @@ func New(bundlePath string, containerID string, rootDir string, cfg *UruncConfig
 
 	config, err := GetUnikernelConfig(bundlePath, spec)
 	if err != nil {
-		return nil, ErrNotUnikernel
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, ErrNotUnikernel
+		}
+		return nil, err
 	}
 
 	confMap := config.Map()


### PR DESCRIPTION
## Description
**Summary of Changes:**
Updated `GetUnikernelConfig` error handling in `pkg/unikontainers/unikontainers.go`. 

Instead of masking all configuration/decoding errors into `ErrNotUnikernel`, it now properly propagates the actual parsing/base64 decoding errors to the user. It only falls back to runc (via `ErrNotUnikernel`) specifically when `os.ErrNotExist` occurs (i.e., no configuration exists).

This prevents silent failures and makes debugging malformed configurations much easier.

### Related issues
* Fixes #876

### How was this tested?
Verified that malformed configurations correctly throw detailed parsing/decoding errors instead of failing silently and falling back to runc.

### LLM usage
I used Google Gemini to help draft this pull request description.

### Checklist
* [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
* [x] The linter passes locally (`make lint`).
* [x] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
* [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
