### PR TITLE
fix(config): keep extra binary defaults on partial decode

### DIFF
--- a/pkg/unikontainers/urunc_config.go
+++ b/pkg/unikontainers/urunc_config.go
@@ -180,6 +180,17 @@ func LoadUruncConfig(path string) (*UruncConfig, error) {
 		}
 		cfg.Monitors[name] = mon
 	}
+	// Same issue for [extra_binaries.virtiofsd], the only supported extra binary today.
+	if bin, ok := cfg.ExtraBins["virtiofsd"]; ok {
+		def := defaultExtraBinConfig()["virtiofsd"]
+		if bin.Path == "" {
+			bin.Path = def.Path
+		}
+		if bin.Options == "" {
+			bin.Options = def.Options
+		}
+		cfg.ExtraBins["virtiofsd"] = bin
+	}
 
 	return cfg, nil
 }

--- a/pkg/unikontainers/urunc_config_test.go
+++ b/pkg/unikontainers/urunc_config_test.go
@@ -619,6 +619,20 @@ path = "/usr/bin/mon"
 		assert.Error(t, err)
 		assert.Equal(t, defaultMonitorsConfig(), config.Monitors)
 	})
+
+	t.Run("partial extra binary section keeps default options", func(t *testing.T) {
+		t.Parallel()
+		path := writeTestConfig(t, `
+[extra_binaries.virtiofsd]
+path = "/opt/urunc/bin/virtiofsd"
+`)
+		config, err := LoadUruncConfig(path)
+		assert.NoError(t, err)
+
+		virtiofsd := config.ExtraBins["virtiofsd"]
+		assert.Equal(t, "/opt/urunc/bin/virtiofsd", virtiofsd.Path)
+		assert.Equal(t, defaultExtraBinConfig()["virtiofsd"].Options, virtiofsd.Options)
+	})
 }
 
 // Note: these tests use t.Setenv and therefore must not call t.Parallel().


### PR DESCRIPTION
## Description
LoadUruncConfig reapplies default values for a partially specified [monitors.name] section, but had no equivalent for [extra_binaries.name]. A partial extra binaries section (e.g. one that only sets path) silently lost the default options. This adds the same defaulting for extra binaries.

### Related issues
- Fixes #1010

### How was this tested?
Added a unit test in urunc_config_test.go covering a partial [extra_binaries.virtiofsd] section that only sets path, asserting the default options value is kept. Ran go build, go vet, and go test for pkg/unikontainers, and golangci-lint run for the package, all clean.

### LLM usage
none

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).