### PR TITLE
fix(firecracker): isolate JSON configuration file per container ID

### DIFF
--- a/pkg/unikontainers/hypervisors/firecracker.go
+++ b/pkg/unikontainers/hypervisors/firecracker.go
@@ -108,6 +108,9 @@ func (fc *Firecracker) BuildExecCmd(args types.ExecArgs, ukernel types.Unikernel
 	// functions in the unikernel interface do not integrate well with FC's
 	// json configuration.
 	JSONConfigFile := filepath.Join("/tmp/", FCJsonFilename)
+	if args.ContainerID != "" {
+		JSONConfigFile = filepath.Join("/tmp/", fmt.Sprintf("fc-%s.json", args.ContainerID))
+	}
 	exArgs := []string{fc.Path(), "--no-api", "--config-file", JSONConfigFile}
 	if !args.Seccomp {
 		exArgs = append(exArgs, "--no-seccomp")

--- a/pkg/unikontainers/hypervisors/firecracker_test.go
+++ b/pkg/unikontainers/hypervisors/firecracker_test.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2023-2026, Nubificus LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hypervisors
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/urunc-dev/urunc/pkg/unikontainers/types"
+)
+
+func newTestFirecracker() *Firecracker {
+	return &Firecracker{
+		binary:     FirecrackerBinary,
+		binaryPath: "/usr/bin/firecracker",
+	}
+}
+
+func TestFirecrackerBuildExecCmd(t *testing.T) {
+	t.Parallel()
+
+	t.Run("default fallback config path when ContainerID is empty", func(t *testing.T) {
+		t.Parallel()
+		fc := newTestFirecracker()
+		args := types.ExecArgs{
+			UnikernelPath: "/path/to/kernel",
+			Command:       "console=ttyS0",
+		}
+		fakeUk := &fakeUnikernel{}
+
+		exArgs, err := fc.BuildExecCmd(args, fakeUk)
+		require.NoError(t, err)
+
+		expectedConfigPath := filepath.Join("/tmp/", FCJsonFilename)
+		assert.Equal(t, []string{
+			"/usr/bin/firecracker",
+			"--no-api",
+			"--config-file",
+			expectedConfigPath,
+			"--no-seccomp",
+		}, exArgs)
+
+		// Clean up generated json config file
+		_ = os.Remove(expectedConfigPath)
+	})
+
+	t.Run("container-isolated config path when ContainerID is set", func(t *testing.T) {
+		t.Parallel()
+		fc := newTestFirecracker()
+		containerID := "test-container-12345"
+		args := types.ExecArgs{
+			ContainerID:   containerID,
+			UnikernelPath: "/path/to/kernel",
+			Command:       "console=ttyS0",
+			Seccomp:       true,
+		}
+		fakeUk := &fakeUnikernel{}
+
+		exArgs, err := fc.BuildExecCmd(args, fakeUk)
+		require.NoError(t, err)
+
+		expectedConfigPath := filepath.Join("/tmp/", "fc-"+containerID+".json")
+		assert.Equal(t, []string{
+			"/usr/bin/firecracker",
+			"--no-api",
+			"--config-file",
+			expectedConfigPath,
+		}, exArgs)
+
+		// Verify file exists and clean up
+		_, err = os.Stat(expectedConfigPath)
+		assert.NoError(t, err, "isolated config file should be created")
+		_ = os.Remove(expectedConfigPath)
+	})
+}


### PR DESCRIPTION
## Description

When launching containers using the Firecracker hypervisor (`firecracker`), `firecracker.go` previously assigned a static configuration file path at `/tmp/fc.json`. To prevent file collisions or race conditions across concurrent container creations on shared filesystems, this change updates `Firecracker.BuildExecCmd` to construct container-isolated configuration paths (`/tmp/fc-<containerID>.json`) using `args.ContainerID` when available, falling back gracefully to `/tmp/fc.json` when `ContainerID` is omitted.

### Related issues

- N/A

### How was this tested?

- Added dedicated unit tests in `pkg/unikontainers/hypervisors/firecracker_test.go` covering `BuildExecCmd` with and without `ContainerID`.
- Ran unit tests with race detector and coverage: `go test -v -race -cover ./pkg/unikontainers/hypervisors/...` (100% pass, no race conditions).
- Ran full unit test suite: `go test -v ./pkg/... ./internal/...` (all tests passed).

### Reviewers

cc @cmainas @OdysseasKalaitsidis

### LLM usage

none

### Checklist

- [x] I have read the [contribution guide](https://urunc.io/developer-guide/contribute/).
- [x] The linter passes locally (`make lint`).
- [ ] The e2e tests of at least one tool pass locally (`make test_ctr`, `make test_nerdctl`, `make test_docker`, `make test_crictl`).
- [x] If LLMs were used: I have read the [llm policy](https://urunc.io/developer-guide/llm-policy/).