### PR TITLE
fix: call createUnikontainer, not reexecUnikontainer, in run command

### DIFF
--- a/cmd/urunc/run.go
+++ b/cmd/urunc/run.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v3"
+	"github.com/urunc-dev/urunc/pkg/unikontainers"
 )
 
 var runUsage = `<container-id>
@@ -66,9 +67,23 @@ var runCommand = &cli.Command{
 			return err
 		}
 
-		// FIXME: This is a refactor of what the previous code did, however I have a feeling
-		// that it will not work...
-		if err := reexecUnikontainer(cmd); err != nil {
+		// run combines create and start in a single invocation, so it
+		// needs to go through the same steps as the create command:
+		// createUnikontainer spawns the reexec process in the background
+		// and waits for it to be ready to receive the StartExecve message.
+		// Only then can startUnikontainer signal the reexec process to
+		// actually execve into the monitor and wait for it to report a
+		// successful start.
+		//
+		// NOTE: this used to call reexecUnikontainer directly instead of
+		// createUnikontainer. reexecUnikontainer is meant to run inside the
+		// reexec'd child process spawned by createUnikontainer (it reads
+		// the _LIBCONTAINER_INITPIPE/_LIBCONTAINER_LOGPIPE file descriptors
+		// that createUnikontainer passes to that child), so calling it here,
+		// in the original urunc process, always failed before
+		// startUnikontainer ever ran.
+		uruncCfg, _ := unikontainers.LoadUruncConfig(unikontainers.ResolveUruncConfigPath()) // ignore the error and use default config
+		if err := createUnikontainer(cmd, uruncCfg); err != nil {
 			return err
 		}
 		if err := startUnikontainer(cmd); err != nil {


### PR DESCRIPTION
## Description
The run command's action func called reexecUnikontainer() directly before startUnikontainer(). reexecUnikontainer is meant to run inside the reexec'd child process that createUnikontainer spawns  calling it directly in the original urunc process skipped that setup, so it always failed immediately, meaning urunc run was non-functional. Restores calling createUnikontainer() first, matching what create already does for its non-reexec path.

### Related issues
none

- Fixes #

### How was this tested?

Cross-compiled and vetted clean (GOOS=linux GOARCH=amd64); the macOS-native build fails on an unrelated pre-existing CGO/nsenter constraint that also reproduces on unmodified main.

### LLM usage

N/a

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [x] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
