### PR TITLE
fix(initrd): merge file mounts into the existing CPIO archive

### DIFF
--- a/.github/contributors.yaml
+++ b/.github/contributors.yaml
@@ -1,4 +1,7 @@
 users:
+  kastakhov:
+    name: Kostiantyn Astakhov
+    email: me@lvfrfn.in.ua
   ananos:
     name: Anastassios Nanos
     email: ananos@nubificus.co.uk

--- a/.github/linters/urunc-dict.txt
+++ b/.github/linters/urunc-dict.txt
@@ -439,3 +439,5 @@ Readonlyfs
 capab
 werr
 cerr
+inodes
+newc

--- a/Makefile
+++ b/Makefile
@@ -237,7 +237,7 @@ test: unittest e2etest
 
 ## unittest Run all unit tests
 .PHONY: unittest
-unittest: test_unikontainers test_metrics test_network test_hypervisors test_unikernels
+unittest: test_unikontainers test_initrd test_metrics test_network test_hypervisors test_unikernels
 
 ## e2etest Run all end-to-end tests
 .PHONY: e2etest
@@ -247,6 +247,13 @@ e2etest: test_nerdctl test_ctr test_crictl test_docker
 test_unikontainers:
 	@echo "Unit testing in unikontainers"
 	@GOFLAGS=$(TEST_FLAGS) $(GO) test $(TEST_OPTS) ./pkg/unikontainers -v
+	@echo " "
+
+## test_initrd Run unit tests for initrd package
+.PHONY: test_initrd
+test_initrd:
+	@echo "Unit testing in initrd"
+	@GOFLAGS=$(TEST_FLAGS) $(GO) test $(TEST_OPTS) ./pkg/unikontainers/initrd -v
 	@echo " "
 
 ## test_metrics Run unit tests for metrics package

--- a/pkg/unikontainers/initrd/initrd.go
+++ b/pkg/unikontainers/initrd/initrd.go
@@ -15,8 +15,13 @@
 package initrd
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"os"
+	"path"
+	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -24,9 +29,50 @@ import (
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
-func addInitrdRecord(w *cpio.Writer, content []byte, fileInfo *syscall.Stat_t, name string) error {
+const maxNewcInode int64 = 1<<32 - 1
+
+const (
+	newcHeaderSize = 110
+	trailerName    = "TRAILER!!!"
+)
+
+// inodeAllocator prevents newly merged entries from colliding with existing
+// c_ino values. Unikraft treats repeated inodes with multiple links as hard
+// links, even when the records have different file types.
+type inodeAllocator struct {
+	used map[int64]struct{}
+	next int64
+}
+
+func newInodeAllocator() *inodeAllocator {
+	return &inodeAllocator{
+		used: make(map[int64]struct{}),
+		next: 1,
+	}
+}
+
+func (a *inodeAllocator) reserve(inode int64) {
+	a.used[inode] = struct{}{}
+}
+
+func (a *inodeAllocator) allocate() (int64, error) {
+	for a.next <= maxNewcInode {
+		inode := a.next
+		a.next++
+		if _, exists := a.used[inode]; exists {
+			continue
+		}
+		a.used[inode] = struct{}{}
+		return inode, nil
+	}
+
+	return 0, errors.New("newc inode space exhausted")
+}
+
+func addInitrdRecord(w *cpio.Writer, content []byte, fileInfo *syscall.Stat_t, name string, inode int64) error {
 	hdr := &cpio.Header{
 		Name:    name,
+		Inode:   inode,
 		Mode:    cpio.FileMode(fileInfo.Mode),
 		Uid:     int(fileInfo.Uid),
 		Guid:    int(fileInfo.Gid),
@@ -46,6 +92,10 @@ func addInitrdRecord(w *cpio.Writer, content []byte, fileInfo *syscall.Stat_t, n
 }
 
 func CopyFileToInitrd(w *cpio.Writer, srcFile string, destFile string) error {
+	return copyFileToInitrdWithInode(w, srcFile, destFile, 0)
+}
+
+func copyFileToInitrdWithInode(w *cpio.Writer, srcFile string, destFile string, inode int64) error {
 	// Get the info of the original file
 	fi, err := os.Stat(srcFile)
 	if err != nil {
@@ -57,7 +107,7 @@ func CopyFileToInitrd(w *cpio.Writer, srcFile string, destFile string) error {
 		if err != nil {
 			return fmt.Errorf("could not read file %s: %w", srcFile, err)
 		}
-		err = addInitrdRecord(w, content, fileInfo, destFile)
+		err = addInitrdRecord(w, content, fileInfo, destFile, inode)
 		if err != nil {
 			return fmt.Errorf("could not add record for %s: %w", srcFile, err)
 		}
@@ -91,6 +141,203 @@ func CopyFileMountsToInitrd(oldInitrd string, mounts []specs.Mount) error {
 	return nil
 }
 
+// MergeFileMountsIntoInitrd adds regular-file bind mounts before the trailer
+// of an uncompressed newc archive. The archive is fully parsed before the
+// disposable initrd is updated in place.
+func MergeFileMountsIntoInitrd(oldInitrd string, mounts []specs.Mount) (retErr error) {
+	fileMounts, err := regularFileBindMounts(mounts)
+	if err != nil {
+		return err
+	}
+	if len(fileMounts) == 0 {
+		return nil
+	}
+
+	initrdFile, err := os.OpenFile(oldInitrd, os.O_RDWR, 0)
+	if err != nil {
+		return fmt.Errorf("could not open %s: %w", oldInitrd, err)
+	}
+	defer func() {
+		if err := initrdFile.Close(); err != nil {
+			closeErr := fmt.Errorf("could not close %s: %w", oldInitrd, err)
+			if retErr == nil {
+				retErr = closeErr
+			} else {
+				retErr = errors.Join(retErr, closeErr)
+			}
+		}
+	}()
+
+	trailerOffset, existingNames, inodes, err := inspectInitrd(initrdFile)
+	if err != nil {
+		return fmt.Errorf("could not parse %s: %w", oldInitrd, err)
+	}
+	if err := initrdFile.Truncate(trailerOffset); err != nil {
+		return fmt.Errorf("could not truncate %s: %w", oldInitrd, err)
+	}
+	if _, err := initrdFile.Seek(trailerOffset, io.SeekStart); err != nil {
+		return fmt.Errorf("could not seek in %s: %w", oldInitrd, err)
+	}
+
+	w := cpio.NewWriter(initrdFile)
+	for _, mount := range fileMounts {
+		archiveName, err := archivePath(mount.Destination)
+		if err != nil {
+			return err
+		}
+		lookupName := archiveLookupPath(archiveName)
+		if err := addMissingParents(w, lookupName, existingNames, inodes); err != nil {
+			return err
+		}
+		inode, err := inodes.allocate()
+		if err != nil {
+			return fmt.Errorf("could not allocate inode for file %s: %w", archiveName, err)
+		}
+		if err := copyFileToInitrdWithInode(w, mount.Source, archiveName, inode); err != nil {
+			return fmt.Errorf("could not add file %s to initrd: %w", mount.Source, err)
+		}
+		existingNames[lookupName] = struct{}{}
+	}
+	if err := w.Close(); err != nil {
+		return fmt.Errorf("could not close initrd writer: %w", err)
+	}
+
+	return nil
+}
+
+func regularFileBindMounts(mounts []specs.Mount) ([]specs.Mount, error) {
+	var fileMounts []specs.Mount
+	for _, mount := range mounts {
+		if mount.Type != "bind" {
+			continue
+		}
+		info, err := os.Stat(mount.Source)
+		if err != nil {
+			return nil, fmt.Errorf("could not stat file %s: %w", mount.Source, err)
+		}
+		if info.Mode().IsRegular() {
+			fileMounts = append(fileMounts, mount)
+		}
+	}
+	return fileMounts, nil
+}
+
+func inspectInitrd(f *os.File) (int64, map[string]struct{}, *inodeAllocator, error) {
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return 0, nil, nil, err
+	}
+
+	r := cpio.NewReader(f)
+	names := make(map[string]struct{})
+	inodes := newInodeAllocator()
+	var trailerOffset int64
+	for {
+		hdr, err := r.Next()
+		if errors.Is(err, io.EOF) {
+			if err := validateTrailerAt(f, trailerOffset); err != nil {
+				return 0, nil, nil, err
+			}
+			return trailerOffset, names, inodes, nil
+		}
+		if err != nil {
+			return 0, nil, nil, fmt.Errorf("could not read newc record at offset %d: %w", trailerOffset, err)
+		}
+		names[archiveLookupPath(hdr.Name)] = struct{}{}
+		inodes.reserve(hdr.Inode)
+		if _, err := io.Copy(io.Discard, r); err != nil {
+			return 0, nil, nil, err
+		}
+		offset, err := f.Seek(0, io.SeekCurrent)
+		if err != nil {
+			return 0, nil, nil, err
+		}
+		trailerOffset = (offset + 3) &^ 3
+	}
+}
+
+func validateTrailerAt(f *os.File, offset int64) error {
+	var header [newcHeaderSize]byte
+	n, err := f.ReadAt(header[:], offset)
+	if err != nil {
+		if errors.Is(err, io.EOF) && n == 0 {
+			return fmt.Errorf("missing newc trailer at offset %d: reached physical EOF", offset)
+		}
+		return fmt.Errorf("could not read newc trailer header at offset %d: %w", offset, err)
+	}
+
+	magic := string(header[:6])
+	if magic != "070701" && magic != "070702" {
+		return fmt.Errorf("invalid newc trailer at offset %d: unsupported magic %q", offset, magic)
+	}
+
+	size, err := strconv.ParseUint(string(header[54:62]), 16, 32)
+	if err != nil {
+		return fmt.Errorf("invalid newc trailer at offset %d: invalid file size: %w", offset, err)
+	}
+	if size != 0 {
+		return fmt.Errorf("invalid newc trailer at offset %d: file size is %d, not zero", offset, size)
+	}
+
+	nameSize, err := strconv.ParseUint(string(header[94:102]), 16, 32)
+	if err != nil {
+		return fmt.Errorf("invalid newc trailer at offset %d: invalid name size: %w", offset, err)
+	}
+	expectedName := trailerName + "\x00"
+	if nameSize != uint64(len(expectedName)) {
+		return fmt.Errorf("invalid newc trailer at offset %d: name size is %d, not %d", offset, nameSize, len(expectedName))
+	}
+
+	name := make([]byte, len(expectedName))
+	if _, err := f.ReadAt(name, offset+newcHeaderSize); err != nil {
+		return fmt.Errorf("could not read newc trailer name at offset %d: %w", offset, err)
+	}
+	if string(name) != expectedName {
+		return fmt.Errorf("invalid newc trailer at offset %d: name is not %q", offset, trailerName)
+	}
+
+	return nil
+}
+
+func archivePath(destination string) (string, error) {
+	if !path.IsAbs(destination) {
+		return "", fmt.Errorf("initrd mount destination %q is not absolute", destination)
+	}
+	// The supported Unikraft image flow uses the ./ namespace. Keeping all new
+	// records there also makes parent lookup and later-record replacement consistent.
+	return "./" + archiveLookupPath(destination), nil
+}
+
+func archiveLookupPath(name string) string {
+	return strings.TrimPrefix(path.Clean(name), "/")
+}
+
+func addMissingParents(w *cpio.Writer, lookupName string, existingNames map[string]struct{}, inodes *inodeAllocator) error {
+	parentName := ""
+	for _, component := range strings.Split(path.Dir(lookupName), "/") {
+		if component == "" || component == "." {
+			continue
+		}
+		parentName = path.Join(parentName, component)
+		if _, exists := existingNames[parentName]; exists {
+			continue
+		}
+
+		archiveName := "./" + parentName
+		inode, err := inodes.allocate()
+		if err != nil {
+			return fmt.Errorf("could not allocate inode for directory %s: %w", archiveName, err)
+		}
+		// Two is the conventional minimum link count for a directory. Unique
+		// allocated inodes keep Unikraft from treating unrelated entries as hard links.
+		hdr := &cpio.Header{Name: archiveName, Inode: inode, Mode: cpio.TypeDir | 0o755, Links: 2}
+		if err := w.WriteHeader(hdr); err != nil {
+			return fmt.Errorf("could not add directory %s to initrd: %w", archiveName, err)
+		}
+		existingNames[parentName] = struct{}{}
+	}
+	return nil
+}
+
 func AddFileToInitrd(oldInitrd string, data string, name string) error {
 	f, err := os.OpenFile(oldInitrd, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
@@ -106,7 +353,7 @@ func AddFileToInitrd(oldInitrd string, data string, name string) error {
 		Uid:  0,
 		Gid:  0,
 	}
-	err = addInitrdRecord(w, []byte(data), &fileInfo, name)
+	err = addInitrdRecord(w, []byte(data), &fileInfo, name, 0)
 	if err != nil {
 		return fmt.Errorf("could not add file %s to initrd: %w", name, err)
 	}

--- a/pkg/unikontainers/initrd/initrd_test.go
+++ b/pkg/unikontainers/initrd/initrd_test.go
@@ -1,0 +1,356 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package initrd
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cavaliergopher/cpio"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeFileMountsIntoInitrd(t *testing.T) {
+	dir := t.TempDir()
+	initrdPath := filepath.Join(dir, "initrd.cpio")
+	writeArchive(t, initrdPath, []archiveEntry{
+		{name: "./etc", inode: 42, links: 2, mode: cpio.TypeDir | 0o755},
+		{name: "./etc/original", inode: 43, links: 1, mode: cpio.TypeReg | 0o644, content: "old"},
+	})
+	require.NoError(t, os.Chmod(initrdPath, 0o640))
+	original := readFile(t, initrdPath)
+	originalInfo, err := os.Stat(initrdPath)
+	require.NoError(t, err)
+	originalTrailer := bytes.Index(original, []byte("TRAILER!!!\x00")) - 110
+	require.GreaterOrEqual(t, originalTrailer, 0)
+
+	configSource := writeSource(t, dir, "config", "mounted config")
+	replacementSource := writeSource(t, dir, "replacement", "new")
+	mounts := []specs.Mount{
+		{Type: "bind", Source: configSource, Destination: "/etc/app/config"},
+		{Type: "bind", Source: replacementSource, Destination: "/etc/original"},
+	}
+
+	require.NoError(t, MergeFileMountsIntoInitrd(initrdPath, mounts))
+
+	updated := readFile(t, initrdPath)
+	require.Equal(t, original[:originalTrailer], updated[:originalTrailer], "existing records changed")
+	require.Equal(t, 1, bytes.Count(updated, []byte("TRAILER!!!\x00")))
+
+	entries := readArchive(t, initrdPath)
+	require.Equal(t, 1, countName(entries, "./etc"), "existing parent was duplicated")
+	require.Equal(t, 1, countName(entries, "./etc/app"), "missing parent was not added once")
+	require.Equal(t, "mounted config", lastContent(entries, "./etc/app/config"))
+	require.Equal(t, 2, countName(entries, "./etc/original"))
+	require.Equal(t, "new", lastContent(entries, "./etc/original"))
+
+	info, err := os.Stat(initrdPath)
+	require.NoError(t, err)
+	require.True(t, os.SameFile(originalInfo, info), "initrd was replaced")
+	require.Equal(t, os.FileMode(0o640), info.Mode().Perm())
+}
+
+func TestMergeFileMountsIntoInitrdCanonicalizesExistingNames(t *testing.T) {
+	dir := t.TempDir()
+	initrdPath := filepath.Join(dir, "initrd.cpio")
+	writeArchive(t, initrdPath, []archiveEntry{
+		{name: "etc", inode: 42, links: 2, mode: cpio.TypeDir | 0o755},
+		{name: "etc/original", inode: 43, links: 1, mode: cpio.TypeReg | 0o644, content: "old"},
+	})
+	original := readFile(t, initrdPath)
+	originalTrailer := bytes.Index(original, []byte("TRAILER!!!\x00")) - 110
+	require.GreaterOrEqual(t, originalTrailer, 0)
+
+	configSource := writeSource(t, dir, "config", "mounted config")
+	replacementSource := writeSource(t, dir, "replacement", "new")
+	require.NoError(t, MergeFileMountsIntoInitrd(initrdPath, []specs.Mount{
+		{Type: "bind", Source: configSource, Destination: "/etc/app/config"},
+		{Type: "bind", Source: replacementSource, Destination: "/etc/original"},
+	}))
+
+	updated := readFile(t, initrdPath)
+	require.Equal(t, original[:originalTrailer], updated[:originalTrailer], "existing records changed")
+
+	entries := readArchive(t, initrdPath)
+	require.Equal(t, 1, countName(entries, "etc"), "existing parent changed")
+	require.Zero(t, countName(entries, "./etc"), "equivalent parent was duplicated")
+	require.Equal(t, 1, countName(entries, "./etc/app"), "missing parent was not added once")
+	require.Equal(t, "mounted config", lastContent(entries, "./etc/app/config"))
+	require.Equal(t, "old", lastContent(entries, "etc/original"), "existing file changed")
+	require.Equal(t, 1, countName(entries, "./etc/original"), "replacement was not emitted")
+	require.Equal(t, "new", lastContent(entries, "./etc/original"))
+	require.Equal(t, "new", lastContentAtLookupPath(entries, "etc/original"),
+		"mounted file did not replace the equivalent existing path")
+}
+
+func TestAddMissingParentsWalksTopDownAndTerminatesAtRoot(t *testing.T) {
+	for _, lookupName := range []string{"etc/app/config", "/etc/app/config"} {
+		t.Run(lookupName, func(t *testing.T) {
+			initrdPath := filepath.Join(t.TempDir(), "initrd.cpio")
+			archive, err := os.Create(initrdPath)
+			require.NoError(t, err)
+			w := cpio.NewWriter(archive)
+
+			require.NoError(t, addMissingParents(w, lookupName, make(map[string]struct{}), newInodeAllocator()))
+			require.NoError(t, w.Close())
+			require.NoError(t, archive.Close())
+
+			entries := readArchive(t, initrdPath)
+			require.Len(t, entries, 2)
+			require.Equal(t, "./etc", entries[0].name)
+			require.Equal(t, "./etc/app", entries[1].name)
+			require.Equal(t, 2, entries[0].links)
+			require.Equal(t, 2, entries[1].links)
+		})
+	}
+}
+
+func TestMergeFileMountsIntoInitrdAssignsUnusedInodes(t *testing.T) {
+	dir := t.TempDir()
+	initrdPath := filepath.Join(dir, "initrd.cpio")
+	writeArchive(t, initrdPath, []archiveEntry{
+		{name: "./existing-one", inode: 1, links: 2, mode: cpio.TypeDir | 0o755},
+		{name: "./existing-two", inode: 2, links: 2, mode: cpio.TypeDir | 0o755},
+	})
+	source := writeSource(t, dir, "mounted", "new")
+
+	require.NoError(t, MergeFileMountsIntoInitrd(initrdPath, []specs.Mount{
+		{Type: "bind", Source: source, Destination: "/new/child/file"},
+	}))
+
+	existingInodes := map[int64]struct{}{1: {}, 2: {}}
+	insertedNames := map[string]struct{}{
+		"./new":            {},
+		"./new/child":      {},
+		"./new/child/file": {},
+	}
+	insertedInodes := make(map[int64]string)
+	for _, entry := range readArchive(t, initrdPath) {
+		if _, inserted := insertedNames[entry.name]; !inserted {
+			continue
+		}
+		require.NotZero(t, entry.inode)
+		require.NotContains(t, existingInodes, entry.inode,
+			"inserted entry %s reused an existing inode", entry.name)
+		require.NotContains(t, insertedInodes, entry.inode,
+			"inserted entries %s and %s share an inode", insertedInodes[entry.inode], entry.name)
+		insertedInodes[entry.inode] = entry.name
+	}
+	require.Len(t, insertedInodes, len(insertedNames))
+}
+
+func TestCopyFileMountsToInitrdStillAppendsArchive(t *testing.T) {
+	dir := t.TempDir()
+	initrdPath := filepath.Join(dir, "initrd.cpio")
+	writeArchive(t, initrdPath, []archiveEntry{{name: "./original", mode: cpio.TypeReg | 0o644, content: "old"}})
+	original := readFile(t, initrdPath)
+	source := writeSource(t, dir, "mounted", "new")
+
+	require.NoError(t, CopyFileMountsToInitrd(initrdPath, []specs.Mount{
+		{Type: "bind", Source: source, Destination: "/mounted"},
+	}))
+
+	updated := readFile(t, initrdPath)
+	require.Equal(t, original, updated[:len(original)])
+	require.Equal(t, 2, bytes.Count(updated, []byte("TRAILER!!!\x00")))
+	require.Equal(t, 0, countName(readArchive(t, initrdPath), "/mounted"), "first member unexpectedly exposed appended entry")
+}
+
+func TestMergeFileMountsIntoInitrdWithoutRegularBindMountsDoesNotRewrite(t *testing.T) {
+	dir := t.TempDir()
+	initrdPath := filepath.Join(dir, "initrd.cpio")
+	writeArchive(t, initrdPath, []archiveEntry{{name: "./original", mode: cpio.TypeReg | 0o644, content: "old"}})
+	original := readFile(t, initrdPath)
+	originalInfo, err := os.Stat(initrdPath)
+	require.NoError(t, err)
+
+	require.NoError(t, MergeFileMountsIntoInitrd(initrdPath, []specs.Mount{
+		{Type: "tmpfs", Source: "tmpfs", Destination: "/tmp"},
+		{Type: "bind", Source: dir, Destination: "/directory"},
+	}))
+
+	require.Equal(t, original, readFile(t, initrdPath))
+	updatedInfo, err := os.Stat(initrdPath)
+	require.NoError(t, err)
+	require.True(t, os.SameFile(originalInfo, updatedInfo), "initrd was replaced")
+}
+
+func TestMergeFileMountsIntoInitrdParseFailureDoesNotMutateOriginal(t *testing.T) {
+	dir := t.TempDir()
+	initrdPath := filepath.Join(dir, "initrd.cpio")
+	require.NoError(t, os.WriteFile(initrdPath, []byte("not a cpio archive"), 0o600))
+	original := readFile(t, initrdPath)
+	originalInfo, err := os.Stat(initrdPath)
+	require.NoError(t, err)
+	source := writeSource(t, dir, "mounted", "new")
+
+	err = MergeFileMountsIntoInitrd(initrdPath, []specs.Mount{
+		{Type: "bind", Source: source, Destination: "/mounted"},
+	})
+
+	require.Error(t, err)
+	require.Equal(t, original, readFile(t, initrdPath))
+	updatedInfo, err := os.Stat(initrdPath)
+	require.NoError(t, err)
+	require.True(t, os.SameFile(originalInfo, updatedInfo), "initrd was replaced")
+}
+
+func TestMergeFileMountsIntoInitrdInvalidTrailerDoesNotMutateOriginal(t *testing.T) {
+	tests := map[string]func(archive []byte, trailerOffset int) []byte{
+		"missing trailer": func(archive []byte, trailerOffset int) []byte {
+			return archive[:trailerOffset]
+		},
+		"empty initrd": func(_ []byte, _ int) []byte {
+			return nil
+		},
+		"truncated trailer": func(archive []byte, trailerOffset int) []byte {
+			return archive[:trailerOffset+newcHeaderSize+len(trailerName)/2]
+		},
+		"non-zero trailer size": func(archive []byte, trailerOffset int) []byte {
+			copy(archive[trailerOffset+54:trailerOffset+62], "00000001")
+			return archive
+		},
+		"invalid trailer name field": func(archive []byte, trailerOffset int) []byte {
+			archive[trailerOffset+newcHeaderSize+len(trailerName)] = 'X'
+			return archive
+		},
+	}
+
+	for name, corruptArchive := range tests {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			initrdPath := filepath.Join(dir, "initrd.cpio")
+			writeArchive(t, initrdPath, []archiveEntry{
+				{name: "./original", mode: cpio.TypeReg | 0o644, content: "old"},
+			})
+			archive := readFile(t, initrdPath)
+			trailerOffset := bytes.Index(archive, []byte(trailerName+"\x00")) - newcHeaderSize
+			require.GreaterOrEqual(t, trailerOffset, 0)
+			require.NoError(t, os.WriteFile(initrdPath, corruptArchive(archive, trailerOffset), 0o600))
+
+			original := readFile(t, initrdPath)
+			originalInfo, err := os.Stat(initrdPath)
+			require.NoError(t, err)
+			source := writeSource(t, dir, "mounted", "new")
+
+			err = MergeFileMountsIntoInitrd(initrdPath, []specs.Mount{
+				{Type: "bind", Source: source, Destination: "/mounted"},
+			})
+
+			require.Error(t, err)
+			require.Equal(t, original, readFile(t, initrdPath))
+			updatedInfo, err := os.Stat(initrdPath)
+			require.NoError(t, err)
+			require.True(t, os.SameFile(originalInfo, updatedInfo), "initrd was replaced")
+		})
+	}
+}
+
+type archiveEntry struct {
+	name    string
+	inode   int64
+	links   int
+	mode    cpio.FileMode
+	content string
+}
+
+func writeArchive(t *testing.T, archivePath string, entries []archiveEntry) {
+	t.Helper()
+	f, err := os.Create(archivePath)
+	require.NoError(t, err)
+	w := cpio.NewWriter(f)
+	for _, entry := range entries {
+		hdr := &cpio.Header{
+			Name: entry.name, Inode: entry.inode, Links: entry.links,
+			Mode: entry.mode, Size: int64(len(entry.content)),
+		}
+		require.NoError(t, w.WriteHeader(hdr))
+		_, err := w.Write([]byte(entry.content))
+		require.NoError(t, err)
+	}
+	require.NoError(t, w.Close())
+	require.NoError(t, f.Close())
+}
+
+func readArchive(t *testing.T, archivePath string) []archiveEntry {
+	t.Helper()
+	f, err := os.Open(archivePath)
+	require.NoError(t, err)
+	defer f.Close()
+
+	var entries []archiveEntry
+	r := cpio.NewReader(f)
+	for {
+		hdr, err := r.Next()
+		if err == io.EOF {
+			return entries
+		}
+		require.NoError(t, err)
+		content, err := io.ReadAll(r)
+		require.NoError(t, err)
+		entries = append(entries, archiveEntry{
+			name: hdr.Name, inode: hdr.Inode, links: hdr.Links,
+			mode: hdr.Mode, content: string(content),
+		})
+	}
+}
+
+func writeSource(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	filename := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(filename, []byte(content), 0o600))
+	return filename
+}
+
+func readFile(t *testing.T, name string) []byte {
+	t.Helper()
+	content, err := os.ReadFile(name)
+	require.NoError(t, err)
+	return content
+}
+
+func countName(entries []archiveEntry, name string) int {
+	count := 0
+	for _, entry := range entries {
+		if entry.name == name {
+			count++
+		}
+	}
+	return count
+}
+
+func lastContent(entries []archiveEntry, name string) string {
+	var content string
+	for _, entry := range entries {
+		if entry.name == name {
+			content = entry.content
+		}
+	}
+	return content
+}
+
+func lastContentAtLookupPath(entries []archiveEntry, lookupPath string) string {
+	var content string
+	for _, entry := range entries {
+		if archiveLookupPath(entry.name) == lookupPath {
+			content = entry.content
+		}
+	}
+	return content
+}

--- a/pkg/unikontainers/initrd_rootfs.go
+++ b/pkg/unikontainers/initrd_rootfs.go
@@ -20,6 +20,7 @@ import (
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/urunc-dev/urunc/pkg/unikontainers/initrd"
 	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
+	"github.com/urunc-dev/urunc/pkg/unikontainers/unikernels"
 )
 
 // TODO: Find and set the correct size for the tmpfs in the host
@@ -29,6 +30,7 @@ type initrdRootfs struct {
 	mounts             []specs.Mount
 	monRootfs          string
 	initrdHostFullPath string
+	guestType          string
 }
 
 func (i initrdRootfs) preSetup() error {
@@ -36,7 +38,12 @@ func (i initrdRootfs) preSetup() error {
 }
 
 func (i initrdRootfs) postSetup() error {
-	err := initrd.CopyFileMountsToInitrd(i.initrdHostFullPath, i.mounts)
+	var err error
+	if i.guestType == unikernels.UnikraftUnikernel {
+		err = initrd.MergeFileMountsIntoInitrd(i.initrdHostFullPath, i.mounts)
+	} else {
+		err = initrd.CopyFileMountsToInitrd(i.initrdHostFullPath, i.mounts)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to update guest's initrd: %w", err)
 	}

--- a/pkg/unikontainers/initrd_rootfs_test.go
+++ b/pkg/unikontainers/initrd_rootfs_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unikontainers
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cavaliergopher/cpio"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/require"
+	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
+	"github.com/urunc-dev/urunc/pkg/unikontainers/unikernels"
+)
+
+// TODO: Move this alongside the tests for newRootfsBuilder in unikontainers.go.
+func TestNewRootfsBuilderPassesGuestTypeToInitrd(t *testing.T) {
+	u := &Unikontainer{
+		State: &specs.State{Annotations: map[string]string{annotType: unikernels.UnikraftUnikernel}},
+		Spec:  &specs.Spec{},
+	}
+
+	builder := u.newRootfsBuilder(types.RootfsParams{Type: "initrd"}, nil, "", "", 0)
+	rfs, ok := builder.(initrdRootfs)
+	require.True(t, ok)
+	require.Equal(t, unikernels.UnikraftUnikernel, rfs.guestType)
+}
+
+func TestInitrdRootfsPostSetupSelectsUpdateByGuestType(t *testing.T) {
+	tests := []struct {
+		name         string
+		guestType    string
+		trailerCount int
+	}{
+		{name: "Unikraft merges", guestType: unikernels.UnikraftUnikernel, trailerCount: 1},
+		{name: "Linux appends", guestType: unikernels.LinuxUnikernel, trailerCount: 2},
+		{name: "unknown appends", guestType: "other", trailerCount: 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			archivePath := filepath.Join(dir, "initrd.cpio")
+			archive, err := os.Create(archivePath)
+			require.NoError(t, err)
+			require.NoError(t, cpio.NewWriter(archive).Close())
+			require.NoError(t, archive.Close())
+
+			source := filepath.Join(dir, "mounted")
+			require.NoError(t, os.WriteFile(source, []byte("new"), 0o600))
+			rfs := initrdRootfs{
+				initrdHostFullPath: archivePath,
+				guestType:          tt.guestType,
+				mounts: []specs.Mount{
+					{Type: "bind", Source: source, Destination: "/mounted"},
+				},
+			}
+
+			require.NoError(t, rfs.postSetup())
+			updated, err := os.ReadFile(archivePath)
+			require.NoError(t, err)
+			require.Equal(t, tt.trailerCount, bytes.Count(updated, []byte("TRAILER!!!\x00")))
+		})
+	}
+}

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -430,6 +430,7 @@ func (u *Unikontainer) newRootfsBuilder(rootfsParams types.RootfsParams, unikern
 			mounts:             u.Spec.Mounts,
 			initrdHostFullPath: filepath.Join(rootfsParams.MonRootfs, rootfsParams.Path),
 			monRootfs:          rootfsParams.MonRootfs,
+			guestType:          u.State.Annotations[annotType],
 		}
 	case "virtiofs", "9pfs":
 		return sharedfsRootfs{


### PR DESCRIPTION
## Description

`CopyFileMountsToInitrd` appends file mounts as a second CPIO archive. Unikraft stops extracting at the original `TRAILER!!!`, making the appended files unavailable inside the guest.

This change:

- Merges file mounts into the existing Unikraft CPIO archive before its trailer.
- Adds missing parent directories and writes one final trailer.
- Avoid inode collisions when merging mounts
- Preserves the original initrd permissions and replaces it only after a successful rewrite.
- Keeps the existing append behavior for Linux and other guest types.
- Adds unit tests for archive merging and guest-type selection.

### Related issues

- Fixes #985

### How was this tested?

- go test ./pkg/unikontainers/initrd
- e2e tests: `test_docker`, `test_ctr`
- Tested an identical Kubernetes workload with unpatched and patched runtimes:
    - The unpatched runtime produced two trailers, and mounted ConfigMap files were unavailable to Unikraft.
    - The patched runtime produced one trailer, and the mounted files were visible with the expected values.

### LLM usage

OpenAI Codex (GPT-5.6) assisted with the implementation, test review, and PR description based on my specifications. I reviewed and approved the final changes.

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [x] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
