### PR TITLE
ci: fix CNI initialization failure in crictl e2e tests

### DIFF
--- a/.github/workflows/vm_test.yml
+++ b/.github/workflows/vm_test.yml
@@ -197,6 +197,37 @@ jobs:
         sudo mkdir -p /opt/cni/bin
         sudo tar Cxzvf /opt/cni/bin "cni-plugins-linux-$(dpkg --print-architecture)-v${SAFE_CNI}.tgz"
         rm -f "cni-plugins-linux-$(dpkg --print-architecture)-v${SAFE_CNI}.tgz"
+        sudo mkdir -p /etc/cni/net.d
+        sudo tee /etc/cni/net.d/10-containerd-net.conflist > /dev/null <<'EOF'
+{
+  "cniVersion": "1.0.0",
+  "name": "containerd-net",
+  "plugins": [
+    {
+      "type": "bridge",
+      "bridge": "cni0",
+      "isGateway": true,
+      "ipMasq": true,
+      "promiscMode": true,
+      "ipam": {
+        "type": "host-local",
+        "ranges": [
+          [{
+            "subnet": "10.88.0.0/16"
+          }]
+        ],
+        "routes": [
+          { "dst": "0.0.0.0/0" }
+        ]
+      }
+    },
+    {
+      "type": "portmap",
+      "capabilities": {"portMappings": true}
+    }
+  ]
+}
+EOF
 
     - name: Install nerdctl
       env:


### PR DESCRIPTION
## Description
This PR fixes the failing `crictl e2e` tests in the CI pipeline where pods fail to create with the error: `"cni plugin not initialized"`. 

The issue started occurring because newer GitHub Action runner images (Ubuntu 22.04+) removed pre-installed tools like `podman`, which was inadvertently supplying the required CNI conflist that `containerd` was relying on. 

To resolve this dependency on external environment factors, this PR updates the `vm_test.yml` workflow to explicitly write a default CNI bridge configuration file (`10-containerd-net.conflist`) into `/etc/cni/net.d/` immediately after the CNI plugins are installed. 

### Related issues
* Fixes #967

### How was this tested?
Verified by running the GitHub Actions CI pipeline (`vm_test.yml`) against this branch to ensure that containerd networking initializes correctly and the `crictl e2e` tests pass.

### LLM usage
I used Google Gemini to help investigate the root cause in the GitHub Actions runner images, formulate the CNI configuration fix in `vm_test.yml`, and draft this pull request.

### Checklist
* [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
* [x] The linter passes locally (`make lint`).
* [x] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
* [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
