### PR TITLE
refactor(core): remove obsolete cmdline annotation

### DIFF
--- a/docs/package/index.md
+++ b/docs/package/index.md
@@ -56,8 +56,6 @@ required annotations are the following:
   `cloud-hypervisor`, d) `spt`,  e) `hvt`, f) `hyperlight-unikraft`.
 - `com.urunc.unikernel.binary`: The path to the unikernel binary inside the
   container's rootfs
-- `com.urunc.unikernel.cmdline`: The application's cmdline to pass to the
-  unikernel.
 
 Except of the above, `urunc` accepts the following optional annotations:
 
@@ -186,9 +184,9 @@ COPY rootfs.cpio /unikernel/initrd
 
 LABEL "com.urunc.unikernel.binary"=/unikernel/kernel
 LABEL "com.urunc.unikernel.initrd"=/unikernel/initrd
-LABEL "com.urunc.unikernel.cmdline"="nginx -c /nginx/conf/nginx.conf"
 LABEL "com.urunc.unikernel.unikernelType"="unikraft"
 LABEL "com.urunc.unikernel.hypervisor"="qemu"
+CMD ["nginx", "-c", "/nginx/conf/nginx.conf"]
 ```
 
 ***Using bunnyfile***

--- a/docs/package/pre-built.md
+++ b/docs/package/pre-built.md
@@ -73,7 +73,6 @@ FROM scratch
 COPY network.hvt /unikernel/network.hvt
 
 LABEL com.urunc.unikernel.binary=/unikernel/network.hvt
-LABEL "com.urunc.unikernel.cmdline"=""
 LABEL "com.urunc.unikernel.unikernelType"="mirage"
 LABEL "com.urunc.unikernel.hypervisor"="hvt"
 LABEL "com.urunc.unikernel.mountRootfs"="false"

--- a/docs/package/reuse.md
+++ b/docs/package/reuse.md
@@ -65,9 +65,9 @@ above `bunnyfile` to the equivalent `Containerfile`:
 FROM unikraft.org/nginx:1.15
 
 LABEL com.urunc.unikernel.binary="/unikraft/bin/kernel"
-LABEL "com.urunc.unikernel.cmdline"="nginx -c /nginx/conf/nginx.conf"
 LABEL "com.urunc.unikernel.unikernelType"="unikraft"
 LABEL "com.urunc.unikernel.hypervisor"="qemu"
+CMD ["nginx", "-c", "/nginx/conf/nginx.conf"]
 ```
 
 In the above file:

--- a/docs/package/rootfs.md
+++ b/docs/package/rootfs.md
@@ -175,10 +175,10 @@ COPY redis.hvt /unikernel/redis.hvt
 COPY redis.conf /conf/redis.conf
 
 LABEL com.urunc.unikernel.binary=/unikernel/redis.hvt
-LABEL "com.urunc.unikernel.cmdline"="redis-server /data/conf/redis.conf"
 LABEL "com.urunc.unikernel.unikernelType"="rumprun"
 LABEL "com.urunc.unikernel.hypervisor"="hvt"
 LABEL "com.urunc.unikernel.mountRootfs"="true"
+CMD ["redis-server", "/data/conf/redis.conf"]
 
 ```
 
@@ -314,9 +314,9 @@ COPY rootfs.cpio /unikernel/rootfs.cpio
 
 LABEL "com.urunc.unikernel.binary"=/unikernel/kernel
 LABEL "com.urunc.unikernel.initrd"="/unikernel/rootfs.cpio"
-LABEL "com.urunc.unikernel.cmdline"="/chttp"
 LABEL "com.urunc.unikernel.unikernelType"="unikraft"
 LABEL "com.urunc.unikernel.hypervisor"="qemu"
+CMD ["/chttp"]
 ```
 
 In the above file:

--- a/docs/tutorials/existing-container-linux.md
+++ b/docs/tutorials/existing-container-linux.md
@@ -321,11 +321,11 @@ COPY vmlinux /kernel
 COPY nginx_rootfs.ext2 /rootfs.ext2
 
 LABEL "com.urunc.unikernel.binary"="/kernel"
-LABEL "com.urunc.unikernel.cmdline"="/urunit /usr/sbin/nginx -g 'daemon off;error_log stderr debug;"
 LABEL "com.urunc.unikernel.unikernelType"="linux"
 LABEL "com.urunc.unikernel.block"="/rootfs.ext2"
 LABEL "com.urunc.unikernel.blkMntPoint"="/"
 LABEL "com.urunc.unikernel.hypervisor"="firecracker"
+CMD ["/urunit", "/usr/sbin/nginx", "-g", "daemon off;error_log stderr debug;"]
 ```
 
 We can build the container with:

--- a/pkg/unikontainers/config.go
+++ b/pkg/unikontainers/config.go
@@ -39,7 +39,6 @@ const (
 	annotType          = "com.urunc.unikernel.unikernelType"
 	annotVersion       = "com.urunc.unikernel.unikernelVersion"
 	annotBinary        = "com.urunc.unikernel.binary"
-	annotCmdLine       = "com.urunc.unikernel.cmdline"
 	annotHypervisor    = "com.urunc.unikernel.hypervisor"
 	annotInitrd        = "com.urunc.unikernel.initrd"
 	annotBlock         = "com.urunc.unikernel.block"
@@ -53,7 +52,6 @@ const (
 type UnikernelConfig struct {
 	UnikernelType    string `json:"com.urunc.unikernel.unikernelType"`
 	UnikernelVersion string `json:"com.urunc.unikernel.unikernelVersion"`
-	UnikernelCmd     string `json:"com.urunc.unikernel.cmdline,omitempty"`
 	UnikernelBinary  string `json:"com.urunc.unikernel.binary"`
 	Hypervisor       string `json:"com.urunc.unikernel.hypervisor"`
 	Initrd           string `json:"com.urunc.unikernel.initrd,omitempty"`
@@ -116,7 +114,6 @@ func GetUnikernelConfig(bundleDir string, spec *specs.Spec) (*UnikernelConfig, e
 func getConfigFromSpec(spec *specs.Spec) *UnikernelConfig {
 	unikernelType := spec.Annotations[annotType]
 	unikernelVersion := spec.Annotations[annotVersion]
-	unikernelCmd := spec.Annotations[annotCmdLine]
 	unikernelBinary := spec.Annotations[annotBinary]
 	hypervisor := spec.Annotations[annotHypervisor]
 	initrd := spec.Annotations[annotInitrd]
@@ -128,7 +125,6 @@ func getConfigFromSpec(spec *specs.Spec) *UnikernelConfig {
 	uniklog.WithFields(logrus.Fields{
 		"unikernelType":    unikernelType,
 		"unikernelVersion": unikernelVersion,
-		"unikernelCmd":     unikernelCmd,
 		"unikernelBinary":  unikernelBinary,
 		"hypervisor":       hypervisor,
 		"initrd":           initrd,
@@ -143,7 +139,6 @@ func getConfigFromSpec(spec *specs.Spec) *UnikernelConfig {
 		UnikernelBinary:  unikernelBinary,
 		UnikernelVersion: unikernelVersion,
 		UnikernelType:    unikernelType,
-		UnikernelCmd:     unikernelCmd,
 		Hypervisor:       hypervisor,
 		Initrd:           initrd,
 		Block:            block,
@@ -183,7 +178,6 @@ func getConfigFromJSON(jsonFilePath string) (*UnikernelConfig, error) {
 	uniklog.WithFields(logrus.Fields{
 		"unikernelType":    tryDecode(conf.UnikernelType),
 		"unikernelVersion": tryDecode(conf.UnikernelVersion),
-		"unikernelCmd":     tryDecode(conf.UnikernelCmd),
 		"unikernelBinary":  tryDecode(conf.UnikernelBinary),
 		"hypervisor":       tryDecode(conf.Hypervisor),
 		"initrd":           tryDecode(conf.Initrd),
@@ -208,13 +202,7 @@ func tryDecode(s string) string {
 
 // decode decodes the base64 encoded values of the Unikernel config
 func (c *UnikernelConfig) decode() error {
-	decoded, err := base64.StdEncoding.DecodeString(c.UnikernelCmd)
-	if err != nil {
-		return fmt.Errorf("failed to decode UnikernelCmd: %v", err)
-	}
-	c.UnikernelCmd = string(decoded)
-
-	decoded, err = base64.StdEncoding.DecodeString(c.Hypervisor)
+	decoded, err := base64.StdEncoding.DecodeString(c.Hypervisor)
 	if err != nil {
 		return fmt.Errorf("failed to decode Hypervisor: %v", err)
 	}
@@ -279,9 +267,6 @@ func (c *UnikernelConfig) decode() error {
 // Map returns a map containing the Unikernel config data
 func (c *UnikernelConfig) Map() map[string]string {
 	myMap := make(map[string]string)
-	if c.UnikernelCmd != "" {
-		myMap[annotCmdLine] = c.UnikernelCmd
-	}
 	if c.UnikernelType != "" {
 		myMap[annotType] = c.UnikernelType
 	}

--- a/pkg/unikontainers/config_test.go
+++ b/pkg/unikontainers/config_test.go
@@ -31,7 +31,6 @@ func TestGetConfigFromSpec(t *testing.T) {
 		spec := &specs.Spec{
 			Annotations: map[string]string{
 				annotType:          "type1",
-				annotCmdLine:       "cmd1",
 				annotBinary:        "binary1",
 				annotHypervisor:    "hypervisor1",
 				annotInitrd:        "initrd1",
@@ -46,7 +45,6 @@ func TestGetConfigFromSpec(t *testing.T) {
 		expectedConfig := &UnikernelConfig{
 			UnikernelBinary: "binary1",
 			UnikernelType:   "type1",
-			UnikernelCmd:    "cmd1",
 			Hypervisor:      "hypervisor1",
 			Initrd:          "initrd1",
 			Block:           "block1",
@@ -104,7 +102,6 @@ func TestGetConfigFromJSON(t *testing.T) {
 		expectedConfig := &UnikernelConfig{
 			UnikernelBinary: "binary1",
 			UnikernelType:   "type1",
-			UnikernelCmd:    "cmd1",
 			Hypervisor:      "hypervisor1",
 			Initrd:          "initrd1",
 			Block:           "block1",
@@ -185,14 +182,12 @@ func TestDecode(t *testing.T) {
 	t.Run("decode success", func(t *testing.T) {
 		t.Parallel()
 		// Prepare the encoded values
-		encodedCmd := base64.StdEncoding.EncodeToString([]byte("testCmd"))
 		encodedHypervisor := base64.StdEncoding.EncodeToString([]byte("testHypervisor"))
 		encodedType := base64.StdEncoding.EncodeToString([]byte("testType"))
 		encodedBinary := base64.StdEncoding.EncodeToString([]byte("testBinary"))
 		encodedInitrd := base64.StdEncoding.EncodeToString([]byte("testInitrd"))
 
 		config := &UnikernelConfig{
-			UnikernelCmd:    encodedCmd,
 			Hypervisor:      encodedHypervisor,
 			UnikernelType:   encodedType,
 			UnikernelBinary: encodedBinary,
@@ -204,7 +199,6 @@ func TestDecode(t *testing.T) {
 
 		// Assert that no error occurred and the values are decoded correctly
 		assert.NoError(t, err)
-		assert.Equal(t, "testCmd", config.UnikernelCmd)
 		assert.Equal(t, "testHypervisor", config.Hypervisor)
 		assert.Equal(t, "testType", config.UnikernelType)
 		assert.Equal(t, "testBinary", config.UnikernelBinary)
@@ -217,7 +211,6 @@ func TestDecode(t *testing.T) {
 		invalidBase64 := "invalid-base64"
 
 		config := &UnikernelConfig{
-			UnikernelCmd:    invalidBase64,
 			Hypervisor:      invalidBase64,
 			UnikernelType:   invalidBase64,
 			UnikernelBinary: invalidBase64,
@@ -237,7 +230,6 @@ func TestMap(t *testing.T) {
 		config := &UnikernelConfig{
 			UnikernelBinary: "binary_value",
 			UnikernelType:   "type_value",
-			UnikernelCmd:    "cmd_value",
 			Hypervisor:      "hypervisor_value",
 			Initrd:          "initrd_value",
 			Block:           "block_value",
@@ -247,7 +239,6 @@ func TestMap(t *testing.T) {
 			BlkDev:          "blkdev_value",
 		}
 		expectedMap := map[string]string{
-			annotCmdLine:       "cmd_value",
 			annotType:          "type_value",
 			annotHypervisor:    "hypervisor_value",
 			annotBinary:        "binary_value",
@@ -266,7 +257,6 @@ func TestMap(t *testing.T) {
 		config := &UnikernelConfig{
 			UnikernelBinary: "",
 			UnikernelType:   "",
-			UnikernelCmd:    "",
 			Hypervisor:      "",
 			Initrd:          "",
 			Block:           "",
@@ -282,7 +272,6 @@ func TestMap(t *testing.T) {
 		config := &UnikernelConfig{
 			UnikernelBinary: "binary_value",
 			UnikernelType:   "",
-			UnikernelCmd:    "cmd_value",
 			Hypervisor:      "",
 			Initrd:          "initrd_value",
 			Block:           "",
@@ -290,7 +279,6 @@ func TestMap(t *testing.T) {
 			MountRootfs:     "0",
 		}
 		expectedMap := map[string]string{
-			annotCmdLine:       "cmd_value",
 			annotBinary:        "binary_value",
 			annotInitrd:        "initrd_value",
 			annotBlockMntPoint: "point_value",

--- a/pkg/unikontainers/unikontainers.go
+++ b/pkg/unikontainers/unikontainers.go
@@ -521,9 +521,6 @@ func (u *Unikontainer) buildMonitorSpec(rootfsParams types.RootfsParams, monRes 
 		Rootfs:     rootfsParams,
 		Block:      monRes.BlockArgs,
 	}
-	if len(guest.CmdLine) == 0 {
-		guest.CmdLine = strings.Fields(u.State.Annotations[annotCmdLine])
-	}
 
 	if rootfsParams.Type == "virtiofs" || rootfsParams.Type == "9pfs" {
 		// Update the paths of the files we need to pass in the monitor process.


### PR DESCRIPTION
Since v0.7.0, urunc reads application arguments directly from the OCI process spec (spec.Process.Args), making the custom annotation 'com.urunc.unikernel.cmdline' obsolete. This removes annotCmdLine and UnikernelCmd from config, cleans up the legacy fallback in unikontainers.go, updates unit tests, and refreshes documentation examples.

Fixes: #1011


### How was this tested?

Verified Linux compilation and test binary generation with 'GOOS=linux go test -c ./pkg/unikontainers', ran 'go vet' across 'pkg/...' with zero issues, and verified that unit tests for 'pkg/unikontainers' pass.

### LLM usage

Claude sonnet 5.0 for verification
### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
