### PR TITLE
feat(config): allow overriding the config path via URUNC_CONFIG_FILE

### DIFF
--- a/cmd/urunc/create.go
+++ b/cmd/urunc/create.go
@@ -74,7 +74,7 @@ var createCommand = &cli.Command{
 			return err
 		}
 		if !cmd.Bool("reexec") {
-			uruncCfg, _ := unikontainers.LoadUruncConfig(unikontainers.UruncConfigPath) // ignore the error and use default config
+			uruncCfg, _ := unikontainers.LoadUruncConfig(unikontainers.ResolveUruncConfigPath()) // ignore the error and use default config
 			return createUnikontainer(cmd, uruncCfg)
 		}
 

--- a/cmd/urunc/main.go
+++ b/cmd/urunc/main.go
@@ -135,7 +135,7 @@ func main() {
 				return nil, err
 			}
 			// ignore error since ParseLogMetricsConfig will print a warning and return default values
-			cfg, _ := unikontainers.ParseLogMetricsConfig(unikontainers.UruncConfigPath)
+			cfg, _ := unikontainers.ParseLogMetricsConfig(unikontainers.ResolveUruncConfigPath())
 			err := configLogrus(cmd, cfg.Log)
 			if err != nil {
 				return nil, err

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,7 +2,16 @@
 
 ## Configuration File Location
 
-`urunc` looks for its configuration file at `/etc/urunc/config.toml`. If the file doesn't exist or contains invalid configuration, `urunc` will use sensible defaults and continue to operate normally.
+`urunc` looks for its configuration file at `/etc/urunc/config.toml` by default. The location can be overridden with the `URUNC_CONFIG_FILE` environment variable, for example `URUNC_CONFIG_FILE=/var/etc/urunc/config.toml`. If the file doesn't exist or contains invalid configuration, `urunc` will use sensible defaults and continue to operate normally.
+
+One way to set the variable is to replace the `containerd-shim-urunc-v2` binary that containerd invokes with a small wrapper script that sets it and execs the real shim. For example, move the real shim aside (e.g. to `containerd-shim-urunc-v2.real`) and save the following as `/usr/local/bin/containerd-shim-urunc-v2`:
+
+```bash
+#!/bin/bash
+URUNC_CONFIG_FILE=/some/path/config.toml exec /usr/local/bin/containerd-shim-urunc-v2.real "$@"
+```
+
+where `/some/path/config.toml` is the configuration file to use and `/usr/local/bin/containerd-shim-urunc-v2.real` is the actual shim binary.
 
 ## Configuration File Format
 

--- a/pkg/containerd-shim/guest_rootfs.go
+++ b/pkg/containerd-shim/guest_rootfs.go
@@ -59,7 +59,7 @@ func chooseGuestRootfs(r *taskAPI.CreateTaskRequest) error {
 	}
 
 	annotations := config.Map()
-	uruncCfg, err := unikontainers.LoadUruncConfig(unikontainers.UruncConfigPath)
+	uruncCfg, err := unikontainers.LoadUruncConfig(unikontainers.ResolveUruncConfigPath())
 	if err != nil && uruncCfg == nil {
 		return err
 	}

--- a/pkg/unikontainers/urunc_config.go
+++ b/pkg/unikontainers/urunc_config.go
@@ -15,6 +15,7 @@
 package unikontainers
 
 import (
+	"os"
 	"strconv"
 	"strings"
 
@@ -23,6 +24,20 @@ import (
 )
 
 const UruncConfigPath = "/etc/urunc/config.toml"
+
+// UruncConfigFileEnv is the environment variable that overrides the default
+// location of the urunc configuration file.
+const UruncConfigFileEnv = "URUNC_CONFIG_FILE"
+
+// ResolveUruncConfigPath returns the path to the urunc configuration file. It
+// uses the URUNC_CONFIG_FILE environment variable when it is set and falls back
+// to UruncConfigPath (/etc/urunc/config.toml) otherwise.
+func ResolveUruncConfigPath() string {
+	if path := os.Getenv(UruncConfigFileEnv); path != "" {
+		return path
+	}
+	return UruncConfigPath
+}
 
 type UruncLog struct {
 	Level  string `toml:"level"`

--- a/pkg/unikontainers/urunc_config_test.go
+++ b/pkg/unikontainers/urunc_config_test.go
@@ -618,3 +618,17 @@ path = "/usr/bin/mon"
 		assert.Equal(t, defaultMonitorsConfig(), config.Monitors)
 	})
 }
+
+// Note: these tests use t.Setenv and therefore must not call t.Parallel().
+func TestResolveUruncConfigPath(t *testing.T) {
+	t.Run("env var unset returns default path", func(t *testing.T) {
+		t.Setenv(UruncConfigFileEnv, "")
+		assert.Equal(t, UruncConfigPath, ResolveUruncConfigPath())
+	})
+
+	t.Run("env var set overrides the path", func(t *testing.T) {
+		customPath := "/var/etc/urunc/config.toml"
+		t.Setenv(UruncConfigFileEnv, customPath)
+		assert.Equal(t, customPath, ResolveUruncConfigPath())
+	})
+}


### PR DESCRIPTION
## Description

The config path was hardcoded to `/etc/urunc/config.toml`, which does not work on immutable or read-only hosts like Talos where `/etc` is not writable. This adds a `URUNC_CONFIG_PATH` env var to set the path, falling back to `/etc/urunc/config.toml` when it is unset. Per #987 this is the temporary env var approach, before config handling moves to the shim.

### Related issues

- Fixes #987

### How was this tested?

Added unit tests for the resolver (env set and unset) and ran golangci-lint locally with no issues.

### LLM usage

The design, the discussion on #979 and #987, and the review were mine. Claude Opus 4.8 helped write the implementation, tests and docs.

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
