### PR TITLE
docs: remove stale block device TODO in firecracker.go

### DIFF
--- a/pkg/unikontainers/hypervisors/firecracker.go
+++ b/pkg/unikontainers/hypervisors/firecracker.go
@@ -153,7 +153,6 @@ func (fc *Firecracker) BuildExecCmd(args types.ExecArgs, ukernel types.Unikernel
 	}
 
 	// Block config for Firecracker
-	// TODO: Add support for block devices in FIrecracker
 	FCDrives := make([]FirecrackerDrive, 0)
 
 	bArgs := ukernel.MonitorBlockCli()


### PR DESCRIPTION
## Description
Removes a stale TODO comment above the Firecracker block device setup code. The comment claims block device support is missing, but the loop right below it already builds FirecrackerDrive entries from ukernel.MonitorBlockCli(), including marking the root device. Block devices are already supported and documented.

### Related issues
- Fixes #1013

### How was this tested?
Comment only change. Ran go build and golangci-lint for the package to confirm nothing else needed touching.

### LLM usage
none

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).