### PR TITLE
ci: provide a CNI config for the e2e tests

### DIFF
--- a/.github/linters/urunc-dict.txt
+++ b/.github/linters/urunc-dict.txt
@@ -129,6 +129,7 @@ clis
 cmainas
 cmdline
 cntr
+conflist
 containerdshim
 containerd
 containerd's
@@ -192,6 +193,7 @@ inlinehilite
 inspectp
 iobase
 iosize
+ipam
 isues
 iversion
 jackpal
@@ -220,6 +222,7 @@ logpipe
 logrus
 lseek
 mand
+masq
 mewz
 mkdocs
 mkdocstrings
@@ -265,6 +268,7 @@ osusergo
 paravirtual
 pids
 pluginid
+portmap
 posixacl
 practises
 prctl

--- a/.github/workflows/vm_test.yml
+++ b/.github/workflows/vm_test.yml
@@ -198,6 +198,42 @@ jobs:
         sudo tar Cxzvf /opt/cni/bin "cni-plugins-linux-$(dpkg --print-architecture)-v${SAFE_CNI}.tgz"
         rm -f "cni-plugins-linux-$(dpkg --print-architecture)-v${SAFE_CNI}.tgz"
 
+    - name: Configure CNI network
+      run: |
+        sudo mkdir -p /etc/cni/net.d
+        sudo tee /etc/cni/net.d/10-containerd-net.conflist > /dev/null <<'EOT'
+        {
+          "cniVersion": "1.0.0",
+          "name": "containerd-net",
+          "plugins": [
+            {
+              "type": "bridge",
+              "bridge": "cni0",
+              "isGateway": true,
+              "ipMasq": true,
+              "hairpinMode": true,
+              "ipam": {
+                "type": "host-local",
+                "ranges": [
+                  [{ "subnet": "10.88.0.0/16" }]
+                ],
+                "routes": [
+                  { "dst": "0.0.0.0/0" }
+                ]
+              }
+            },
+            {
+              "type": "portmap",
+              "capabilities": { "portMappings": true }
+            },
+            {
+              "type": "firewall"
+            }
+          ]
+        }
+        EOT
+        sudo systemctl restart containerd
+
     - name: Install nerdctl
       env:
         NERDCTL_VERSION: ${{ inputs.nerdctl_version }}
@@ -310,6 +346,21 @@ jobs:
         go version
         go env GOROOT
         make prepare
+
+    - name: Wait for CRI network to be ready
+      run: |
+        for _ in $(seq 1 30); do
+          ready=$(sudo crictl info -o json | jq -r '.status.conditions[] | select(.type=="NetworkReady") | .status')
+          if [ "$ready" = "true" ]; then
+            echo "CRI network is ready"
+            exit 0
+          fi
+          sleep 2
+        done
+        echo "CRI network did not become ready in time"
+        ls -l /etc/cni/net.d /opt/cni/bin || true
+        sudo crictl info || true
+        exit 1
 
     - name: Run ${{ matrix.test }}
       id: test

--- a/.github/workflows/vm_test.yml
+++ b/.github/workflows/vm_test.yml
@@ -117,7 +117,7 @@ jobs:
     - name: Install base dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y git wget build-essential libseccomp-dev pkg-config bc make qemu-system
+        sudo apt-get install -y git wget build-essential libseccomp-dev pkg-config bc make qemu-system jq
         wget https://s3.nbfc.io/nbfc-assets/github/urunc/bin/virtiofsd
         sudo chmod +x virtiofsd
         sudo mv virtiofsd /usr/libexec/virtiofsd
@@ -350,7 +350,7 @@ jobs:
     - name: Wait for CRI network to be ready
       run: |
         for _ in $(seq 1 30); do
-          ready=$(sudo crictl info -o json | jq -r '.status.conditions[] | select(.type=="NetworkReady") | .status')
+          ready=$(sudo crictl info -o json 2>/dev/null | jq -r '.status.conditions[] | select(.type=="NetworkReady") | .status' || true)
           if [ "$ready" = "true" ]; then
             echo "CRI network is ready"
             exit 0


### PR DESCRIPTION
## Description

The workflow installs the CNI plugin binaries in `/opt/cni/bin`, but never writes a config in `/etc/cni/net.d`. containerd needs both, so with an empty conf dir the CRI plugin has no network to attach a pod to and every pod creation fails with `cni plugin not initialized`.

Until now that config came from the runner image, which used to ship podman's `87-podman-bridge.conflist`. Newer images no longer install it and the crictl tests started failing. Only crictl is affected, since nerdctl generates its own config and the ctr and docker jobs do not use CRI networking.

So the workflow now writes its own config a bridge on `10.88.0.0/16` with a gateway and a default route, plus portmap and firewall, which is the same shape as the one we were getting from the image. It also waits for the CRI network to report ready before the tests, so a similar break fails with a clear message instead of a list of failing tests, and it installs `jq`, which that check needs.

### Related issues

 Fixes #967

### How was this tested?

Locally on arm64 and amd64, in Ubuntu 22.04 machines with systemd and the versions we pin in `ci.yml`. With an empty conf dir I get the same `cni plugin not initialized` error as CI. With the config, the network reports ready, the pod gets `10.88.0.2` and pinging it from the host works, which is what `pingTest` does.

I also checked that CRI picks our file over the one nerdctl generates, and that the firewall plugin matters when the`FORWARD` policy is `DROP` as Docker sets it on the runners: pod egress works with it and is blocked without it.

Finally I built urunc and solo5-spt in the same machine and ran the Spt specs that do not need devmapper, 2 Passed and 0 Failed`. `Spt-mirage-net` is the one that pings the unikernel through CRI, so that is the failing path covered. The devmapper specs and the monitors that need KVM are left to CI.

### LLM usage

I used Claude (Opus 5) to help investigate the runner image change and draft the workflow steps. I reviewed everything and I am responsible for the result.

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [ ] The linter passes locally (`make lint`).
- [x] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`). 
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).