### PR TITLE
refactor(9pfs): Let the guest set the cli options

### DIFF
--- a/.github/linters/urunc-dict.txt
+++ b/.github/linters/urunc-dict.txt
@@ -452,3 +452,5 @@ hmpj
 ndots
 resolv
 dupword
+multidevs
+MMIO

--- a/pkg/unikontainers/hypervisors/qemu.go
+++ b/pkg/unikontainers/hypervisors/qemu.go
@@ -134,8 +134,10 @@ func (q *Qemu) BuildExecCmd(args types.ExecArgs, ukernel types.Unikernel) ([]str
 
 	switch args.Sharedfs.Type {
 	case "9pfs":
-		fsdevArg := fmt.Sprintf("local,id=rootfs9p,security_model=none,path=%s", args.Sharedfs.Path)
-		exArgs = append(exArgs, "-fsdev", fsdevArg, "-device", "virtio-9p-pci,fsdev=rootfs9p,mount_tag=fs0")
+		// The 9p transport depends on the guest, so let the guest supply
+		// the cli options; nil means no support for 9pfs
+		sharedFSOption := ukernel.MonitorSharedfsCli(args.Sharedfs.Type, args.Sharedfs.Path)
+		exArgs = append(exArgs, sharedFSOption...)
 	case "virtiofs":
 		objArg := fmt.Sprintf("memory-backend-file,id=mem,size=%sM,mem-path=/tmp,share=on", qemuMem)
 		exArgs = append(exArgs,

--- a/pkg/unikontainers/hypervisors/qemu_test.go
+++ b/pkg/unikontainers/hypervisors/qemu_test.go
@@ -25,21 +25,23 @@ import (
 )
 
 // fakeUnikernel is a minimal stub of types.Unikernel used only to drive
-// Qemu.BuildExecCmd. The three Monitor* methods are the ones the function
+// Qemu.BuildExecCmd. The four Monitor* methods are the ones the function
 // consults; the rest return zero values.
 type fakeUnikernel struct {
-	netCli     []string
-	blockCli   []types.MonitorBlockArgs
-	monitorCli types.MonitorCliArgs
+	netCli      []string
+	blockCli    []types.MonitorBlockArgs
+	sharedfsCli []string
+	monitorCli  types.MonitorCliArgs
 }
 
-func (f *fakeUnikernel) Init(types.UnikernelParams) error          { return nil }
-func (f *fakeUnikernel) CommandString() (string, error)            { return "", nil }
-func (f *fakeUnikernel) SupportsBlock() bool                       { return true }
-func (f *fakeUnikernel) SupportsFS(string) bool                    { return true }
-func (f *fakeUnikernel) MonitorNetCli(string, string) []string     { return f.netCli }
-func (f *fakeUnikernel) MonitorBlockCli() []types.MonitorBlockArgs { return f.blockCli }
-func (f *fakeUnikernel) MonitorCli() types.MonitorCliArgs          { return f.monitorCli }
+func (f *fakeUnikernel) Init(types.UnikernelParams) error           { return nil }
+func (f *fakeUnikernel) CommandString() (string, error)             { return "", nil }
+func (f *fakeUnikernel) SupportsBlock() bool                        { return true }
+func (f *fakeUnikernel) SupportsFS(string) bool                     { return true }
+func (f *fakeUnikernel) MonitorNetCli(string, string) []string      { return f.netCli }
+func (f *fakeUnikernel) MonitorBlockCli() []types.MonitorBlockArgs  { return f.blockCli }
+func (f *fakeUnikernel) MonitorSharedfsCli(string, string) []string { return f.sharedfsCli }
+func (f *fakeUnikernel) MonitorCli() types.MonitorCliArgs           { return f.monitorCli }
 
 const (
 	testQemuBinary = "/usr/bin/qemu-system-x86_64"
@@ -180,17 +182,30 @@ func TestQemuBuildExecCmd(t *testing.T) {
 			mustContain: []string{"-initrd /rootfs/initrd.img"},
 		},
 		{
-			name: "Sharedfs 9pfs renders fsdev and virtio-9p-pci",
+			name: "Sharedfs 9pfs appends the guest-supplied CLI verbatim",
 			args: types.ExecArgs{
 				UnikernelPath: testKernelPath,
 				Command:       testCommand,
 				Sharedfs:      types.SharedfsParams{Type: "9pfs", Path: "/srv/share"},
 			},
-			unikernel: &fakeUnikernel{},
+			unikernel: &fakeUnikernel{sharedfsCli: []string{
+				"-fsdev", "local,id=rootfs9p,security_model=none,multidevs=remap,path=/srv/share",
+				"-device", "virtio-9p-pci,fsdev=rootfs9p,mount_tag=fs0",
+			}},
 			mustContain: []string{
-				"-fsdev local,id=rootfs9p,security_model=none,path=/srv/share",
+				"-fsdev local,id=rootfs9p,security_model=none,multidevs=remap,path=/srv/share",
 				"-device virtio-9p-pci,fsdev=rootfs9p,mount_tag=fs0",
 			},
+		},
+		{
+			name: "Sharedfs 9pfs with a guest that supplies no CLI renders nothing",
+			args: types.ExecArgs{
+				UnikernelPath: testKernelPath,
+				Command:       testCommand,
+				Sharedfs:      types.SharedfsParams{Type: "9pfs", Path: "/srv/share"},
+			},
+			unikernel:      &fakeUnikernel{},
+			mustNotContain: []string{"-fsdev", "virtio-9p"},
 		},
 		{
 			name: "Sharedfs virtiofs renders memory-backend-file and vhost-user-fs-pci",

--- a/pkg/unikontainers/types/types.go
+++ b/pkg/unikontainers/types/types.go
@@ -24,6 +24,7 @@ type Unikernel interface {
 	SupportsFS(string) bool
 	MonitorNetCli(string, string) []string
 	MonitorBlockCli() []MonitorBlockArgs
+	MonitorSharedfsCli(string, string) []string
 	MonitorCli() MonitorCliArgs
 }
 

--- a/pkg/unikontainers/unikernels/hermit_rs.go
+++ b/pkg/unikontainers/unikernels/hermit_rs.go
@@ -97,6 +97,12 @@ func (h *Hermit) MonitorBlockCli() []types.MonitorBlockArgs {
 	return nil
 }
 
+// MonitorSharedfsCli is nil since we have not checked the support of
+// shared-fs for hermit.
+func (h *Hermit) MonitorSharedfsCli(_ string, _ string) []string {
+	return nil
+}
+
 func (h *Hermit) MonitorCli() types.MonitorCliArgs {
 	return types.MonitorCliArgs{
 		OtherArgs: []string{"-no-reboot"},

--- a/pkg/unikontainers/unikernels/linux.go
+++ b/pkg/unikontainers/unikernels/linux.go
@@ -195,6 +195,17 @@ func (l *Linux) MonitorBlockCli() []types.MonitorBlockArgs {
 	return blkArgs
 }
 
+// MonitorSharedfsCli exposes the 9p shared rootfs over QEMU's PCI transport.
+func (l *Linux) MonitorSharedfsCli(fsType string, path string) []string {
+	if l.Monitor != "qemu" || fsType != "9pfs" {
+		return nil
+	}
+	return []string{
+		"-fsdev", "local,id=rootfs9p,security_model=none,multidevs=remap,path=" + path,
+		"-device", "virtio-9p-pci,fsdev=rootfs9p,mount_tag=fs0",
+	}
+}
+
 func (l *Linux) MonitorCli() types.MonitorCliArgs {
 	switch l.Monitor {
 	case "qemu":

--- a/pkg/unikontainers/unikernels/mewz.go
+++ b/pkg/unikontainers/unikernels/mewz.go
@@ -67,6 +67,11 @@ func (m *Mewz) MonitorBlockCli() []types.MonitorBlockArgs {
 	return nil
 }
 
+// MonitorSharedfsCli is nil since Mewz does not support shared-fs
+func (m *Mewz) MonitorSharedfsCli(_ string, _ string) []string {
+	return nil
+}
+
 // Mewz does not require any monitor specific cli option
 func (m *Mewz) MonitorCli() types.MonitorCliArgs {
 	switch m.Monitor {

--- a/pkg/unikontainers/unikernels/mirage.go
+++ b/pkg/unikontainers/unikernels/mirage.go
@@ -95,6 +95,11 @@ func (m *Mirage) MonitorBlockCli() []types.MonitorBlockArgs {
 	}
 }
 
+// MonitorSharedfsCli is nil since mirage does not support shared-fs
+func (m *Mirage) MonitorSharedfsCli(_ string, _ string) []string {
+	return nil
+}
+
 func (m *Mirage) MonitorCli() types.MonitorCliArgs {
 	return types.MonitorCliArgs{}
 }

--- a/pkg/unikontainers/unikernels/rumprun.go
+++ b/pkg/unikontainers/unikernels/rumprun.go
@@ -171,6 +171,11 @@ func (r *Rumprun) MonitorBlockCli() []types.MonitorBlockArgs {
 	}
 }
 
+// MonitorSharedfsCli is nil since rumprun does not support shared-fs
+func (r *Rumprun) MonitorSharedfsCli(_ string, _ string) []string {
+	return nil
+}
+
 // Rumprun can execute only on top of Solo5 and currently there
 // are no generic Solo5-specific arguments that Rumprun requires
 func (r *Rumprun) MonitorCli() types.MonitorCliArgs {

--- a/pkg/unikontainers/unikernels/unikraft.go
+++ b/pkg/unikontainers/unikernels/unikraft.go
@@ -97,6 +97,17 @@ func (u *Unikraft) MonitorBlockCli() []types.MonitorBlockArgs {
 	return nil
 }
 
+// MonitorSharedfsCli exposes the 9p shared rootfs over QEMU's PCI transport.
+func (u *Unikraft) MonitorSharedfsCli(fsType string, path string) []string {
+	if u.Monitor != "qemu" || fsType != "9pfs" {
+		return nil
+	}
+	return []string{
+		"-fsdev", "local,id=rootfs9p,security_model=none,multidevs=remap,path=" + path,
+		"-device", "virtio-9p-pci,fsdev=rootfs9p,mount_tag=fs0",
+	}
+}
+
 // There are no generic CLI hypervisor options for Unikraft yet.
 func (u *Unikraft) MonitorCli() types.MonitorCliArgs {
 	return types.MonitorCliArgs{}


### PR DESCRIPTION
## Description

Add MonitorSharedfsCli to the Unikernel interface so each guest returns its own 9p device CLI (or nil) instead of Qemu hardcoding a single virtio-9p-pci device.

This is required for FreeBSD guest support which uses MMIO for the transport layer instead of PCI.

### Related issues

Required for https://github.com/urunc-dev/urunc/issues/1033
It does not fix it.

### How was this tested?

e2e tests

### LLM usage

Opus 4.8 for unit tests.

### Checklist

- [ ] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [ ] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [ ] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
