### PR TITLE
fix(config): add hyperlight-unikraft default monitor values

### DIFF
--- a/.github/contributors.yaml
+++ b/.github/contributors.yaml
@@ -146,3 +146,6 @@ users:
   alimx07:
     name: Ali Mohamed
     email: amx746@gmail.com
+  Nachiket-Roy:
+    name: Nachiket Roy
+    email: nachiket.roy.2@gmail.com

--- a/.github/linters/urunc-dict.txt
+++ b/.github/linters/urunc-dict.txt
@@ -470,3 +470,4 @@ Cvol
 Crootfs
 APIC
 makefs
+Nachiket

--- a/deployment/urunc-deploy/config.toml
+++ b/deployment/urunc-deploy/config.toml
@@ -33,6 +33,11 @@ default_memory_mb = 256
 default_vcpus = 1
 path = "/opt/urunc/bin/solo5-hvt"
 
+[monitors.hyperlight-unikraft]
+default_memory_mb = 256
+default_vcpus = 1
+
 [extra_binaries.virtiofsd]
 path = "/opt/urunc/libexec/virtiofsd"
 options = "--cache always --sandbox none"
+

--- a/deployment/urunc-deploy/config.toml
+++ b/deployment/urunc-deploy/config.toml
@@ -40,4 +40,3 @@ default_vcpus = 1
 [extra_binaries.virtiofsd]
 path = "/opt/urunc/libexec/virtiofsd"
 options = "--cache always --sandbox none"
-

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -151,8 +151,10 @@ values.
 
 - [QEMU/KVM](./hypervisor-support#qemu) - `qemu`
 - [Firecracker](./hypervisor-support#firecracker) - `firecracker`
+- [Cloud-Hypervisor](./hypervisor-support#cloud-hypervisor) - `cloud-hypervisor`
 - [Solo5-hvt](./hypervisor-support#solo5-hvt) - `hvt` - Solo5 hvt (KVM-based tender)
 - [Solo5-spt](./hypervisor-support#solo5-spt) - `spt` - Solo5 spt (Seccomp-based tender)
+- [Hyperlight](./hypervisor-support#hyperlight) - `hyperlight-unikraft`
 
 #### Monitor Options
 
@@ -297,6 +299,16 @@ default_vcpus = 1
 # path is not set by default - urunc will search in PATH
 
 [monitors.spt]
+default_memory_mb = 256
+default_vcpus = 1
+# path is not set by default - urunc will search in PATH
+
+[monitors.cloud-hypervisor]
+default_memory_mb = 256
+default_vcpus = 1
+# path is not set by default - urunc will search in PATH
+
+[monitors.hyperlight-unikraft]
 default_memory_mb = 256
 default_vcpus = 1
 # path is not set by default - urunc will search in PATH

--- a/pkg/unikontainers/urunc_config.go
+++ b/pkg/unikontainers/urunc_config.go
@@ -146,11 +146,12 @@ const (
 
 func defaultMonitorsConfig() map[string]types.MonitorConfig {
 	return map[string]types.MonitorConfig{
-		"qemu":             {DefaultMemoryMB: defaultMonitorMemoryMB, DefaultVCPUs: defaultMonitorVCPUs},
-		"hvt":              {DefaultMemoryMB: defaultMonitorMemoryMB, DefaultVCPUs: defaultMonitorVCPUs},
-		"spt":              {DefaultMemoryMB: defaultMonitorMemoryMB, DefaultVCPUs: defaultMonitorVCPUs},
-		"firecracker":      {DefaultMemoryMB: defaultMonitorMemoryMB, DefaultVCPUs: defaultMonitorVCPUs},
-		"cloud-hypervisor": {DefaultMemoryMB: defaultMonitorMemoryMB, DefaultVCPUs: defaultMonitorVCPUs},
+		"qemu":                {DefaultMemoryMB: defaultMonitorMemoryMB, DefaultVCPUs: defaultMonitorVCPUs},
+		"hvt":                 {DefaultMemoryMB: defaultMonitorMemoryMB, DefaultVCPUs: defaultMonitorVCPUs},
+		"spt":                 {DefaultMemoryMB: defaultMonitorMemoryMB, DefaultVCPUs: defaultMonitorVCPUs},
+		"firecracker":         {DefaultMemoryMB: defaultMonitorMemoryMB, DefaultVCPUs: defaultMonitorVCPUs},
+		"cloud-hypervisor":    {DefaultMemoryMB: defaultMonitorMemoryMB, DefaultVCPUs: defaultMonitorVCPUs},
+		"hyperlight-unikraft": {DefaultMemoryMB: defaultMonitorMemoryMB, DefaultVCPUs: defaultMonitorVCPUs},
 	}
 }
 

--- a/pkg/unikontainers/urunc_config_test.go
+++ b/pkg/unikontainers/urunc_config_test.go
@@ -491,12 +491,13 @@ func TestDefaultConfigs(t *testing.T) {
 		t.Parallel()
 		config := defaultMonitorsConfig()
 
-		assert.Len(t, config, 5)
+		assert.Len(t, config, 6)
 		assert.Contains(t, config, "qemu")
 		assert.Contains(t, config, "hvt")
 		assert.Contains(t, config, "spt")
 		assert.Contains(t, config, "firecracker")
 		assert.Contains(t, config, "cloud-hypervisor")
+		assert.Contains(t, config, "hyperlight-unikraft")
 
 		// Check default values for each monitor
 		for _, hvConfig := range config {
@@ -529,7 +530,7 @@ func TestDefaultConfigs(t *testing.T) {
 		assert.Equal(t, testTimestampsPath, config.Timestamps.Destination)
 		assert.False(t, config.Runtime.Libcontainer)
 		assert.False(t, config.Runtime.VAccel)
-		assert.Len(t, config.Monitors, 5)
+		assert.Len(t, config.Monitors, 6)
 		assert.Len(t, config.ExtraBins, 1)
 	})
 


### PR DESCRIPTION
## Description

<!-- Describe the changes and why they are needed. -->
Adds the missing default monitor configuration for the `hyperlight-unikraft` runtime.

The initial Hyperlight support did not register `hyperlight-unikraft` in `defaultMonitorsConfig()`. Because of this, when no explicit monitor configuration was provided through `config.toml` or OCI resource limits, the runtime received zero-valued defaults: 0 MB memory and 0 vCPUs.

This caused the generated Hyperlight configuration to omit the `--memory` argument, allowing Hyperlight to fall back to its own host-side default instead of using urunc's standard resource defaults.

### Changes

- Added `hyperlight-unikraft` to `defaultMonitorsConfig()` with:
  - 256 MB memory
  - 1 vCPU
- Updated the unit test assertions in `urunc_config_test.go` to cover the new default.
- Added `hyperlight-unikraft` to the sample deployment configuration.
- Updated the documentation to reflect the default monitor configuration.

This ensures Hyperlight unikernels have consistent urunc defaults even when no explicit resource limits are configured.

### Related issues
<!-- Include links to relevant issues or other pages. -->

- Fixes #1035

### How was this tested?
End-to-End Verification 
<img width="1177" height="235" alt="Screenshot from 2026-09-09 02-20-08" src="https://github.com/user-attachments/assets/b3b38490-f5f6-4baf-8b17-a5f79be6d87b" />

<!-- Describe how you tested your changes. Include relevant details such as test configuration, commands run, or manual testing steps. -->

### LLM usage

<!-- Mention the LLm(s) that assisted with the creation of this PR. (N/A) if none was used-->
Claude Opus 4.6

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [x] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).
