### PR TITLE
Remove dead logLevel guard in createReexecCmd

### DIFF
--- a/cmd/urunc/create.go
+++ b/cmd/urunc/create.go
@@ -302,9 +302,7 @@ func createReexecCmd(initSock *os.File, logPipe *os.File) *exec.Cmd {
 	reexecCommand.Env = append(reexecCommand.Env, "_LIBCONTAINER_INITPIPE=3")
 	reexecCommand.Env = append(reexecCommand.Env, "_LIBCONTAINER_LOGPIPE=4")
 	logLevel := strconv.Itoa(int(logrus.GetLevel()))
-	if logLevel != "" {
-		reexecCommand.Env = append(reexecCommand.Env, "_LIBCONTAINER_LOGLEVEL="+logLevel)
-	}
+	reexecCommand.Env = append(reexecCommand.Env, "_LIBCONTAINER_LOGLEVEL="+logLevel)
 
 	return reexecCommand
 }


### PR DESCRIPTION
## Description
`createReexecCmd` guarded setting the `_LIBCONTAINER_LOGLEVEL` env var behind `if logLevel != ""`, but `logLevel` comes from `strconv.Itoa(int(logrus.GetLevel()))`, which never returns an empty string. The guard is always true and dead. Removes it.

## Issues Resolved
Fixes #837