### PR TITLE
fix(network): use exact regex pattern in getTapIndex

### DIFF
--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -67,9 +67,10 @@ func getTapIndex() (int, error) {
 	if err != nil {
 		return 0, err
 	}
+	tapRe := regexp.MustCompile(`^tap\d+(_urunc)?$`)
 	tapCount := 0
 	for _, iface := range ifaces {
-		if strings.Contains(iface.Name, "tap") {
+		if tapRe.MatchString(iface.Name) {
 			tapCount++
 		}
 	}

--- a/pkg/network/network_test.go
+++ b/pkg/network/network_test.go
@@ -15,6 +15,7 @@
 package network
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -53,6 +54,40 @@ func TestNewNetworkManager(t *testing.T) {
 				assert.NoError(t, err, "NewNetworkManager() should not return an error")
 				assert.NotNil(t, got, "NewNetworkManager() should return a non-nil manager")
 			}
+		})
+	}
+}
+
+func TestGetTapIndex(t *testing.T) {
+	tapCount, err := getTapIndex()
+	assert.NoError(t, err, "getTapIndex() should not error")
+	assert.GreaterOrEqual(t, tapCount, 0, "tapCount should be >= 0")
+}
+
+func TestTapDeviceRegexMatching(t *testing.T) {
+	tapRe := regexp.MustCompile(`^tap\d+(_urunc)?$`)
+
+	tests := []struct {
+		ifaceName   string
+		shouldMatch bool
+	}{
+		{"tap0_urunc", true},
+		{"tap1_urunc", true},
+		{"tap0", true},
+		{"tap12", true},
+		{"vtap0", false},
+		{"cni-tap0", false},
+		{"bootstrap0", false},
+		{"stape0", false},
+		{"tap-master", false},
+		{"eth0", false},
+		{"lo", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.ifaceName, func(t *testing.T) {
+			matched := tapRe.MatchString(tt.ifaceName)
+			assert.Equal(t, tt.shouldMatch, matched, "interface name %s match expectation failed", tt.ifaceName)
 		})
 	}
 }


### PR DESCRIPTION
/kind bug

### Rationale
In Kubernetes and containerized environments, network interface names created by host systems or CNI plugins often contain `"tap"` as a substring (e.g. `bootstrap0`, `vtap0`, `cni-tap0`, `stape0`).

Currently, `getTapIndex()` in `pkg/network/network.go` checks:
```go
if strings.Contains(iface.Name, "tap") {
    tapCount++
}
```
When `DynamicNetwork.NetworkSetup()` runs during container creation, if `tapIndex > 0`, `urunc` aborts container launch with:
`unsupported operation: can't spawn multiple unikernels in the same network namespace`

This causes `urunc` to falsely believe a unikernel is already running and refuse to spawn the first container whenever any interface with `"tap"` in its name exists in the network namespace.

This PR updates `getTapIndex()` to use the regex pattern `^tap\d+(_urunc)?$`, matching `urunc`'s own TAP device naming convention while ignoring unrelated host/CNI interfaces.

Fixes #938

### Reviewer Notes
- Added unit tests `TestGetTapIndex` and `TestTapDeviceRegexMatching` in `pkg/network/network_test.go`.
- Tagging maintainers @cmainas @OdysseasKalaitsidis for review.

### LLM usage
none

```release-note
fix(network): prevent false positive TAP interface matching in getTapIndex()
```