### PR TITLE
feat(devcontainer): add Dev Container configuration for reproducible …

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,51 @@
+# Copyright (c) 2023-2026, Nubificus LTD
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV GO_VERSION=1.26.4
+
+RUN apt-get update && apt-get install -y \
+    curl \
+    wget \
+    git \
+    make \
+    gcc \
+    qemu-kvm \
+    qemu-utils \
+    bridge-utils \
+    iptables \
+    net-tools \
+    iproute2 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN wget -q https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz \
+    && tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz \
+    && rm go${GO_VERSION}.linux-amd64.tar.gz
+ENV PATH=$PATH:/usr/local/go/bin
+
+RUN apt-get update && apt-get install -y \
+    containerd \
+    containernetworking-plugins \
+    && rm -rf /var/lib/apt/lists/*
+
+# NOTE: Firecracker, Solo5, and Cloud-Hypervisor are not pre-installed.
+# These are required only for e2e tests that spawn VMs. Users can install
+# them manually, or use the local VS Code + Docker path with --device=/dev/kvm
+# for full e2e testing. The dev container supports make unittest and make lint
+# out of the box.
+
+WORKDIR /workspace
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+    "name": "urunc Development Environment",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "features": {
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+    },
+    "runArgs": [
+        "--device=/dev/kvm",
+        "--privileged"
+    ],
+    "postCreateCommand": "bash .devcontainer/post-create.sh",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "golang.Go",
+                "ms-vscode.makefile-tools"
+            ]
+        }
+    },
+    "remoteUser": "root"
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Copyright (c) 2023-2026, Nubificus LTD
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+echo "Setting up urunc development environment..."
+
+git config --global --add safe.directory /workspace
+
+go env -w GOPROXY=https://proxy.golang.org,direct
+
+go mod download
+
+echo "Checking installed tools..."
+qemu-system-x86_64 --version || true
+firecracker --version || true
+cloud-hypervisor --version || true
+go version
+
+echo "Setup complete. Run 'make unittest' to verify."


### PR DESCRIPTION
## Description

Right now, getting started with `urunc` requires manually installing Docker, QEMU, containerd, CNI plugins, and Go across different package managers and manual steps. This is documented in the installation guide, but it's a significant barrier for new contributors and LFX mentees who just want to run `make unittest` or `make lint`.
 A Dev Container automates that same setup into a reproducible, version controlled environment.

## What's added

- `.devcontainer/devcontainer.json` : configures the container with Docker in Docker, KVM passthrough (`--device=/dev/kvm`), and VS Code extensions for Go development
- `.devcontainer/Dockerfile` : Ubuntu 22.04 base image with Go, QEMU, containerd, CNI plugins, and build tools pre installed
- `.devcontainer/post-create.sh` : runs after container creation to set up git safe directory and download Go modules

## How to use it

Local VS Code + Docker (recommended for full e2e testing):
1. Install the Dev Containers extension in VS Code
2. Open the project and run "Dev Containers: Reopen in Container"
3. The container gets KVM access, so VM based e2e tests can work if VMMs are installed manually

GitHub Codespaces:
- Supports `make unittest`, `make lint`, and build workflows
- e2e tests that spawn VMs (Firecracker/QEMU) are not available because Codespaces standard instances don't support nested virtualization/KVM

## Verification

Tested locally with `docker build` and `docker run`:
```
docker build -f .devcontainer/Dockerfile -t urunc-dev-test .
docker run --rm -it -v $(pwd):/workspace -w /workspace urunc-dev-test bash
```

## Test results

`make unittest` was run inside the dev container. The test suite passes overall with 3 pre existing failures that are unrelated to this PR:


| Failing test | Reason |
|---|---|
| `TestCopyFile/copy_file_target_dir_creation_failed` | Test expects `mkdir` to fail with permission denied, but root can create any directory |
| `TestCopyFile/copy_file_target_file_creation_failed` | Test expects read-only filesystem error, but root ignores read-only flags |
| `TestMoveFile/move_file_target_file_creation_failed` | Same read only filesystem assumption fails under root |

These failures occur whenever tests run as `root` (which the dev container does) and are not introduced by this PR. They are existing issues in `pkg/unikontainers/utils_test.go`.

# Inside container:
```
bash .devcontainer/post-create.sh
make unittest   
make lint       
```
## Related
Fixes #953 