### PR TITLE
chore: Update solo5 builder base image

### DIFF
--- a/deployment/urunc-deploy/Dockerfile
+++ b/deployment/urunc-deploy/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:bullseye@sha256:25c0cab214b810db1b3c8adef5a12a92596979abddf86bb364e8d9c9d111df9f AS solo5-builder
+FROM debian:bookworm@sha256:6ebd97fa83deb272194a2cf015b3d26a4d538e9ad3a7a79d544c8af5b0a01443 AS solo5-builder
 
 # Remove libc-bin files to avoid segmentation fault.
 # See more: https://stackoverflow.com/questions/78105004/docker-build-fails-because-unable-to-install-libc-bins


### PR DESCRIPTION
## Description

Update the Solo5 builder base image in the urunc-deploy Dockerfile due to the end-of-life for Debian 11.

### Related issues

- Fixes https://github.com/urunc-dev/urunc/issues/1028

### How was this tested?

Manually trigger the urunc-deploy image building workflow See https://github.com/urunc-dev/urunc/actions/runs/34132906577

### LLM usage

N/A

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [x] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
