### PR TITLE
fix(cloud-hypervisor): pass block devices in a single --disk flag

### DIFF
--- a/pkg/unikontainers/hypervisors/cloud_hypervisor.go
+++ b/pkg/unikontainers/hypervisors/cloud_hypervisor.go
@@ -108,6 +108,7 @@ func (ch *CloudHypervisor) BuildExecCmd(args types.ExecArgs, ukernel types.Unike
 
 	// Block device configuration
 	blockArgs := ukernel.MonitorBlockCli()
+	var disks []string
 	for _, blockArg := range blockArgs {
 		if blockArg.ExactArgs != "" {
 			exArgs = append(exArgs, strings.Split(strings.TrimSpace(blockArg.ExactArgs), " ")...)
@@ -116,8 +117,12 @@ func (ch *CloudHypervisor) BuildExecCmd(args types.ExecArgs, ukernel types.Unike
 			if blockArg.ID != "" {
 				diskArg += fmt.Sprintf(",id=%s", blockArg.ID)
 			}
-			exArgs = append(exArgs, "--disk", diskArg)
+			disks = append(disks, diskArg)
 		}
+	}
+	if len(disks) > 0 {
+		exArgs = append(exArgs, "--disk")
+		exArgs = append(exArgs, disks...)
 	}
 
 	// Initrd configuration


### PR DESCRIPTION
## Description

`CloudHypervisor.BuildExecCmd` appended a separate `--disk` flag per block
device. Cloud Hypervisor only accepts one `--disk` flag with every disk as a
value after it and rejects a repeated flag:

```
error: the argument '--disk <disk>...' cannot be used multiple times
```

So any container with more than one block device (e.g. block rootfs + a
block-backed volume) failed to start. A single disk worked, which is why the
existing e2e cases (all single-disk) missed it.

Fix: collect the disk specs and emit them behind one `--disk`.

```
# before
--disk path=/rootfs.img,id=rootfs --disk path=/dev/loop0,id=vol0

# after
--disk path=/rootfs.img,id=rootfs path=/dev/loop0,id=vol0
```

`ExactArgs` and the no-block-device case are unaffected.

### Related issues

- Fixes #988

### How was this tested?

Reproduced end-to-end with urunc + cloud-hypervisor v50.0.0 
using a hand-built OCI bundle with a block rootfs and one
loop-backed volume no containerd/devmapper needed. Before the fix,
cloud-hypervisor rejects the args; after, it proceeds to kernel loading.

Also ran `go build ./...`, `go vet`, `gofmt`, and the existing
`./pkg/unikontainers/...` unit tests all pass
### LLM usage

Claude sonnet investigating the bug and fixes

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`) no new issues from this change.
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
